### PR TITLE
Make transaction watching resilient to high pending volume and request failure

### DIFF
--- a/src/entities/transactions/transaction.ts
+++ b/src/entities/transactions/transaction.ts
@@ -324,6 +324,14 @@ export function isAwaitingRelayTransactionHash(transaction: Pick<RainbowTransact
   return typeof transaction.relayExecutionId === 'string' && transaction.hash === transaction.relayExecutionId;
 }
 
+/**
+ * Returns true when a confirmed transaction has an onchain hash instead
+ * of a managed relay placeholder.
+ */
+export function hasConfirmedOnchainHash(transaction: Pick<RainbowTransaction, 'hash' | 'relayExecutionId' | 'status'>): boolean {
+  return transaction.status === TransactionStatus.confirmed && !isAwaitingRelayTransactionHash(transaction);
+}
+
 export type TransactionApiResponse = {
   status: TransactionStatus;
   id: Hash;

--- a/src/framework/ui/hooks/useWatcher.ts
+++ b/src/framework/ui/hooks/useWatcher.ts
@@ -8,30 +8,38 @@ interface UseWatcherProps {
   enabled?: boolean;
   /** Delay between runs, in ms. */
   interval?: number;
-  /** Invoked once per tick; rejections are caught and logged. */
+  /** Asynchronous work to run on each polling cycle. */
   watchFunction: (abortController: AbortController) => Promise<void>;
 }
 
 /**
- * Generic self-rescheduling poll loop: runs `watch` immediately, then every `interval` ms while
- * `enabled`, passing an `AbortController` that is aborted on disable/unmount.
+ * Runs `watchFunction` repeatedly while `enabled`.
+ * The first run starts immediately; later runs start after the previous run finishes and the delay expires.
+ * The delay is `interval` after success and increases by `interval` per failure; only the first failure in a sequence is logged.
  */
 export function useWatcher({ enabled = true, interval = time.seconds(1), watchFunction }: UseWatcherProps): void {
   useEffect(() => {
     if (!enabled) return;
 
     const abortController = new AbortController();
+    let nextDelay = interval;
     let timeoutId: ReturnType<typeof setTimeout> | null = null;
 
     const run = async () => {
       if (abortController.signal.aborted) return;
+
       try {
         await watchFunction(abortController);
+        nextDelay = interval;
       } catch (error) {
-        if (!abortController.signal.aborted) logger.error(new RainbowError('[useWatcher]: watch failed', error));
+        if (!abortController.signal.aborted) {
+          if (nextDelay === interval) logger.error(new RainbowError('[useWatcher]: watch failed', error));
+          nextDelay += interval;
+        }
       }
+
       if (!abortController.signal.aborted) {
-        timeoutId = setTimeout(run, interval);
+        timeoutId = setTimeout(run, nextDelay);
       }
     };
 
@@ -39,7 +47,7 @@ export function useWatcher({ enabled = true, interval = time.seconds(1), watchFu
 
     return () => {
       abortController.abort();
-      if (timeoutId) clearTimeout(timeoutId);
+      if (timeoutId !== null) clearTimeout(timeoutId);
     };
   }, [enabled, interval, watchFunction]);
 }

--- a/src/hooks/pendingTransactionResolution.test.ts
+++ b/src/hooks/pendingTransactionResolution.test.ts
@@ -108,25 +108,18 @@ describe('pendingTransactionResolution', () => {
     expect(mockFetchRawTransaction).not.toHaveBeenCalled();
   });
 
-  it('keeps a confirmed managed transaction settled when relay refresh fails', async () => {
-    mockGetStatus.mockRejectedValue(new Error('relay unavailable'));
+  it('propagates relay refresh failures to the watcher', async () => {
+    const error = new Error('relay unavailable');
+    mockGetStatus.mockRejectedValue(error);
 
-    const resolution = await resolveTrackedTransaction({
-      abortController: null,
-      address: '0x123',
-      currency: 'ETH',
-      transaction: buildManagedConfirmedTransaction(),
-    });
-
-    expect(resolution).toMatchObject({
-      kind: 'settled',
-      transaction: expect.objectContaining({
-        hash: 'execution-1',
-        relayExecutionId: 'execution-1',
-        status: TransactionStatus.confirmed,
-        title: 'swap.confirmed',
-      }),
-    });
+    await expect(
+      resolveTrackedTransaction({
+        abortController: null,
+        address: '0x123',
+        currency: 'ETH',
+        transaction: buildManagedConfirmedTransaction(),
+      })
+    ).rejects.toBe(error);
   });
 
   it('keeps a confirmed managed transaction settled while relay exposes a late origin hash', async () => {

--- a/src/hooks/pendingTransactionResolution.ts
+++ b/src/hooks/pendingTransactionResolution.ts
@@ -23,6 +23,8 @@ export type TrackedTransactionResolution =
   | { kind: 'pending'; relayStatus?: RelayStatusSnapshot; transaction: PendingTransaction }
   | { kind: 'settled'; relayStatus?: RelayStatusSnapshot; transaction: SettledTransaction };
 
+type ManagedTransaction = RainbowTransaction & { relayExecutionId: string };
+
 // ============ API =========================================================== //
 
 /**
@@ -45,7 +47,7 @@ export async function resolveTrackedTransaction({
   currency: SupportedCurrencyKey;
   transaction: RainbowTransaction;
 }): Promise<TrackedTransactionResolution> {
-  if (transaction.relayExecutionId) {
+  if (isManagedTransaction(transaction)) {
     return resolveManagedTrackedTransaction({
       abortController,
       address,
@@ -116,10 +118,7 @@ async function resolveOnchainPendingTransaction({
     };
   }
 
-  return {
-    kind: 'settled',
-    transaction: nextTransaction,
-  };
+  return { kind: 'settled', transaction: nextTransaction };
 }
 
 async function resolveManagedTrackedTransaction({
@@ -131,12 +130,11 @@ async function resolveManagedTrackedTransaction({
   abortController: AbortController | null;
   address: string;
   currency: SupportedCurrencyKey;
-  transaction: RainbowTransaction;
+  transaction: ManagedTransaction;
 }): Promise<TrackedTransactionResolution> {
   const executionId = transaction.relayExecutionId;
-  if (!executionId) return preserveTrackedTransaction(transaction);
-
   const { status: relayStatus } = await relayService.getStatus(executionId);
+
   const trackedTransaction = applyManagedExecutionStatus(transaction, relayStatus);
   const isAwaitingOriginTxHash = isAwaitingRelayTransactionHash(trackedTransaction);
 
@@ -222,30 +220,12 @@ function toPendingTransaction(transaction: RainbowTransaction): PendingTransacti
   };
 }
 
-function preserveTrackedTransaction(transaction: RainbowTransaction): TrackedTransactionResolution {
-  if (isSettledStatus(transaction.status)) {
-    return {
-      kind: 'settled',
-      transaction: buildSettledTransaction(transaction, transaction.status),
-    };
-  }
-
-  return {
-    kind: 'pending',
-    transaction: toPendingTransaction(transaction),
-  };
-}
-
 function buildSettledTransaction(transaction: RainbowTransaction, status: SettledTransaction['status']): SettledTransaction {
   const title = buildTransactionTitle(transaction.type, status);
 
   if (isMatchingSettledTransaction(transaction, status, title)) return transaction;
 
-  return {
-    ...transaction,
-    status,
-    title,
-  };
+  return { ...transaction, status, title };
 }
 
 function shouldPreferLocalTransaction(originalType: TransactionType): boolean {
@@ -281,6 +261,10 @@ function mergePreferredLocalMinedTransaction(original: RainbowTransaction, fetch
 }
 
 // ============ Type Checks =================================================== //
+
+function isManagedTransaction(transaction: RainbowTransaction): transaction is ManagedTransaction {
+  return Boolean(transaction.relayExecutionId);
+}
 
 function isMinedTransaction(transaction: RainbowTransaction | null): transaction is MinedTransaction {
   return (

--- a/src/hooks/pendingTransactionResolution.ts
+++ b/src/hooks/pendingTransactionResolution.ts
@@ -19,7 +19,7 @@ import { RelayExecutionStatus, type RelayStatusSnapshot } from '@rainbow-me/sdk'
 
 // ============ Types ========================================================= //
 
-type TrackedTransactionResolution =
+export type TrackedTransactionResolution =
   | { kind: 'pending'; relayStatus?: RelayStatusSnapshot; transaction: PendingTransaction }
   | { kind: 'settled'; relayStatus?: RelayStatusSnapshot; transaction: SettledTransaction };
 

--- a/src/hooks/pendingTransactionResolution.ts
+++ b/src/hooks/pendingTransactionResolution.ts
@@ -13,7 +13,7 @@ import {
 import type { SupportedCurrencyKey } from '@/features/currency/supportedCurrencies';
 import { applyManagedExecutionStatus } from '@/features/delegation/utils/managedExecutionStatus';
 import { relayService } from '@/features/delegation/utils/relayService';
-import { logger, RainbowError } from '@/logger';
+import { logger } from '@/logger';
 import { fetchRawTransaction } from '@/resources/transactions/transaction';
 import { RelayExecutionStatus, type RelayStatusSnapshot } from '@rainbow-me/sdk';
 
@@ -32,6 +32,7 @@ type TrackedTransactionResolution =
  * Wallet-owned transactions settle by transaction hash. Managed relay
  * transactions settle by relay status and may be re-resolved after local
  * confirmation while relay-owned onchain evidence is still incomplete.
+ * Request failures reject so the watcher can back off.
  */
 export async function resolveTrackedTransaction({
   abortController,
@@ -74,27 +75,20 @@ async function fetchTransaction({
   currency: SupportedCurrencyKey;
   transaction: RainbowTransaction;
 }): Promise<PendingTransaction | SettledTransaction> {
-  try {
-    if (!transaction.chainId || !transaction.hash) {
-      throw new Error('Pending transaction missing chainId or hash');
-    }
-
-    const fetchedTransaction = await fetchRawTransaction({
-      abortController,
-      address,
-      chainId: transaction.chainId,
-      currency,
-      hash: transaction.hash,
-      originalType: transaction.type,
-    });
-
-    return applyTransactionUpdates(transaction, fetchedTransaction);
-  } catch (e) {
-    logger.error(new RainbowError('[fetchTransaction]: Failed to fetch transaction', e), {
-      transaction,
-    });
-    return toPendingTransaction(transaction);
+  if (!transaction.chainId || !transaction.hash) {
+    throw new Error('Pending transaction missing chainId or hash');
   }
+
+  const fetchedTransaction = await fetchRawTransaction({
+    abortController,
+    address,
+    chainId: transaction.chainId,
+    currency,
+    hash: transaction.hash,
+    originalType: transaction.type,
+  });
+
+  return applyTransactionUpdates(transaction, fetchedTransaction);
 }
 
 async function resolveOnchainPendingTransaction({
@@ -139,65 +133,58 @@ async function resolveManagedTrackedTransaction({
   currency: SupportedCurrencyKey;
   transaction: RainbowTransaction;
 }): Promise<TrackedTransactionResolution> {
-  try {
-    const executionId = transaction.relayExecutionId;
-    if (!executionId) return preserveTrackedTransaction(transaction);
+  const executionId = transaction.relayExecutionId;
+  if (!executionId) return preserveTrackedTransaction(transaction);
 
-    const { status: relayStatus } = await relayService.getStatus(executionId);
-    const trackedTransaction = applyManagedExecutionStatus(transaction, relayStatus);
-    const isAwaitingOriginTxHash = isAwaitingRelayTransactionHash(trackedTransaction);
+  const { status: relayStatus } = await relayService.getStatus(executionId);
+  const trackedTransaction = applyManagedExecutionStatus(transaction, relayStatus);
+  const isAwaitingOriginTxHash = isAwaitingRelayTransactionHash(trackedTransaction);
 
-    switch (relayStatus.status) {
-      case RelayExecutionStatus.Confirmed:
-        if (isAwaitingOriginTxHash) {
-          logger.warn('[resolveTrackedTransaction]: managed relay execution finished without onchain transaction evidence', {
-            executionId,
-            status: relayStatus.status,
-          });
-        }
+  switch (relayStatus.status) {
+    case RelayExecutionStatus.Confirmed:
+      if (isAwaitingOriginTxHash) {
+        logger.warn('[resolveTrackedTransaction]: managed relay execution finished without onchain transaction evidence', {
+          executionId,
+          status: relayStatus.status,
+        });
+      }
 
+      return {
+        kind: 'settled',
+        relayStatus,
+        transaction: buildSettledTransaction(trackedTransaction, TransactionStatus.confirmed),
+      };
+
+    case RelayExecutionStatus.Failed:
+    case RelayExecutionStatus.Reverted:
+      return {
+        kind: 'settled',
+        relayStatus,
+        transaction: buildSettledTransaction(trackedTransaction, TransactionStatus.failed),
+      };
+
+    default:
+      if (isSettledStatus(transaction.status)) {
         return {
           kind: 'settled',
           relayStatus,
-          transaction: buildSettledTransaction(trackedTransaction, TransactionStatus.confirmed),
+          transaction: buildSettledTransaction(trackedTransaction, transaction.status),
         };
+      }
 
-      case RelayExecutionStatus.Failed:
-      case RelayExecutionStatus.Reverted:
-        return {
-          kind: 'settled',
-          relayStatus,
-          transaction: buildSettledTransaction(trackedTransaction, TransactionStatus.failed),
-        };
+      if (isAwaitingOriginTxHash) {
+        return { kind: 'pending', relayStatus, transaction: toPendingTransaction(trackedTransaction) };
+      }
 
-      default:
-        if (isSettledStatus(transaction.status)) {
-          return {
-            kind: 'settled',
-            relayStatus,
-            transaction: buildSettledTransaction(trackedTransaction, transaction.status),
-          };
-        }
-
-        if (isAwaitingOriginTxHash) {
-          return { kind: 'pending', relayStatus, transaction: toPendingTransaction(trackedTransaction) };
-        }
-
-        return {
-          ...(await resolveOnchainPendingTransaction({
-            abortController,
-            address,
-            currency,
-            transaction: trackedTransaction,
-          })),
-          relayStatus,
-        };
-    }
-  } catch (e) {
-    logger.error(new RainbowError('[resolveTrackedTransaction]: Failed to fetch managed relay execution status', e), {
-      executionId: transaction.relayExecutionId,
-    });
-    return preserveTrackedTransaction(transaction);
+      return {
+        ...(await resolveOnchainPendingTransaction({
+          abortController,
+          address,
+          currency,
+          transaction: trackedTransaction,
+        })),
+        relayStatus,
+      };
   }
 }
 

--- a/src/hooks/useTransactionWatcher.ts
+++ b/src/hooks/useTransactionWatcher.ts
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, useRef } from 'react';
 
 import { time } from '@/framework/core/utils/time';
 import { useWatcher } from '@/framework/ui/hooks/useWatcher';
@@ -10,16 +10,20 @@ interface UseTransactionWatcherProps<T> {
 }
 
 /**
- * Watches a set of transactions: polls `watchFunction` with the latest `transactions` while there
- * are any, stopping when the set empties. A thin wrapper over `useWatcher`.
+ * Polls while `transactions` is nonempty.
+ * Each run receives the latest transaction array without restarting the polling schedule when
+ * that array changes.
  */
 export function useTransactionWatcher<T>({ interval = time.seconds(1), transactions, watchFunction }: UseTransactionWatcherProps<T>) {
+  const transactionsRef = useRef(transactions);
+  transactionsRef.current = transactions;
+
   useWatcher({
     enabled: transactions.length > 0,
     interval,
     watchFunction: useCallback(
-      (abortController: AbortController) => watchFunction(transactions, abortController),
-      [watchFunction, transactions]
+      (abortController: AbortController) => watchFunction(transactionsRef.current, abortController),
+      [watchFunction]
     ),
   });
 }

--- a/src/hooks/useTransactionWatcher.ts
+++ b/src/hooks/useTransactionWatcher.ts
@@ -11,8 +11,9 @@ interface UseTransactionWatcherProps<T> {
 
 /**
  * Polls while `transactions` is nonempty.
- * Each run receives the latest transaction array without restarting the polling schedule when
- * that array changes.
+ *
+ * Each run receives the latest transaction array without restarting
+ * the polling schedule when that array changes.
  */
 export function useTransactionWatcher<T>({ interval = time.seconds(1), transactions, watchFunction }: UseTransactionWatcherProps<T>) {
   const transactionsRef = useRef(transactions);

--- a/src/hooks/useWatchPendingTxs.test.ts
+++ b/src/hooks/useWatchPendingTxs.test.ts
@@ -19,7 +19,13 @@ import { RelayExecutionStatus } from '@rainbow-me/sdk';
 import { SwapType } from '@rainbow-me/swaps';
 
 import { resolveTrackedTransaction } from './pendingTransactionResolution';
-import { watchPendingTransactions } from './useWatchPendingTxs';
+import { useWatchPendingTransactions } from './useWatchPendingTxs';
+
+jest.mock('react', () => ({
+  ...jest.requireActual<typeof import('react')>('react'),
+  useCallback: (callback: unknown) => callback,
+  useRef: (initialValue: unknown) => ({ current: initialValue }),
+}));
 
 jest.mock('./pendingTransactionResolution', () => ({
   resolveTrackedTransaction: jest.fn(),
@@ -52,6 +58,17 @@ jest.mock('@/state/swaps/swapsStore', () => ({
     }),
   },
 }));
+
+jest.mock('@/state/assets/userAssetsStoreManager', () => {
+  const state: { address: string; cachedStore?: unknown; currency: 'ETH' } = { address: '0x123', currency: 'ETH' };
+  return {
+    userAssetsStoreManager: Object.assign((selector: (storeState: typeof state) => unknown) => selector(state), {
+      getState: () => state,
+      setState: (nextState: Partial<typeof state>) => Object.assign(state, nextState),
+      subscribe: jest.fn(),
+    }),
+  };
+});
 
 jest.mock('@/state/wallets/walletsStore', () => ({
   getAccountAddress: () => '0x123',
@@ -97,10 +114,11 @@ type ConfirmedManagedTransaction = Omit<PendingTransaction, 'status' | 'title'> 
   title: 'swap.confirmed';
 };
 
-describe('watchPendingTransactions', () => {
+describe('useWatchPendingTransactions', () => {
   const mockResolveTrackedTransaction = jest.mocked(resolveTrackedTransaction);
   const mockFetchRawTransaction = jest.mocked(fetchRawTransaction);
   let refetchQueriesSpy: jest.SpiedFunction<typeof queryClient.refetchQueries>;
+  let watchPendingTransactions: ReturnType<typeof useWatchPendingTransactions>;
 
   beforeEach(() => {
     jest.useFakeTimers();
@@ -109,6 +127,7 @@ describe('watchPendingTransactions', () => {
     resetStores();
 
     refetchQueriesSpy = jest.spyOn(queryClient, 'refetchQueries').mockImplementation(async () => undefined);
+    watchPendingTransactions = useWatchPendingTransactions({ address: TEST_ADDRESS });
   });
 
   afterEach(() => {
@@ -161,12 +180,9 @@ describe('watchPendingTransactions', () => {
         transaction: confirmedTransaction,
       });
 
-    await watchPendingTransactions({
-      abortController: new AbortController(),
-      address: TEST_ADDRESS,
-      currency: TEST_CURRENCY,
-      transactions: [stillPendingTransaction, confirmedPendingTransaction],
-    });
+    const transactions = [stillPendingTransaction, confirmedPendingTransaction];
+    await watchPendingTransactions(transactions, new AbortController());
+    await watchPendingTransactions(transactions, new AbortController());
     await flushBackgroundSync();
 
     expect(usePendingTransactionsStore.getState().pendingTransactions[TEST_ADDRESS]).toEqual([
@@ -199,18 +215,17 @@ describe('watchPendingTransactions', () => {
   });
 
   it('drops settled overlays once history includes them', async () => {
+    const pendingTransaction = buildManagedPendingTransaction({ hash: 'execution-1', relayExecutionId: 'execution-1' });
     const settledTransaction: SettledTransaction = {
-      ...buildManagedPendingTransaction({
-        hash: '0x1111111111111111111111111111111111111111111111111111111111111111',
-        relayExecutionId: 'execution-1',
-      }),
+      ...pendingTransaction,
+      hash: '0x1111111111111111111111111111111111111111111111111111111111111111',
       status: TransactionStatus.confirmed,
       title: 'swap.confirmed',
     };
 
     pendingTransactionsActions.setPendingTransactions({
       address: TEST_ADDRESS,
-      pendingTransactions: [buildManagedPendingTransaction({ hash: 'execution-1', relayExecutionId: 'execution-1' })],
+      pendingTransactions: [pendingTransaction],
     });
     mockResolveTrackedTransaction.mockResolvedValue({
       kind: 'settled',
@@ -236,12 +251,7 @@ describe('watchPendingTransactions', () => {
       );
     });
 
-    await watchPendingTransactions({
-      abortController: new AbortController(),
-      address: TEST_ADDRESS,
-      currency: TEST_CURRENCY,
-      transactions: [buildManagedPendingTransaction({ hash: 'execution-1', relayExecutionId: 'execution-1' })],
-    });
+    await watchPendingTransactions([pendingTransaction], new AbortController());
     await flushBackgroundSync();
 
     expect(usePendingTransactionsStore.getState().pendingTransactions[TEST_ADDRESS]).toEqual([]);
@@ -263,12 +273,7 @@ describe('watchPendingTransactions', () => {
       transaction: pendingTransaction,
     });
 
-    await watchPendingTransactions({
-      abortController: new AbortController(),
-      address: TEST_ADDRESS,
-      currency: TEST_CURRENCY,
-      transactions: [pendingTransaction],
-    });
+    await watchPendingTransactions([pendingTransaction], new AbortController());
 
     expect(mockResolveTrackedTransaction).toHaveBeenCalledTimes(1);
     expect(mockResolveTrackedTransaction).toHaveBeenCalledWith(
@@ -282,11 +287,10 @@ describe('watchPendingTransactions', () => {
   });
 
   it('syncs managed destination history after a confirmed transition', async () => {
+    const pendingTransaction = buildManagedPendingTransaction({ hash: 'execution-1', relayExecutionId: 'execution-1' });
     const settledTransaction: SettledTransaction = {
-      ...buildManagedPendingTransaction({
-        hash: '0x1111111111111111111111111111111111111111111111111111111111111111',
-        relayExecutionId: 'execution-1',
-      }),
+      ...pendingTransaction,
+      hash: '0x1111111111111111111111111111111111111111111111111111111111111111',
       changes: [
         {
           asset: buildChangedAsset({
@@ -334,7 +338,7 @@ describe('watchPendingTransactions', () => {
 
     pendingTransactionsActions.setPendingTransactions({
       address: TEST_ADDRESS,
-      pendingTransactions: [buildManagedPendingTransaction({ hash: 'execution-1', relayExecutionId: 'execution-1' })],
+      pendingTransactions: [pendingTransaction],
     });
     mockResolveTrackedTransaction.mockResolvedValue({
       kind: 'settled',
@@ -342,12 +346,7 @@ describe('watchPendingTransactions', () => {
       transaction: settledTransaction,
     });
 
-    await watchPendingTransactions({
-      abortController: new AbortController(),
-      address: TEST_ADDRESS,
-      currency: TEST_CURRENCY,
-      transactions: [buildManagedPendingTransaction({ hash: 'execution-1', relayExecutionId: 'execution-1' })],
-    });
+    await watchPendingTransactions([pendingTransaction], new AbortController());
     await flushBackgroundSync();
 
     expect(mockFetchRawTransaction).toHaveBeenNthCalledWith(
@@ -387,12 +386,7 @@ describe('watchPendingTransactions', () => {
       transaction: failedTransaction,
     });
 
-    await watchPendingTransactions({
-      abortController: new AbortController(),
-      address: TEST_ADDRESS,
-      currency: TEST_CURRENCY,
-      transactions: [pendingTransaction],
-    });
+    await watchPendingTransactions([pendingTransaction], new AbortController());
 
     expect(usePendingTransactionsStore.getState().pendingTransactions[TEST_ADDRESS]).toEqual([]);
     expect(Object.values(useRainbowToastsStore.getState().toasts)).toHaveLength(1);
@@ -403,8 +397,10 @@ describe('watchPendingTransactions', () => {
 
   it('updates the local overlay before managed history sync finishes', async () => {
     const originHash: `0x${string}` = '0x1111111111111111111111111111111111111111111111111111111111111111';
+    const pendingTransaction = buildManagedPendingTransaction({ hash: 'execution-1', relayExecutionId: 'execution-1' });
     const confirmedTransaction: SettledTransaction = {
-      ...buildManagedPendingTransaction({ hash: originHash, relayExecutionId: 'execution-1' }),
+      ...pendingTransaction,
+      hash: originHash,
       status: TransactionStatus.confirmed,
       title: 'swap.confirmed',
     };
@@ -412,7 +408,7 @@ describe('watchPendingTransactions', () => {
 
     pendingTransactionsActions.setPendingTransactions({
       address: TEST_ADDRESS,
-      pendingTransactions: [buildManagedPendingTransaction({ hash: 'execution-1', relayExecutionId: 'execution-1' })],
+      pendingTransactions: [pendingTransaction],
     });
     mockResolveTrackedTransaction.mockResolvedValue({
       kind: 'settled',
@@ -431,12 +427,7 @@ describe('watchPendingTransactions', () => {
     });
     mockFetchRawTransaction.mockImplementation(() => relayFetch.promise);
 
-    await watchPendingTransactions({
-      abortController: new AbortController(),
-      address: TEST_ADDRESS,
-      currency: TEST_CURRENCY,
-      transactions: [buildManagedPendingTransaction({ hash: 'execution-1', relayExecutionId: 'execution-1' })],
-    });
+    await watchPendingTransactions([pendingTransaction], new AbortController());
 
     expect(usePendingTransactionsStore.getState().pendingTransactions[TEST_ADDRESS]).toEqual([confirmedTransaction]);
     expect(Object.values(useRainbowToastsStore.getState().toasts)[0]?.transaction).toEqual(confirmedTransaction);
@@ -469,12 +460,7 @@ describe('watchPendingTransactions', () => {
       transaction: confirmedTransaction,
     });
 
-    await watchPendingTransactions({
-      abortController: new AbortController(),
-      address: TEST_ADDRESS,
-      currency: TEST_CURRENCY,
-      transactions: [pendingTransaction],
-    });
+    await watchPendingTransactions([pendingTransaction], new AbortController());
     await flushBackgroundSync();
 
     expect(usePendingTransactionsStore.getState().pendingTransactions[TEST_ADDRESS]).toEqual([]);

--- a/src/hooks/useWatchPendingTxs.ts
+++ b/src/hooks/useWatchPendingTxs.ts
@@ -1,20 +1,15 @@
 import { useCallback, useRef } from 'react';
 
-import type { Address, Hash } from 'viem';
+import type { Address } from 'viem';
 
 import { analytics } from '@/analytics';
 import { event } from '@/analytics/event';
 import { rainbowToastsActions } from '@/components/rainbow-toast/useRainbowToastsStore';
-import {
-  isAwaitingRelayTransactionHash,
-  TransactionStatus,
-  type PendingTransaction,
-  type RainbowTransaction,
-} from '@/entities/transactions';
+import { hasConfirmedOnchainHash, TransactionStatus, type PendingTransaction, type RainbowTransaction } from '@/entities/transactions';
 import type { SupportedCurrencyKey } from '@/features/currency/supportedCurrencies';
 import { areDestinationTxHashesEqual } from '@/features/delegation/utils/managedExecutionStatus';
 import { backendNetworksActions } from '@/features/network/stores/backendNetworksStore';
-import { type ChainId } from '@/features/network/types/backendNetworks';
+import type { ChainId } from '@/features/network/types/backendNetworks';
 import { logger, RainbowError } from '@/logger';
 import { queryClient } from '@/react-query';
 import { consolidatedTransactionsQueryKey } from '@/resources/transactions/consolidatedTransactions';
@@ -22,9 +17,9 @@ import { fetchRawTransaction, type PaginatedTransactions } from '@/resources/tra
 import { userAssetsStoreManager } from '@/state/assets/userAssetsStoreManager';
 import { useAssetUpdatesStore } from '@/state/assetUpdates/assetUpdates';
 import { pendingTransactionsActions, usePendingTransactionsStore } from '@/state/pendingTransactions';
-import { type RelayStatusSnapshot } from '@rainbow-me/sdk';
+import { type RelayOnchainEvidence, type RelayStatusSnapshot } from '@rainbow-me/sdk';
 
-import { resolveTrackedTransaction } from './pendingTransactionResolution';
+import { resolveTrackedTransaction, type TrackedTransactionResolution } from './pendingTransactionResolution';
 
 // ============ Types ========================================================== //
 
@@ -38,7 +33,7 @@ type TransactionHistoryPages = NonNullable<PaginatedTransactions['pages']>;
  * number of pending transactions.
  */
 export const useWatchPendingTransactions = ({ address }: { address: Address }) => {
-  const currency = userAssetsStoreManager(state => state.currency);
+  const currency = userAssetsStoreManager(s => s.currency);
   const nextTransactionIndex = useRef(0);
 
   return useCallback(
@@ -61,6 +56,7 @@ export const useWatchPendingTransactions = ({ address }: { address: Address }) =
 
 /**
  * Resolves one pending transaction and applies the result to the latest local overlays.
+ * History reconciliation continues in the background after the local result is applied.
  * If that transaction was replaced while the request was in flight, the stale result is discarded.
  */
 export async function watchPendingTransaction({
@@ -74,92 +70,66 @@ export async function watchPendingTransaction({
   currency: SupportedCurrencyKey;
   transaction: PendingTransaction;
 }): Promise<void> {
-  const now = Math.floor(Date.now() / 1000);
-  const resolution = await resolveTrackedTransaction({
-    abortController,
-    address,
-    currency,
-    transaction,
-  });
-
+  const resolution = await resolveTrackedTransaction({ abortController, address, currency, transaction });
   if (abortController.signal.aborted) return;
 
   const currentTransactions = usePendingTransactionsStore.getState().pendingTransactions[address];
   if (!currentTransactions?.includes(transaction)) return;
 
-  const historyPages = readHistoryPages({ address, currency });
-  const visibleTransactions = buildVisibleTransactions({
-    currentTransactions,
-    historyPages,
-    nextTransaction: resolution.transaction,
-    sourceTransaction: transaction,
-  });
-
-  pendingTransactionsActions.setPendingTransactions({
+  pendingTransactionsActions.applyTransactionResolution({
     address,
-    pendingTransactions: visibleTransactions,
+    pendingTransaction: transaction,
+    resolvedTransaction: resolution.transaction,
   });
 
-  const settledTransaction = resolution.kind === 'settled' ? resolution.transaction : undefined;
-  if (settledTransaction) rainbowToastsActions.handleTransaction(settledTransaction);
+  if (resolution.kind === 'settled') {
+    const settledTransaction = resolution.transaction;
+    rainbowToastsActions.handleTransaction(settledTransaction);
 
-  const isConfirmed = settledTransaction?.status === TransactionStatus.confirmed;
-  if (isConfirmed) {
-    useAssetUpdatesStore.getState().addWatchedTransactions({
-      address,
-      transactions: [settledTransaction],
-    });
+    if (settledTransaction.status === TransactionStatus.confirmed) {
+      useAssetUpdatesStore.getState().addWatchedTransactions({ address, transactions: [settledTransaction] });
 
-    analytics.track(event.pendingTransactionResolved, {
-      chainId: settledTransaction.chainId,
-      type: settledTransaction.type,
-      timeToResolve: typeof settledTransaction.minedAt === 'number' ? (now - settledTransaction.minedAt) * 1000 : undefined,
-    });
+      analytics.track(event.pendingTransactionResolved, {
+        chainId: settledTransaction.chainId,
+        type: settledTransaction.type,
+        timeToResolve:
+          typeof settledTransaction.minedAt === 'number' ? (Math.floor(Date.now() / 1000) - settledTransaction.minedAt) * 1000 : undefined,
+      });
+    }
   }
 
-  const hasIndexableConfirmation = isConfirmed && !isAwaitingRelayTransactionHash(settledTransaction);
-  const relayStatus =
-    resolution.relayStatus && didRelayOnchainEvidenceChange(transaction, resolution.transaction) ? resolution.relayStatus : undefined;
-
-  if (!hasIndexableConfirmation && !relayStatus) return;
-
-  void syncConsolidatedHistory({
-    address,
-    currency,
-    hasIndexableConfirmation,
-    historyPages,
-    relayStatus,
-  });
+  void reconcileTransactionHistory({ address, currency, transaction, resolution });
 }
 
-function didRelayOnchainEvidenceChange(previousTransaction: RainbowTransaction, nextTransaction: RainbowTransaction): boolean {
-  if (nextTransaction.hash !== previousTransaction.hash) {
-    return true;
-  }
-  return !areDestinationTxHashesEqual(previousTransaction.relayDestinationTxHashes, nextTransaction.relayDestinationTxHashes);
-}
+// ============ History Reconciliation ========================================= //
 
-// ============ History Sync =================================================== //
+const EMPTY_HISTORY_PAGES: TransactionHistoryPages = [];
 
-async function syncConsolidatedHistory({
+/**
+ * Indexes newly resolved relay transactions, refreshes history for onchain evidence,
+ * then retires local overlays that history now represents.
+ */
+async function reconcileTransactionHistory({
   address,
   currency,
-  hasIndexableConfirmation,
-  historyPages,
-  relayStatus,
+  transaction,
+  resolution,
 }: {
   address: Address;
   currency: SupportedCurrencyKey;
-  hasIndexableConfirmation: boolean;
-  historyPages: TransactionHistoryPages;
-  relayStatus?: RelayStatusSnapshot;
+  transaction: PendingTransaction;
+  resolution: TrackedTransactionResolution;
 }): Promise<void> {
-  try {
-    const didRequestRelayTransactions = relayStatus
-      ? await requestRelayTransactionsByHash({ address, currency, historyPages, relayStatus })
-      : false;
+  const { relayStatus, transaction: resolvedTransaction } = resolution;
 
-    if (!hasIndexableConfirmation && !didRequestRelayTransactions) return;
+  try {
+    let didFetchRelayTransactions = false;
+
+    if (relayStatus && didRelayOnchainEvidenceChange(transaction, resolvedTransaction)) {
+      didFetchRelayTransactions = await requestRelayTransactionsByHash({ address, currency, relayStatus });
+    }
+
+    if (!didFetchRelayTransactions && !hasConfirmedOnchainHash(resolvedTransaction)) return;
 
     await queryClient.refetchQueries({
       queryKey: consolidatedTransactionsQueryKey({
@@ -170,74 +140,78 @@ async function syncConsolidatedHistory({
       type: 'all',
     });
 
-    pruneIndexedTransactions({ address, currency });
+    const currentOverlays = usePendingTransactionsStore.getState().pendingTransactions[address];
+    if (!currentOverlays) return;
+
+    pendingTransactionsActions.setPendingTransactions({
+      address,
+      pendingTransactions: getVisibleTransactionOverlays(address, currency, currentOverlays),
+    });
   } catch (error) {
-    logger.error(new RainbowError('[watchPendingTransaction]: Failed to sync indexed transaction history', error), {
+    logger.error(new RainbowError('[watchPendingTransaction]: Failed to reconcile transaction history', error), {
       address,
       relayStatus: relayStatus?.status,
     });
   }
 }
 
+/**
+ * Fetches relay transactions by hash so they're indexed by the
+ * backend before history refreshes.
+ */
 async function requestRelayTransactionsByHash({
   address,
   currency,
-  historyPages,
   relayStatus,
 }: {
   address: Address;
   currency: SupportedCurrencyKey;
-  historyPages: TransactionHistoryPages;
   relayStatus: RelayStatusSnapshot;
 }): Promise<boolean> {
   const onchain = relayStatus.onchain;
   if (!onchain) return false;
 
-  const seen = new Set<string>();
-  const requests: Promise<RainbowTransaction | null>[] = [];
+  const transactions = getRelayTransactionsMissingFromHistory(address, currency, onchain);
+  if (!transactions.length) return false;
 
-  function queueTransactionLookups(source: { chainId: ChainId; txHashes: readonly Hash[] }): void {
-    for (const hash of source.txHashes) {
-      const identity = `${source.chainId}:${hash.toLowerCase()}`;
-      if (seen.has(identity) || isTransactionInHistory({ historyPages, transaction: { chainId: source.chainId, hash } })) continue;
+  const rejections = (
+    await Promise.allSettled(transactions.map(({ chainId, hash }) => fetchRawTransaction({ address, currency, chainId, hash })))
+  ).filter(result => result.status === 'rejected');
 
-      seen.add(identity);
-      requests.push(fetchRawTransaction({ address, currency, chainId: source.chainId, hash }));
-    }
-  }
-
-  queueTransactionLookups(onchain.origin);
-  if (onchain.type === 'crosschain') {
-    queueTransactionLookups(onchain.destination);
-  }
-
-  if (!requests.length) return false;
-
-  const results = await Promise.allSettled(requests);
-  let failedRequestCount = 0;
-  let firstError: unknown;
-
-  for (const result of results) {
-    if (result.status === 'fulfilled') continue;
-    failedRequestCount += 1;
-    firstError ??= result.reason;
-  }
-
-  if (failedRequestCount) {
-    logger.error(new RainbowError('[watchPendingTransaction]: Failed to look up relay transactions', firstError), {
-      failedRequestCount,
-      requestCount: requests.length,
+  if (rejections.length) {
+    logger.error(new RainbowError('[watchPendingTransaction]: Failed to look up relay transactions', rejections[0].reason), {
+      failedRequestCount: rejections.length,
+      requestCount: transactions.length,
     });
   }
 
   return true;
 }
 
-// ============ Visibility ===================================================== //
+function getRelayTransactionsMissingFromHistory(
+  address: Address,
+  currency: SupportedCurrencyKey,
+  onchain: RelayOnchainEvidence
+): Pick<RainbowTransaction, 'chainId' | 'hash'>[] {
+  const sources = onchain.type === 'crosschain' ? [onchain.origin, onchain.destination] : [onchain.origin];
+  let relayTransactionsById: Record<string, Pick<RainbowTransaction, 'chainId' | 'hash'>> | undefined;
 
-const EMPTY_PAGES: TransactionHistoryPages = [];
+  for (const { chainId, txHashes } of sources) {
+    for (const hash of txHashes) {
+      (relayTransactionsById ??= {})[transactionId(chainId, hash)] ??= { chainId, hash };
+    }
+  }
 
-function readHistoryPages({ address, currency }: { address: Address; currency: SupportedCurrencyKey }): TransactionHistoryPages {
+  if (!relayTransactionsById) return [];
+
+  for (const id of eachTransactionIdInHistory(address, currency)) {
+    delete relayTransactionsById[id];
+  }
+
+  return Object.values(relayTransactionsById);
+}
+
+function readHistoryPages(address: Address, currency: SupportedCurrencyKey): TransactionHistoryPages {
   const queryData = queryClient.getQueryData<PaginatedTransactions>(
     consolidatedTransactionsQueryKey({
       address,
@@ -246,77 +220,41 @@ function readHistoryPages({ address, currency }: { address: Address; currency: S
     })
   );
 
-  return queryData?.pages ?? EMPTY_PAGES;
+  return queryData?.pages ?? EMPTY_HISTORY_PAGES;
 }
 
-function buildVisibleTransactions({
-  currentTransactions,
-  historyPages,
-  nextTransaction,
-  sourceTransaction,
-}: {
-  currentTransactions: RainbowTransaction[];
-  historyPages: TransactionHistoryPages;
-  nextTransaction: RainbowTransaction;
-  sourceTransaction: PendingTransaction;
-}): RainbowTransaction[] {
-  const visibleTransactions: RainbowTransaction[] = [];
+function getVisibleTransactionOverlays(
+  address: Address,
+  currency: SupportedCurrencyKey,
+  overlays: RainbowTransaction[]
+): RainbowTransaction[] {
+  let indexedTransactionIds: Set<string> | undefined;
 
-  for (const transaction of currentTransactions) {
-    const visibleTransaction = transaction === sourceTransaction ? nextTransaction : transaction;
+  return overlays.filter(overlay => {
+    if (overlay.status === TransactionStatus.pending) return true;
+    if (!hasConfirmedOnchainHash(overlay)) return false;
 
-    if (shouldRetainLocalTransactionOverlay({ historyPages, transaction: visibleTransaction })) {
-      visibleTransactions.push(visibleTransaction);
-    }
-  }
+    indexedTransactionIds ??= new Set(eachTransactionIdInHistory(address, currency));
 
-  return visibleTransactions;
-}
-
-function pruneIndexedTransactions({ address, currency }: { address: Address; currency: SupportedCurrencyKey }): void {
-  const historyPages = readHistoryPages({ address, currency });
-  const currentTransactions = usePendingTransactionsStore.getState().pendingTransactions[address];
-  if (!currentTransactions) return;
-
-  const visibleTransactions = currentTransactions.filter(transaction => shouldRetainLocalTransactionOverlay({ historyPages, transaction }));
-
-  pendingTransactionsActions.setPendingTransactions({
-    address,
-    pendingTransactions: visibleTransactions,
+    return !indexedTransactionIds.has(transactionId(overlay.chainId, overlay.hash));
   });
 }
 
-function shouldRetainLocalTransactionOverlay({
-  historyPages,
-  transaction,
-}: {
-  historyPages: TransactionHistoryPages;
-  transaction: RainbowTransaction;
-}): boolean {
-  if (transaction.status === TransactionStatus.pending) return true;
-  if (transaction.status === TransactionStatus.failed) return false;
-  if (isAwaitingRelayTransactionHash(transaction)) return false;
-  return !isTransactionInHistory({ historyPages, transaction });
+function didRelayOnchainEvidenceChange(previousTransaction: RainbowTransaction, nextTransaction: RainbowTransaction): boolean {
+  return (
+    nextTransaction.hash !== previousTransaction.hash ||
+    !areDestinationTxHashesEqual(previousTransaction.relayDestinationTxHashes, nextTransaction.relayDestinationTxHashes)
+  );
 }
 
-function isTransactionInHistory({
-  historyPages,
-  transaction,
-}: {
-  historyPages: TransactionHistoryPages;
-  transaction: Pick<RainbowTransaction, 'chainId' | 'hash'>;
-}): boolean {
-  const targetHash = transaction.hash.toLowerCase();
-
-  for (const page of historyPages) {
-    if (
-      page.transactions.some(
-        indexedTransaction => indexedTransaction.chainId === transaction.chainId && indexedTransaction.hash.toLowerCase() === targetHash
-      )
-    ) {
-      return true;
+function* eachTransactionIdInHistory(address: Address, currency: SupportedCurrencyKey): Generator<string> {
+  for (const page of readHistoryPages(address, currency)) {
+    for (const transaction of page.transactions) {
+      yield transactionId(transaction.chainId, transaction.hash);
     }
   }
+}
 
-  return false;
+function transactionId(chainId: ChainId, hash: string): string {
+  return `${chainId}:${hash.toLowerCase()}`;
 }

--- a/src/hooks/useWatchPendingTxs.ts
+++ b/src/hooks/useWatchPendingTxs.ts
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, useRef } from 'react';
 
 import type { Address, Hash } from 'viem';
 
@@ -10,7 +10,6 @@ import {
   TransactionStatus,
   type PendingTransaction,
   type RainbowTransaction,
-  type SettledTransaction,
 } from '@/entities/transactions';
 import type { SupportedCurrencyKey } from '@/features/currency/supportedCurrencies';
 import { areDestinationTxHashesEqual } from '@/features/delegation/utils/managedExecutionStatus';
@@ -29,139 +28,42 @@ import { resolveTrackedTransaction } from './pendingTransactionResolution';
 
 // ============ Types ========================================================== //
 
-type WatchPendingTransactionsArgs = {
-  abortController: AbortController;
-  address: Address;
-  currency: SupportedCurrencyKey;
-  transactions: PendingTransaction[];
-};
-
 type TransactionHistoryPages = NonNullable<PaginatedTransactions['pages']>;
-
-type TransactionEntry = {
-  nextTransaction: RainbowTransaction;
-  relayStatus?: RelayStatusSnapshot;
-  settledTransition?: SettledTransaction;
-};
-
-type RelayTransactionLookupSource = {
-  chainId: ChainId;
-  txHashes: readonly Hash[];
-};
 
 // ============ API ============================================================ //
 
 /**
- * Returns the pending-transaction watcher callback scoped to `address`.
+ * Creates a watcher that polls one pending transaction per run.
+ * Selection advances in round-robin order, keeping each run's request work independent of the
+ * number of pending transactions.
  */
 export const useWatchPendingTransactions = ({ address }: { address: Address }) => {
   const currency = userAssetsStoreManager(state => state.currency);
+  const nextTransactionIndex = useRef(0);
 
   return useCallback(
-    (transactions: PendingTransaction[], abortController: AbortController) =>
-      watchPendingTransactions({
+    (transactions: PendingTransaction[], abortController: AbortController) => {
+      if (!transactions.length) return Promise.resolve();
+
+      const transactionIndex = nextTransactionIndex.current % transactions.length;
+      nextTransactionIndex.current = (transactionIndex + 1) % transactions.length;
+
+      return watchPendingTransaction({
         abortController,
         address,
         currency,
-        transactions,
-      }),
+        transaction: transactions[transactionIndex],
+      });
+    },
     [address, currency]
   );
 };
 
 /**
- * Resolves pending-transaction overlays, triggers side effects for newly
- * settled transactions, and keeps hash-backed successful overlays visible until
- * history catches up.
+ * Resolves one pending transaction and applies the result to the latest local overlays.
+ * If that transaction was replaced while the request was in flight, the stale result is discarded.
  */
-export async function watchPendingTransactions({
-  abortController,
-  address,
-  currency,
-  transactions,
-}: WatchPendingTransactionsArgs): Promise<void> {
-  if (!transactions.length) return;
-
-  const currentTransactions = readStoredTransactions(address);
-  let canceled = abortController.signal.aborted;
-  abortController.signal.addEventListener('abort', () => {
-    canceled = true;
-  });
-
-  const now = Math.floor(Date.now() / 1000);
-  const entries = await Promise.all(
-    transactions.map(transaction =>
-      readTransactionEntry({
-        abortController,
-        address,
-        currency,
-        transaction,
-      })
-    )
-  );
-
-  if (canceled) return;
-
-  const relayStatuses: RelayStatusSnapshot[] = [];
-  const settledTransitions: SettledTransaction[] = [];
-  const confirmedTransitions: SettledTransaction[] = [];
-
-  for (const entry of entries) {
-    if (entry.relayStatus) relayStatuses.push(entry.relayStatus);
-
-    const settledTransition = entry.settledTransition;
-    if (!settledTransition) continue;
-
-    settledTransitions.push(settledTransition);
-    if (settledTransition.status === TransactionStatus.confirmed) confirmedTransitions.push(settledTransition);
-  }
-
-  const historyPages = readHistoryPages({ address, currency });
-  const visibleTransactions = buildVisibleTransactions({
-    currentTransactions,
-    entries,
-    historyPages,
-  });
-
-  pendingTransactionsActions.setPendingTransactions({
-    address,
-    pendingTransactions: visibleTransactions,
-  });
-
-  if (settledTransitions.length) {
-    settledTransitions.forEach(transaction => rainbowToastsActions.handleTransaction(transaction));
-  }
-
-  if (confirmedTransitions.length) {
-    useAssetUpdatesStore.getState().addWatchedTransactions({
-      address,
-      transactions: confirmedTransitions,
-    });
-
-    confirmedTransitions.forEach(transaction => {
-      analytics.track(event.pendingTransactionResolved, {
-        chainId: transaction.chainId,
-        type: transaction.type,
-        timeToResolve: typeof transaction.minedAt === 'number' ? (now - transaction.minedAt) * 1000 : undefined,
-      });
-    });
-  }
-
-  const hasIndexableConfirmation = confirmedTransitions.some(transaction => !isAwaitingRelayTransactionHash(transaction));
-  if (!hasIndexableConfirmation && !relayStatuses.length) return;
-
-  void syncConsolidatedHistory({
-    address,
-    currency,
-    hasIndexableConfirmation,
-    historyPages,
-    relayStatuses,
-  });
-}
-
-// ============ Resolution ===================================================== //
-
-async function readTransactionEntry({
+export async function watchPendingTransaction({
   abortController,
   address,
   currency,
@@ -171,7 +73,8 @@ async function readTransactionEntry({
   address: Address;
   currency: SupportedCurrencyKey;
   transaction: PendingTransaction;
-}): Promise<TransactionEntry> {
+}): Promise<void> {
+  const now = Math.floor(Date.now() / 1000);
   const resolution = await resolveTrackedTransaction({
     abortController,
     address,
@@ -179,15 +82,54 @@ async function readTransactionEntry({
     transaction,
   });
 
-  const relayStatus = resolution.relayStatus;
-  const trackedTransaction = resolution.transaction;
-  const settledTransition = resolution.kind === 'settled' ? resolution.transaction : undefined;
+  if (abortController.signal.aborted) return;
 
-  return {
-    nextTransaction: trackedTransaction,
-    relayStatus: relayStatus && didRelayOnchainEvidenceChange(transaction, trackedTransaction) ? relayStatus : undefined,
-    settledTransition,
-  };
+  const currentTransactions = usePendingTransactionsStore.getState().pendingTransactions[address];
+  if (!currentTransactions?.includes(transaction)) return;
+
+  const historyPages = readHistoryPages({ address, currency });
+  const visibleTransactions = buildVisibleTransactions({
+    currentTransactions,
+    historyPages,
+    nextTransaction: resolution.transaction,
+    sourceTransaction: transaction,
+  });
+
+  pendingTransactionsActions.setPendingTransactions({
+    address,
+    pendingTransactions: visibleTransactions,
+  });
+
+  const settledTransaction = resolution.kind === 'settled' ? resolution.transaction : undefined;
+  if (settledTransaction) rainbowToastsActions.handleTransaction(settledTransaction);
+
+  const isConfirmed = settledTransaction?.status === TransactionStatus.confirmed;
+  if (isConfirmed) {
+    useAssetUpdatesStore.getState().addWatchedTransactions({
+      address,
+      transactions: [settledTransaction],
+    });
+
+    analytics.track(event.pendingTransactionResolved, {
+      chainId: settledTransaction.chainId,
+      type: settledTransaction.type,
+      timeToResolve: typeof settledTransaction.minedAt === 'number' ? (now - settledTransaction.minedAt) * 1000 : undefined,
+    });
+  }
+
+  const hasIndexableConfirmation = isConfirmed && !isAwaitingRelayTransactionHash(settledTransaction);
+  const relayStatus =
+    resolution.relayStatus && didRelayOnchainEvidenceChange(transaction, resolution.transaction) ? resolution.relayStatus : undefined;
+
+  if (!hasIndexableConfirmation && !relayStatus) return;
+
+  void syncConsolidatedHistory({
+    address,
+    currency,
+    hasIndexableConfirmation,
+    historyPages,
+    relayStatus,
+  });
 }
 
 function didRelayOnchainEvidenceChange(previousTransaction: RainbowTransaction, nextTransaction: RainbowTransaction): boolean {
@@ -204,20 +146,20 @@ async function syncConsolidatedHistory({
   currency,
   hasIndexableConfirmation,
   historyPages,
-  relayStatuses,
+  relayStatus,
 }: {
   address: Address;
   currency: SupportedCurrencyKey;
   hasIndexableConfirmation: boolean;
   historyPages: TransactionHistoryPages;
-  relayStatuses: readonly RelayStatusSnapshot[];
+  relayStatus?: RelayStatusSnapshot;
 }): Promise<void> {
   try {
-    const relayTransactionLookupCount = relayStatuses.length
-      ? await lookUpRelayTransactionsByHash({ address, currency, historyPages, relayStatuses })
-      : 0;
+    const didRequestRelayTransactions = relayStatus
+      ? await requestRelayTransactionsByHash({ address, currency, historyPages, relayStatus })
+      : false;
 
-    if (!hasIndexableConfirmation && relayTransactionLookupCount === 0) return;
+    if (!hasIndexableConfirmation && !didRequestRelayTransactions) return;
 
     await queryClient.refetchQueries({
       queryKey: consolidatedTransactionsQueryKey({
@@ -230,34 +172,31 @@ async function syncConsolidatedHistory({
 
     pruneIndexedTransactions({ address, currency });
   } catch (error) {
-    logger.error(new RainbowError('[watchPendingTransactions]: Failed to sync indexed transaction history', error), {
+    logger.error(new RainbowError('[watchPendingTransaction]: Failed to sync indexed transaction history', error), {
       address,
-      relayStatuses: relayStatuses.length,
+      relayStatus: relayStatus?.status,
     });
   }
 }
 
-/**
- * Fetches relayed transactions through `/transactions/GetTransactionByHash`
- * so the consolidated history backend indexes them immediately.
- *
- * Returns the number of newly fetched transactions.
- */
-async function lookUpRelayTransactionsByHash({
+async function requestRelayTransactionsByHash({
   address,
   currency,
   historyPages,
-  relayStatuses,
+  relayStatus,
 }: {
   address: Address;
   currency: SupportedCurrencyKey;
   historyPages: TransactionHistoryPages;
-  relayStatuses: readonly RelayStatusSnapshot[];
-}): Promise<number> {
+  relayStatus: RelayStatusSnapshot;
+}): Promise<boolean> {
+  const onchain = relayStatus.onchain;
+  if (!onchain) return false;
+
   const seen = new Set<string>();
   const requests: Promise<RainbowTransaction | null>[] = [];
 
-  function queueRelayTransactionLookups(source: RelayTransactionLookupSource): void {
+  function queueTransactionLookups(source: { chainId: ChainId; txHashes: readonly Hash[] }): void {
     for (const hash of source.txHashes) {
       const identity = `${source.chainId}:${hash.toLowerCase()}`;
       if (seen.has(identity) || isTransactionInHistory({ historyPages, transaction: { chainId: source.chainId, hash } })) continue;
@@ -267,30 +206,36 @@ async function lookUpRelayTransactionsByHash({
     }
   }
 
-  for (const statusSnapshot of relayStatuses) {
-    const onchain = statusSnapshot.onchain;
-    if (!onchain) continue;
-    queueRelayTransactionLookups(onchain.origin);
-
-    if (onchain.type === 'crosschain') {
-      queueRelayTransactionLookups(onchain.destination);
-    }
+  queueTransactionLookups(onchain.origin);
+  if (onchain.type === 'crosschain') {
+    queueTransactionLookups(onchain.destination);
   }
 
-  if (!requests.length) return 0;
+  if (!requests.length) return false;
 
-  await Promise.allSettled(requests);
-  return requests.length;
+  const results = await Promise.allSettled(requests);
+  let failedRequestCount = 0;
+  let firstError: unknown;
+
+  for (const result of results) {
+    if (result.status === 'fulfilled') continue;
+    failedRequestCount += 1;
+    firstError ??= result.reason;
+  }
+
+  if (failedRequestCount) {
+    logger.error(new RainbowError('[watchPendingTransaction]: Failed to look up relay transactions', firstError), {
+      failedRequestCount,
+      requestCount: requests.length,
+    });
+  }
+
+  return true;
 }
 
 // ============ Visibility ===================================================== //
 
 const EMPTY_PAGES: TransactionHistoryPages = [];
-const EMPTY_TRANSACTIONS: RainbowTransaction[] = [];
-
-function readStoredTransactions(address: Address): RainbowTransaction[] {
-  return usePendingTransactionsStore.getState().pendingTransactions[address] || EMPTY_TRANSACTIONS;
-}
 
 function readHistoryPages({ address, currency }: { address: Address; currency: SupportedCurrencyKey }): TransactionHistoryPages {
   const queryData = queryClient.getQueryData<PaginatedTransactions>(
@@ -306,26 +251,22 @@ function readHistoryPages({ address, currency }: { address: Address; currency: S
 
 function buildVisibleTransactions({
   currentTransactions,
-  entries,
   historyPages,
+  nextTransaction,
+  sourceTransaction,
 }: {
   currentTransactions: RainbowTransaction[];
-  entries: TransactionEntry[];
   historyPages: TransactionHistoryPages;
+  nextTransaction: RainbowTransaction;
+  sourceTransaction: PendingTransaction;
 }): RainbowTransaction[] {
   const visibleTransactions: RainbowTransaction[] = [];
-  let pendingEntryIndex = 0;
 
   for (const transaction of currentTransactions) {
-    let nextTransaction = transaction;
+    const visibleTransaction = transaction === sourceTransaction ? nextTransaction : transaction;
 
-    if (transaction.status === TransactionStatus.pending) {
-      nextTransaction = entries[pendingEntryIndex]?.nextTransaction ?? transaction;
-      pendingEntryIndex += 1;
-    }
-
-    if (shouldRetainLocalTransactionOverlay({ historyPages, transaction: nextTransaction })) {
-      visibleTransactions.push(nextTransaction);
+    if (shouldRetainLocalTransactionOverlay({ historyPages, transaction: visibleTransaction })) {
+      visibleTransactions.push(visibleTransaction);
     }
   }
 
@@ -334,7 +275,9 @@ function buildVisibleTransactions({
 
 function pruneIndexedTransactions({ address, currency }: { address: Address; currency: SupportedCurrencyKey }): void {
   const historyPages = readHistoryPages({ address, currency });
-  const currentTransactions = readStoredTransactions(address);
+  const currentTransactions = usePendingTransactionsStore.getState().pendingTransactions[address];
+  if (!currentTransactions) return;
+
   const visibleTransactions = currentTransactions.filter(transaction => shouldRetainLocalTransactionOverlay({ historyPages, transaction }));
 
   pendingTransactionsActions.setPendingTransactions({

--- a/src/resources/transactions/transaction.ts
+++ b/src/resources/transactions/transaction.ts
@@ -62,13 +62,11 @@ export type BackendTransactionArgs = {
   enabled: boolean;
 };
 
-// 4xx responses where the client cannot meaningfully react. Silenced so the pending-tx
-// watcher's 1Hz polling doesn't flood Sentry while a persistent server-side condition
-// (auth, WAF, rate limit, not-yet-indexed) clears. 400 / 422 and other client-bug codes
-// are deliberately omitted: those signal malformed requests we want to see.
-const SILENCED_FETCH_STATUSES = new Set([401, 403, 404, 408, 429]);
-
-export const fetchRawTransaction = async ({
+/**
+ * Fetches and parses a transaction by hash.
+ * A 404 response returns `null`; other platform request or parsing failures reject.
+ */
+export async function fetchRawTransaction({
   abortController,
   address,
   currency,
@@ -82,7 +80,7 @@ export const fetchRawTransaction = async ({
   chainId: ChainId;
   hash: string;
   originalType?: TransactionType;
-}): Promise<RainbowTransaction | null> => {
+}): Promise<RainbowTransaction | null> {
   if (IS_TEST) {
     const mockCashTransaction = await getMockCashTransactionByHash({ address, currency, chainId, hash });
     if (mockCashTransaction) return mockCashTransaction;
@@ -160,13 +158,10 @@ export const fetchRawTransaction = async ({
 
     return parsed;
   } catch (e) {
-    if (e instanceof RainbowFetchError && e.response && SILENCED_FETCH_STATUSES.has(e.response.status)) {
-      return null;
-    }
-    logger.error(new RainbowError('[transaction]: Failed to fetch transaction', e));
-    return null;
+    if (e instanceof RainbowFetchError && e.response?.status === 404) return null;
+    throw e;
   }
-};
+}
 
 // ///////////////////////////////////////////////
 // Query Function
@@ -174,10 +169,19 @@ export const fetchRawTransaction = async ({
 export const transactionQueryKey = ({ hash, address, currency, chainId, originalType }: TransactionArgs) =>
   createQueryKey('transactions', { address, currency, chainId, hash, originalType }, { persisterVersion: 1 });
 
-export function transactionQueryFn({
+/**
+ * Fetches a transaction for React Query.
+ * Missing transactions return `null`. Other failures are logged and also return `null`.
+ */
+export async function transactionQueryFn({
   queryKey: [{ address, currency, chainId, hash, originalType }],
 }: QueryFunctionArgs<typeof transactionQueryKey>): Promise<RainbowTransaction | null> {
-  return fetchRawTransaction({ address, currency, chainId, hash, originalType });
+  try {
+    return await fetchRawTransaction({ address, currency, chainId, hash, originalType });
+  } catch (error) {
+    logger.error(new RainbowError('[transaction]: Failed to fetch transaction', error));
+    return null;
+  }
 }
 
 export const fetchCachedTransaction = async ({

--- a/src/state/pendingTransactions/index.ts
+++ b/src/state/pendingTransactions/index.ts
@@ -1,7 +1,13 @@
 import { createBaseStore, createStoreActions } from '@storesjs/stores';
 
 import { rainbowToastsActions } from '@/components/rainbow-toast/useRainbowToastsStore';
-import { isPendingTransaction, type NewTransaction, type PendingTransaction, type RainbowTransaction } from '@/entities/transactions';
+import {
+  hasConfirmedOnchainHash,
+  isPendingTransaction,
+  type NewTransaction,
+  type PendingTransaction,
+  type RainbowTransaction,
+} from '@/entities/transactions';
 import { type ChainId } from '@/features/network/types/backendNetworks';
 import { convertNewTransactionToRainbowTransaction } from '@/parsers/transactions';
 import { nonceActions } from '@/state/nonces';
@@ -10,6 +16,15 @@ import { shallowEqual } from '@/worklets/comparisons';
 export type PendingTransactionsState = {
   pendingTransactions: Partial<Record<string, RainbowTransaction[]>>;
   addPendingTransaction: ({ address, pendingTransaction }: { address: string; pendingTransaction: RainbowTransaction }) => void;
+  applyTransactionResolution: ({
+    address,
+    pendingTransaction,
+    resolvedTransaction,
+  }: {
+    address: string;
+    pendingTransaction: PendingTransaction;
+    resolvedTransaction: RainbowTransaction;
+  }) => void;
   clearPendingTransactions: () => void;
   getPendingTransactions: (address: string) => PendingTransaction[];
   getTransactionsInReverseOrder: (address: string) => RainbowTransaction[];
@@ -47,6 +62,25 @@ export const usePendingTransactionsStore = createBaseStore<PendingTransactionsSt
 
       rainbowToastsActions.handleTransaction(pendingTransaction);
     },
+
+    applyTransactionResolution: ({ address, pendingTransaction, resolvedTransaction }) =>
+      set(state => {
+        const transactions = state.pendingTransactions[address];
+        if (!transactions) return state;
+
+        const index = transactions.indexOf(pendingTransaction);
+        if (index === -1 || shallowEqual(transactions[index], resolvedTransaction)) return state;
+
+        const nextTransactions = [...transactions];
+        const shouldRetain = isPendingTransaction(resolvedTransaction) || hasConfirmedOnchainHash(resolvedTransaction);
+
+        if (shouldRetain) nextTransactions[index] = resolvedTransaction;
+        else nextTransactions.splice(index, 1);
+
+        return {
+          pendingTransactions: { ...state.pendingTransactions, [address]: nextTransactions },
+        };
+      }),
 
     clearPendingTransactions: () =>
       set({


### PR DESCRIPTION
Fixes APP-3936

## What changed (plus any additional context for devs)
- Previously, having a high number of concurrent pending transactions would result in each being polled once per second. With enough pending transactions, this would eventually lead to the user being rate limited, which would then cascade into errors and excessive retries.
- The pending transaction watcher now checks one pending transaction per second, cycling through the pending list rather than polling every pending transaction each second
  - Now copies the transaction data into a ref to stabilize the watcher's dependency on transaction data, which prevents the loop from repeatedly restarting when multiple pending transactions exist and are being updated
  - It waits progressively longer after consecutive request failures
  - It logs each failure sequence once and returns to the normal interval after success
- Simplifies the pending transaction watcher's logic/transformations/lookups and moves the core transaction update into an `applyTransactionResolution` method within the pending transactions store

## Screen recordings / screenshots

## What to test
