### PR TITLE
chore: improve agent worktree setup

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,24 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$(git rev-parse --show-toplevel)/scripts/worktree-setup.sh\""
+          }
+        ]
+      }
+    ],
+    "SubagentStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$(git rev-parse --show-toplevel)/scripts/worktree-setup.sh\""
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,21 @@
+# Worktree setup, mirroring the hooks in .claude/settings.json so both agents
+# prepare a worktree the same way. Codex requires you to review and trust a
+# project-local hook definition once, interactively, before it will run; until
+# then these do not fire, and `codex exec` blocks waiting for the prompt.
+# Changing a definition below requires re-approval.
+
+[[hooks.SessionStart]]
+matcher = "startup|resume"
+
+[[hooks.SessionStart.hooks]]
+type = "command"
+command = 'bash "$(git rev-parse --show-toplevel)/scripts/worktree-setup.sh"'
+statusMessage = "Preparing worktree"
+
+[[hooks.SubagentStart]]
+matcher = ".*"
+
+[[hooks.SubagentStart.hooks]]
+type = "command"
+command = 'bash "$(git rev-parse --show-toplevel)/scripts/worktree-setup.sh"'
+statusMessage = "Preparing worktree"

--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,0 +1,16 @@
+# Gitignored files copied into every worktree an agent creates. Paths only, so
+# nothing sensitive lives here; the file contents stay gitignored. Consumed
+# natively by Claude Code, and by Codex via scripts/worktree-setup.sh.
+# https://code.claude.com/docs/en/worktrees
+
+# Required before anything can typecheck or build.
+.env
+.xcode.env.local
+ios/*.xcconfig
+src/config/debug.ts
+src/graphql/config.js
+src/graphql/__generated__/
+
+# node_modules is deliberately absent: scripts/worktree-setup.sh copies it
+# instead, which is far cheaper (copy-on-write, ~46MB) and checks the lockfile
+# first so a branch that changes dependencies installs rather than clones.

--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -5,12 +5,18 @@
 
 # Required before anything can typecheck or build.
 .env
-.xcode.env.local
-ios/*.xcconfig
 src/config/debug.ts
 src/graphql/config.js
+
+# Generated output, copied as a snapshot rather than regenerated. Re-run
+# `yarn graphql-codegen` in the worktree if the branch changes queries, schemas
+# or codegen config.
 src/graphql/__generated__/
 
-# node_modules is deliberately absent: scripts/worktree-setup.sh copies it
-# instead, which is far cheaper (copy-on-write, ~46MB) and checks the lockfile
-# first so a branch that changes dependencies installs rather than clones.
+# Deliberately absent:
+#   ios/*.xcconfig, .xcode.env.local  postinstall.sh appends to these, so copying
+#     them yields duplicate keys. Worktrees don't build the app anyway, since
+#     pods and simulators are single-instance.
+#   node_modules  scripts/worktree-setup.sh runs `yarn install` instead, so the
+#     tree comes from this branch's own lockfile and patches/ rather than from
+#     whatever branch another checkout happens to be sitting on.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ React Native crypto wallet app (iOS & Android). Uses React Navigation, `@storesj
 
 Worktree setup is automatic and needs no action: `scripts/worktree-setup.sh` runs once per worktree, via the `SessionStart` hooks in `.claude/settings.json` and `.codex/config.toml`.
 
-- **Worktree missing dependencies:** run `bash scripts/worktree-setup.sh`. Idempotent, and no-ops in the main checkout.
+- **Worktree missing dependencies:** run `bash scripts/worktree-setup.sh`. It skips worktrees that already have `node_modules`, so use `yarn install` if a tree is present but broken.
 - **Never run the app from a worktree** -- Metro, simulators and pods are single-instance. Use the main checkout.
 
 ## Architecture

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,13 @@ React Native crypto wallet app (iOS & Android). Uses React Navigation, `@storesj
 - **Single test:** `yarn jest path/to/test`
 - **Dependency rules + cycles:** `yarn lint:deps` (dependency-cruiser via `tools/deps-check/`: architectural boundaries, plus circular deps checked against a grandfathered per-platform baseline). Net-new cycles fail; removing cycles also fails until you run `yarn lint:deps:baseline:update` and commit the baselines, which keeps them exact. Per-rule policies (grandfathered vs strict) live in `tools/deps-check/policies.ts`.
 
+## Worktrees
+
+Worktree setup is automatic and needs no action: `scripts/worktree-setup.sh` runs once per worktree, via the `SessionStart` hooks in `.claude/settings.json` and `.codex/config.toml`.
+
+- **Worktree missing dependencies:** run `bash scripts/worktree-setup.sh`. Idempotent, and no-ops in the main checkout.
+- **Never run the app from a worktree** -- Metro, simulators and pods are single-instance. Use the main checkout.
+
 ## Architecture
 
 ### State management

--- a/scripts/worktree-setup.sh
+++ b/scripts/worktree-setup.sh
@@ -7,33 +7,24 @@
 # GraphQL types, node_modules) are all absent and every yarn script fails until
 # they are put in place.
 #
-# Runs automatically, once per worktree:
-#   - Claude Code, via the SessionStart / SubagentStart hooks in .claude/settings.json
-#   - Codex, via .codex/setup.sh
+# Runs automatically via the SessionStart / SubagentStart hooks in
+# .claude/settings.json and .codex/config.toml. Those fire on resume, /clear and
+# compaction as well as on a new session, so this returns early once a worktree
+# is set up.
 #
-# Safe to run by hand and safe to run repeatedly; it no-ops once a worktree is
-# set up, and no-ops entirely in the main checkout.
+# Safe to run by hand. No-ops entirely in the main checkout.
 
 set -eo pipefail
 
 MAIN=$(dirname "$(git rev-parse --path-format=absolute --git-common-dir)")
 HERE=$(git rev-parse --show-toplevel)
 
-# The main checkout owns its own dependencies; there is nothing to prepare.
+# The main checkout owns its own dependencies.
 if [ "$MAIN" = "$HERE" ]; then
   exit 0
 fi
 
 cd "$HERE"
-
-# Copy-on-write where the filesystem supports it (APFS clone, btrfs/XFS
-# reflink), plain copy elsewhere. Cloning node_modules costs about 46MB and 30s
-# rather than 2.2GB and several minutes.
-clone() {
-  cp -c -R "$1" "$2" 2>/dev/null ||
-    cp -R --reflink=auto "$1" "$2" 2>/dev/null ||
-    cp -R "$1" "$2"
-}
 
 # Gitignored files declared in .worktreeinclude. Claude Code copies these itself
 # before this script runs, so the loop is a no-op there; it does the real work
@@ -42,7 +33,7 @@ if [ -f .worktreeinclude ]; then
   while IFS= read -r pattern || [ -n "$pattern" ]; do
     case "$pattern" in '' | '#'*) continue ;; esac
     pattern=${pattern%/}
-    # Deliberately unquoted so patterns such as ios/*.xcconfig glob.
+    # Deliberately unquoted so glob patterns expand.
     for src in "$MAIN"/$pattern; do
       [ -e "$src" ] || continue
       rel=${src#"$MAIN"/}
@@ -50,25 +41,31 @@ if [ -f .worktreeinclude ]; then
       # Mirror .worktreeinclude semantics: never copy a git-tracked file.
       git -C "$MAIN" check-ignore -q "$rel" || continue
       mkdir -p "$(dirname "$rel")"
-      clone "$src" "$rel"
+      cp -R "$src" "$rel"
     done
   done <.worktreeinclude
 fi
 
+# Any worktree that already has dependencies is left alone. yarn runs the root
+# postinstall on every install, and postinstall appends to the ios/*.xcconfig
+# files, so installing on every session would grow them without bound.
 if [ -d node_modules ]; then
   exit 0
 fi
 
-# The main checkout's node_modules is a valid tree only for the main checkout's
-# lockfile. An identical lockfile makes cloning correct by construction; a
-# different one means this branch resolves different packages (or different
-# entries in patches/) and has to install.
-if cmp -s yarn.lock "$MAIN/yarn.lock"; then
-  echo "🌱 Lockfiles match; cloning node_modules from $MAIN..."
-  clone "$MAIN/node_modules" node_modules
-else
-  echo "🌱 Lockfile differs from the main checkout; installing..."
-  yarn install --immutable
+# Installing from this branch's own lockfile and patches/ makes the tree correct
+# by construction, with no reasoning about any other checkout's state. Around
+# 23s against the warm global cache, though not a quick relink: yarn runs
+# postinstall.sh, which rewrites the tree with rn-nodeify, applies patch-package
+# and fires the RAINBOW_SCRIPTS_APP_*_PREBUILD_HOOK commands when set. Those
+# hooks warn and continue here, since they point into rainbow-scripts, which a
+# worktree doesn't have.
+echo "🌱 Installing dependencies for $HERE..."
+yarn install --immutable
+
+if [ ! -d node_modules ]; then
+  echo "✖ node_modules is still missing after install. Run 'yarn install' here to see why." >&2
+  exit 1
 fi
 
 echo "✅ Worktree ready: $HERE"

--- a/scripts/worktree-setup.sh
+++ b/scripts/worktree-setup.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+#
+# Prepares a git worktree so it can typecheck, lint, test and build.
+#
+# A worktree is a fresh checkout and git brings tracked files only, so the
+# gitignored files this repo needs (.env, src/config/debug.ts, the generated
+# GraphQL types, node_modules) are all absent and every yarn script fails until
+# they are put in place.
+#
+# Runs automatically, once per worktree:
+#   - Claude Code, via the SessionStart / SubagentStart hooks in .claude/settings.json
+#   - Codex, via .codex/setup.sh
+#
+# Safe to run by hand and safe to run repeatedly; it no-ops once a worktree is
+# set up, and no-ops entirely in the main checkout.
+
+set -eo pipefail
+
+MAIN=$(dirname "$(git rev-parse --path-format=absolute --git-common-dir)")
+HERE=$(git rev-parse --show-toplevel)
+
+# The main checkout owns its own dependencies; there is nothing to prepare.
+if [ "$MAIN" = "$HERE" ]; then
+  exit 0
+fi
+
+cd "$HERE"
+
+# Copy-on-write where the filesystem supports it (APFS clone, btrfs/XFS
+# reflink), plain copy elsewhere. Cloning node_modules costs about 46MB and 30s
+# rather than 2.2GB and several minutes.
+clone() {
+  cp -c -R "$1" "$2" 2>/dev/null ||
+    cp -R --reflink=auto "$1" "$2" 2>/dev/null ||
+    cp -R "$1" "$2"
+}
+
+# Gitignored files declared in .worktreeinclude. Claude Code copies these itself
+# before this script runs, so the loop is a no-op there; it does the real work
+# under Codex, which has no declarative equivalent.
+if [ -f .worktreeinclude ]; then
+  while IFS= read -r pattern || [ -n "$pattern" ]; do
+    case "$pattern" in '' | '#'*) continue ;; esac
+    pattern=${pattern%/}
+    # Deliberately unquoted so patterns such as ios/*.xcconfig glob.
+    for src in "$MAIN"/$pattern; do
+      [ -e "$src" ] || continue
+      rel=${src#"$MAIN"/}
+      [ -e "$rel" ] && continue
+      # Mirror .worktreeinclude semantics: never copy a git-tracked file.
+      git -C "$MAIN" check-ignore -q "$rel" || continue
+      mkdir -p "$(dirname "$rel")"
+      clone "$src" "$rel"
+    done
+  done <.worktreeinclude
+fi
+
+if [ -d node_modules ]; then
+  exit 0
+fi
+
+# The main checkout's node_modules is a valid tree only for the main checkout's
+# lockfile. An identical lockfile makes cloning correct by construction; a
+# different one means this branch resolves different packages (or different
+# entries in patches/) and has to install.
+if cmp -s yarn.lock "$MAIN/yarn.lock"; then
+  echo "🌱 Lockfiles match; cloning node_modules from $MAIN..."
+  clone "$MAIN/node_modules" node_modules
+else
+  echo "🌱 Lockfile differs from the main checkout; installing..."
+  yarn install --immutable
+fi
+
+echo "✅ Worktree ready: $HERE"


### PR DESCRIPTION
Both Claude Code and Codex can run parallel work in git worktrees, but a worktree is a fresh checkout and git brings only tracked files. Everything gitignored that the repo actually needs is therefore missing:
* the env file
* the local debug config
* the generated GraphQL types, and
* node_modules`

 Nothing typechecks, lints, tests or builds until the worktree ixs setup explicitely, and an agent that lands in one just fails on `Cannot find module`.

With this change worktrees now prepare themselves. A setup script runs via each agent's session-start hooks, copies the gitignored files declared in `.worktreeinclude`, then installs dependencies if the worktree has none. That takes about ~20s against a warm yarn cache, and installing from the branch's own lockfile and `patches/` means the tree is correct by construction rather than inherited from whatever branch another checkout happens to be sitting on.

I tested both Claude Code and Codex end to end with this locally.