### PR TITLE
feat(cash): link wallet

### DIFF
--- a/src/analytics/event.ts
+++ b/src/analytics/event.ts
@@ -138,6 +138,9 @@ export const event = {
   cashPasskeyFailed: 'cash.passkey_failed',
   cashCardLinked: 'cash.card_linked',
   cashCardLinkFailed: 'cash.card_link_failed',
+  cashWalletLinkPrompted: 'cash.wallet_link_prompted',
+  cashWalletLinked: 'cash.wallet_linked',
+  cashWalletLinkFailed: 'cash.wallet_link_failed',
   cashSignInSubmitted: 'cash.sign_in_submitted',
   cashSignInSucceeded: 'cash.sign_in_succeeded',
   cashSignInFailed: 'cash.sign_in_failed',
@@ -570,6 +573,11 @@ export type EventProperties = {
     brand: string;
   };
   [event.cashCardLinkFailed]: {
+    reason: string;
+  };
+  [event.cashWalletLinkPrompted]: undefined;
+  [event.cashWalletLinked]: undefined;
+  [event.cashWalletLinkFailed]: {
     reason: string;
   };
   [event.cashSignInSubmitted]: {

--- a/src/features/cash/components/CashActionButton.tsx
+++ b/src/features/cash/components/CashActionButton.tsx
@@ -5,7 +5,7 @@ import ButtonPressAnimation from '@/components/animations/ButtonPressAnimation';
 import Spinner from '@/components/Spinner';
 import { Box, Text, useForegroundColor, type TextProps } from '@/design-system';
 
-type SetupActionButtonProps = {
+type CashActionButtonProps = {
   disabled?: boolean;
   label: string;
   loading?: boolean;
@@ -15,7 +15,7 @@ type SetupActionButtonProps = {
   textSize?: TextProps['size'];
 };
 
-export const SetupActionButton = memo(function SetupActionButton({
+export const CashActionButton = memo(function CashActionButton({
   disabled = false,
   label,
   loading = false,
@@ -23,7 +23,7 @@ export const SetupActionButton = memo(function SetupActionButton({
   shadow = false,
   testID,
   textSize = '22pt',
-}: SetupActionButtonProps) {
+}: CashActionButtonProps) {
   const blue = useForegroundColor('blue');
   const isDisabled = disabled || loading;
 

--- a/src/features/cash/screens/add-cash-sheet/AddCashSheet.tsx
+++ b/src/features/cash/screens/add-cash-sheet/AddCashSheet.tsx
@@ -1,4 +1,4 @@
-import React, { memo, useCallback, useEffect, useState } from 'react';
+import React, { memo, useCallback, useEffect, useRef, useState } from 'react';
 import { Platform, StyleSheet } from 'react-native';
 
 import { useFocusEffect } from '@react-navigation/native';
@@ -14,6 +14,8 @@ import { HoldToActivateButton } from '@/components/hold-to-activate-button/HoldT
 import { NumberPad } from '@/components/number-pad/NumberPad';
 import { DEFAULT_HANDLE_COLOR_DARK, DEFAULT_HANDLE_COLOR_LIGHT, PanelSheet } from '@/components/PanelSheet/PanelSheet';
 import { Box, Inline, Text, useColorMode, useForegroundColor } from '@/design-system';
+import { isPasskeyCancellation } from '@/features/cash/services/cashPasskeyService';
+import { checkWalletLink } from '@/features/cash/services/walletLinkService';
 import { cashBuyOrderActions, useCashBuyOrderStore, useCashBuyPhase } from '@/features/cash/stores/cashBuyOrderStore';
 import { useCashLinkedCard, type LinkedCard } from '@/features/cash/stores/cashPaymentMethodStore';
 import { ChainId } from '@/features/network/types/backendNetworks';
@@ -21,6 +23,7 @@ import { opacity } from '@/framework/ui/utils/opacity';
 import { WrappedAlert as Alert } from '@/helpers/alert';
 import usePrevious from '@/hooks/usePrevious';
 import * as i18n from '@/languages';
+import { logger, RainbowError } from '@/logger';
 import { useNavigation } from '@/navigation/Navigation';
 import Routes from '@/navigation/routesNames';
 import { USDC_ADDRESS } from '@/references/constants';
@@ -334,7 +337,15 @@ export const AddCashSheet = memo(function AddCashSheet() {
   const phase = useCashBuyPhase();
   const previousPhase = usePrevious(phase);
   const errorCode = useCashBuyOrderStore(state => state.errorCode);
-  const isProcessing = phase === 'pending';
+  const [isCheckingWallet, setIsCheckingWallet] = useState(false);
+  const walletCheckRef = useRef<AbortController | null>(null);
+  const isProcessing = isCheckingWallet || phase === 'pending';
+
+  useEffect(() => {
+    return () => {
+      walletCheckRef.current?.abort();
+    };
+  }, []);
 
   useEffect(() => {
     if (previousPhase !== undefined) return;
@@ -390,10 +401,40 @@ export const AddCashSheet = memo(function AddCashSheet() {
     analytics.track(analytics.event.cashAmountEntered, { amount: amount.amount, entryMode: 'keypad' });
   }, [mode, amount.canSubmit, amount.amount]);
 
-  const handleHoldToAdd = useCallback(() => {
-    if (!linkedCard) return;
-    cashBuyOrderActions.submitBuyOrder({ cardId: linkedCard.id, depositAmount: amount.amount, walletAddress: accountAddress });
-  }, [accountAddress, amount.amount, linkedCard]);
+  // A deposit can only credit a wallet the Cash account has linked, so resolve that first: the token
+  // it mints also authorizes the order that follows.
+  const handleHoldToAdd = useCallback(async () => {
+    if (!linkedCard || walletCheckRef.current) return;
+
+    const controller = new AbortController();
+    walletCheckRef.current = controller;
+    setIsCheckingWallet(true);
+    try {
+      const status = await checkWalletLink(accountAddress, controller);
+      if (controller.signal.aborted) return;
+      if (status === 'needsLink') {
+        navigation.navigate(Routes.CASH_ADD_WALLET_SHEET, {
+          walletAddress: accountAddress,
+          cardId: linkedCard.id,
+          depositAmount: amount.amount,
+        });
+        return;
+      }
+      cashBuyOrderActions.submitBuyOrder({ cardId: linkedCard.id, depositAmount: amount.amount, walletAddress: accountAddress });
+    } catch (error) {
+      if (controller.signal.aborted || isPasskeyCancellation(error)) return;
+      logger.error(new RainbowError('[AddCashSheet]: Failed to resolve the deposit wallet', error));
+      Alert.alert(
+        i18n.t(i18n.l.cash.add_cash_screen.wallet_check_error_title),
+        i18n.t(i18n.l.cash.add_cash_screen.wallet_check_error_generic)
+      );
+    } finally {
+      if (walletCheckRef.current === controller) {
+        walletCheckRef.current = null;
+      }
+      setIsCheckingWallet(false);
+    }
+  }, [accountAddress, amount.amount, linkedCard, navigation]);
 
   const handleAddCard = useCallback(() => {
     navigation.navigate(Routes.CASH_DEPOSIT_SETUP_SCREEN);

--- a/src/features/cash/screens/add-wallet-sheet/AddWalletSheet.tsx
+++ b/src/features/cash/screens/add-wallet-sheet/AddWalletSheet.tsx
@@ -1,0 +1,134 @@
+import React, { memo, useCallback } from 'react';
+
+import { useFocusEffect, useRoute, type RouteProp } from '@react-navigation/native';
+
+import { analytics } from '@/analytics';
+import ContactAvatar from '@/components/contacts/ContactAvatar';
+import ImageAvatar from '@/components/contacts/ImageAvatar';
+import { PanelSheet } from '@/components/PanelSheet/PanelSheet';
+import { Box, Stack, Text } from '@/design-system';
+import { CashActionButton } from '@/features/cash/components/CashActionButton';
+import { cashBuyOrderActions } from '@/features/cash/stores/cashBuyOrderStore';
+import * as i18n from '@/languages';
+import { useNavigation } from '@/navigation/Navigation';
+import type Routes from '@/navigation/routesNames';
+import { type RootStackParamList } from '@/navigation/types';
+import { useAccountProfileInfo, useIsHardwareWallet, useIsReadOnlyWallet } from '@/state/wallets/walletsStore';
+import { formatAddressForDisplay } from '@/utils/abbreviations';
+
+import { useWalletLinkFlow } from './useWalletLinkFlow';
+
+function WalletAvatar() {
+  const { accountSymbol, accountColor, accountImage } = useAccountProfileInfo();
+
+  return accountImage ? (
+    <ImageAvatar image={accountImage} size="lmedium" />
+  ) : (
+    <ContactAvatar color={accountColor} size="lmedium" value={accountSymbol} />
+  );
+}
+
+function LinkDescription({ walletAddress }: { walletAddress: string }) {
+  const address = formatAddressForDisplay(walletAddress, 4, 6);
+  const [before, after] = i18n.t(i18n.l.cash.add_wallet.description, { address }).split(address);
+
+  return (
+    <Text color="labelQuaternary" size="17pt" weight="bold">
+      {before}
+      <Text color="labelTertiary" size="17pt" weight="bold">
+        {address}
+      </Text>
+      {after}
+    </Text>
+  );
+}
+
+function UnsupportedWallet({ description, onDismiss }: { description: string; onDismiss: () => void }) {
+  return (
+    <Box paddingBottom="32px" paddingHorizontal="24px" paddingTop="28px">
+      <Stack space="24px">
+        <Stack space="12px">
+          <Text align="center" color="label" size="22pt" weight="heavy">
+            {i18n.t(i18n.l.cash.add_wallet.unsupported_title)}
+          </Text>
+          <Text align="center" color="labelTertiary" size="17pt" weight="semibold">
+            {description}
+          </Text>
+        </Stack>
+        <CashActionButton
+          label={i18n.t(i18n.l.cash.add_wallet.cancel)}
+          onPress={onDismiss}
+          testID="cash-deposit-add-wallet-unsupported-dismiss"
+        />
+      </Stack>
+    </Box>
+  );
+}
+
+export const AddWalletSheet = memo(function AddWalletSheet() {
+  const { params } = useRoute<RouteProp<RootStackParamList, typeof Routes.CASH_ADD_WALLET_SHEET>>();
+  const { walletAddress, cardId, depositAmount } = params;
+  const { goBack } = useNavigation();
+  const isReadOnlyWallet = useIsReadOnlyWallet();
+  const isHardwareWallet = useIsHardwareWallet();
+
+  const handleLinked = useCallback(() => {
+    goBack();
+    cashBuyOrderActions.submitBuyOrder({ cardId, depositAmount, walletAddress });
+  }, [cardId, depositAmount, goBack, walletAddress]);
+
+  const { state, confirm } = useWalletLinkFlow({ onLinked: handleLinked, walletAddress });
+  const isUnsupportedWallet = isReadOnlyWallet || isHardwareWallet;
+
+  useFocusEffect(
+    useCallback(() => {
+      // Only a wallet that can actually sign was prompted; counting the rest would read as drop-off.
+      if (isUnsupportedWallet) return;
+      analytics.track(analytics.event.cashWalletLinkPrompted);
+    }, [isUnsupportedWallet])
+  );
+
+  if (isUnsupportedWallet) {
+    return (
+      <PanelSheet>
+        <UnsupportedWallet
+          description={i18n.t(isReadOnlyWallet ? i18n.l.cash.add_wallet.watching_description : i18n.l.cash.add_wallet.hardware_description)}
+          onDismiss={goBack}
+        />
+      </PanelSheet>
+    );
+  }
+
+  const isError = state === 'error';
+
+  return (
+    <PanelSheet>
+      <Box paddingBottom="20px" paddingHorizontal="20px" paddingTop="52px">
+        <Stack space="32px">
+          <Box paddingHorizontal="12px">
+            <Stack space="16px">
+              <WalletAvatar />
+              <Stack space="16px">
+                <Text color="label" size="26pt" weight="heavy">
+                  {i18n.t(isError ? i18n.l.cash.add_wallet.error_title : i18n.l.cash.add_wallet.title)}
+                </Text>
+                <LinkDescription walletAddress={walletAddress} />
+                {isError && (
+                  <Text color="red" size="17pt" weight="bold">
+                    {i18n.t(i18n.l.cash.add_wallet.error_description)}
+                  </Text>
+                )}
+              </Stack>
+            </Stack>
+          </Box>
+          <CashActionButton
+            label={i18n.t(isError ? i18n.l.cash.add_wallet.retry : i18n.l.cash.add_wallet.confirm)}
+            loading={state === 'linking' || state === 'linked'}
+            onPress={confirm}
+            testID="cash-deposit-add-wallet-confirm"
+          />
+        </Stack>
+      </Box>
+    </PanelSheet>
+  );
+});

--- a/src/features/cash/screens/add-wallet-sheet/useWalletLinkFlow.ts
+++ b/src/features/cash/screens/add-wallet-sheet/useWalletLinkFlow.ts
@@ -1,0 +1,64 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import { type Address } from 'viem';
+
+import { analytics } from '@/analytics';
+import { logger, RainbowError } from '@/logger';
+
+import { isPasskeyCancellation } from '../../services/cashPasskeyService';
+import { linkWalletWithSignature, WalletSignatureError } from '../../services/walletLinkService';
+
+export type WalletLinkState = 'idle' | 'linking' | 'linked' | 'error';
+
+export type UseWalletLinkFlow = {
+  state: WalletLinkState;
+  confirm: () => void;
+};
+
+export function useWalletLinkFlow({ onLinked, walletAddress }: { onLinked: () => void; walletAddress: Address }): UseWalletLinkFlow {
+  const [state, setState] = useState<WalletLinkState>('idle');
+  const abortRef = useRef<AbortController | null>(null);
+
+  const confirm = useCallback(async () => {
+    // `linked` outlives the flow: the sheet is dismissing, and a tap landing in that window would
+    // re-sign and re-POST an already-linked wallet.
+    if (abortRef.current || state === 'linked') return;
+
+    const controller = new AbortController();
+    abortRef.current = controller;
+    setState('linking');
+
+    try {
+      await linkWalletWithSignature(walletAddress, controller);
+      if (controller.signal.aborted) return;
+      setState('linked');
+      analytics.track(analytics.event.cashWalletLinked);
+      onLinked();
+    } catch (e) {
+      if (controller.signal.aborted) return;
+      // A cancelled passkey and the signature stage both already spoke to the user; anything past
+      // them is ours to surface.
+      if (e instanceof WalletSignatureError || isPasskeyCancellation(e)) {
+        setState('idle');
+        return;
+      }
+      logger.error(new RainbowError('[useWalletLinkFlow]: Failed to link wallet', e));
+      analytics.track(analytics.event.cashWalletLinkFailed, { reason: e instanceof Error ? e.message : String(e) });
+      // Recovered by confirming again rather than a dedicated retry: the timestamp is inside the
+      // signed message, so replaying the old signature would land outside the server's skew window.
+      setState('error');
+    } finally {
+      if (abortRef.current === controller) {
+        abortRef.current = null;
+      }
+    }
+  }, [onLinked, state, walletAddress]);
+
+  useEffect(() => {
+    return () => {
+      abortRef.current?.abort();
+    };
+  }, []);
+
+  return { state, confirm };
+}

--- a/src/features/cash/screens/cash-deposit-setup/components/SetupStepLayout.tsx
+++ b/src/features/cash/screens/cash-deposit-setup/components/SetupStepLayout.tsx
@@ -6,10 +6,10 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import ButtonPressAnimation from '@/components/animations/ButtonPressAnimation';
 import { Box, Text, useBackgroundColor } from '@/design-system';
+import { CashActionButton } from '@/features/cash/components/CashActionButton';
 import * as i18n from '@/languages';
 
 import { useCashDepositSetupNavigation } from '../useCashDepositSetupNavigation';
-import { SetupActionButton } from './SetupActionButton';
 
 type SetupStepLayoutProps = {
   title: string;
@@ -80,7 +80,7 @@ export const SetupStepLayout = memo(function SetupStepLayout({
 
         <Box style={styles.body}>{children}</Box>
 
-        <SetupActionButton
+        <CashActionButton
           disabled={actionDisabled}
           label={actionLabel ?? i18n.t(i18n.l.cash.deposit_setup.next)}
           loading={actionLoading}

--- a/src/features/cash/screens/cash-deposit-setup/components/SetupSuccessStepLayout.tsx
+++ b/src/features/cash/screens/cash-deposit-setup/components/SetupSuccessStepLayout.tsx
@@ -5,9 +5,9 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { DEFAULT_HANDLE_COLOR_DARK, DEFAULT_HANDLE_COLOR_LIGHT } from '@/components/PanelSheet/PanelSheet';
 import { Box, Text, useColorMode } from '@/design-system';
+import { CashActionButton } from '@/features/cash/components/CashActionButton';
 
 import { useCashDepositSetupNavigation } from '../useCashDepositSetupNavigation';
-import { SetupActionButton } from './SetupActionButton';
 import { SetupCancelButton } from './SetupCancelButton';
 
 type SetupSuccessStepAccessory =
@@ -83,7 +83,7 @@ export const SetupSuccessStepLayout = memo(function SetupSuccessStepLayout({
       </Box>
 
       <Box bottom={{ custom: actionBottom }} left={{ custom: 20 }} position="absolute" right={{ custom: 20 }}>
-        <SetupActionButton label={actionLabel} onPress={onAction ?? next} shadow testID="cash-setup-success-action" />
+        <CashActionButton label={actionLabel} onPress={onAction ?? next} shadow testID="cash-setup-success-action" />
       </Box>
     </Box>
   );

--- a/src/features/cash/services/cashSignInService.ts
+++ b/src/features/cash/services/cashSignInService.ts
@@ -6,7 +6,7 @@ import { useCashAuthTokenStore } from '../stores/cashAuthTokenStore';
 import { getPasskeyAssertion, isPasskeyCancellation } from './cashPasskeyService';
 import { finalizeAuth, finishLogin, startLogin } from './userClient';
 
-export type CashSignInTrigger = 'cardLink';
+export type CashSignInTrigger = 'cardLink' | 'addCash';
 
 const TOKEN_EXPIRY_MARGIN = time.seconds(30);
 

--- a/src/features/cash/services/rampClient.ts
+++ b/src/features/cash/services/rampClient.ts
@@ -37,6 +37,11 @@ export enum CardBrand {
   Mastercard = 'CARD_BRAND_MASTERCARD',
 }
 
+export enum WalletSignatureMethod {
+  Unspecified = 'WALLET_SIGNATURE_METHOD_UNSPECIFIED',
+  EthPersonalSign = 'WALLET_SIGNATURE_METHOD_ETH_PERSONAL_SIGN',
+}
+
 export function isTerminalOrderStatus(status: OrderStatus): boolean {
   return status === OrderStatus.Completed || status === OrderStatus.Failed;
 }
@@ -112,6 +117,10 @@ function isUnauthorized(error: unknown): boolean {
   return error instanceof RainbowFetchError && error.response?.status === 401;
 }
 
+export function isNotFoundError(error: unknown): boolean {
+  return error instanceof RainbowFetchError && error.response?.status === 404;
+}
+
 // The user JWT replaces the shared app key on these calls. On 401 the cached
 // token is assumed stale: drop it, run one fresh sign-in ceremony, retry once.
 // Tokens are acquired outside the try so a 401 from the ceremony's own RPCs
@@ -150,4 +159,38 @@ export async function completeCardLinkSession(
   const { id, lastFourDigits } = data.card;
   // TODO: Replace it with actual CC brands once APP-3934 is resolved
   return { id, brand: CARD_BRAND_LABELS[CardBrand.Visa], last4: lastFourDigits };
+}
+
+// ---- Wallet link -----------------------------------------------------------
+
+export type RampWallet = { id: string; address: string };
+
+export type WalletSignature = {
+  /** EIP-191 signature of the link message, 0x-prefixed. */
+  hexSignature: string;
+  method: WalletSignatureMethod;
+  /** Unix seconds as a string (the wire type is int64). Must equal the timestamp inside the signed message. */
+  timestamp: string;
+};
+
+type ListWalletsResponse = { wallets?: RampWallet[] };
+
+type LinkWalletResponse = { wallet: RampWallet };
+
+export async function listWallets(abortController?: AbortController | null): Promise<RampWallet[]> {
+  const { data } = await authorizedRequest('addCash', headers =>
+    getCashPlatformClient().get<ListWalletsResponse>('/ramp/wallets', { abortController, headers })
+  );
+  // protojson drops empty repeated fields, so an account with no wallets responds `{}`.
+  return data.wallets ?? [];
+}
+
+export async function linkWallet(
+  { address, signature }: { address: string; signature: WalletSignature },
+  abortController?: AbortController | null
+): Promise<RampWallet> {
+  const { data } = await authorizedRequest('addCash', headers =>
+    getCashPlatformClient().post<LinkWalletResponse>('/ramp/wallets/link', { address, signature }, { abortController, headers })
+  );
+  return data.wallet;
 }

--- a/src/features/cash/services/walletLinkService.test.ts
+++ b/src/features/cash/services/walletLinkService.test.ts
@@ -1,0 +1,197 @@
+import { type Address } from 'viem';
+
+import { loadWallet, signPersonalMessage } from '@/model/wallet';
+
+import { useCashAccountStore } from '../stores/cashAccountStore';
+import { useCashWalletStore } from '../stores/cashWalletStore';
+import { ensureAccessToken } from './cashSignInService';
+import { linkWallet, listWallets } from './rampClient';
+import { checkWalletLink, linkWalletWithSignature, WalletSignatureError } from './walletLinkService';
+
+jest.mock('react-native-dotenv', () => ({ IS_TESTING: 'false' }));
+
+jest.mock('./rampClient', () => ({
+  listWallets: jest.fn(),
+  linkWallet: jest.fn(),
+  WalletSignatureMethod: { EthPersonalSign: 'WALLET_SIGNATURE_METHOD_ETH_PERSONAL_SIGN' },
+}));
+
+jest.mock('./cashSignInService', () => ({
+  ensureAccessToken: jest.fn(),
+}));
+
+jest.mock('@/model/wallet', () => ({
+  loadWallet: jest.fn(),
+  signPersonalMessage: jest.fn(),
+}));
+
+jest.mock('@/handlers/web3', () => ({
+  getProvider: jest.fn(() => ({})),
+}));
+
+const mockListWallets = listWallets as jest.Mock;
+const mockLinkWallet = linkWallet as jest.Mock;
+const mockEnsureAccessToken = ensureAccessToken as jest.Mock;
+const mockLoadWallet = loadWallet as jest.Mock;
+const mockSignPersonalMessage = signPersonalMessage as jest.Mock;
+
+const USER_ID = 'a7f1c2d3-0000-4000-8000-000000000001';
+const ADDRESS = '0xAbC0000000000000000000000000000000000001' as Address;
+const LOWERCASE_ADDRESS = '0xabc0000000000000000000000000000000000001';
+const OTHER_ADDRESS = '0x0000000000000000000000000000000000000002';
+const SIGNATURE = '0xf00d';
+const NOW_MS = 1785312000000;
+const TIMESTAMP = 1785312000;
+const UNLOCK_DELAY_MS = 90_000;
+
+let nowMs = NOW_MS;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  nowMs = NOW_MS;
+  jest.spyOn(Date, 'now').mockImplementation(() => nowMs);
+  useCashAccountStore.setState({ userId: USER_ID });
+  useCashWalletStore.setState({ linkedWallets: [] });
+  mockEnsureAccessToken.mockResolvedValue('jwt');
+  mockListWallets.mockResolvedValue([]);
+  mockLinkWallet.mockResolvedValue({ id: 'wallet-1', address: ADDRESS });
+  mockLoadWallet.mockResolvedValue({});
+  mockSignPersonalMessage.mockResolvedValue({ result: SIGNATURE });
+});
+
+describe('checkWalletLink', () => {
+  it('acquires a token before asking the backend', async () => {
+    const order: string[] = [];
+    mockEnsureAccessToken.mockImplementation(async () => {
+      order.push('token');
+      return 'jwt';
+    });
+    mockListWallets.mockImplementation(async () => {
+      order.push('list');
+      return [];
+    });
+
+    await expect(checkWalletLink(ADDRESS)).resolves.toBe('needsLink');
+
+    expect(order).toEqual(['token', 'list']);
+  });
+
+  it('does not ask the backend when sign-in fails', async () => {
+    mockEnsureAccessToken.mockRejectedValue(new Error('cancelled'));
+
+    await expect(checkWalletLink(ADDRESS)).rejects.toThrow('cancelled');
+
+    expect(mockListWallets).not.toHaveBeenCalled();
+  });
+
+  it('answers from the cache without a request, whatever the casing', async () => {
+    useCashWalletStore.setState({ linkedWallets: [{ id: 'wallet-1', address: LOWERCASE_ADDRESS }] });
+
+    await expect(checkWalletLink(ADDRESS)).resolves.toBe('linked');
+
+    expect(mockListWallets).not.toHaveBeenCalled();
+  });
+
+  it('replaces the cache with the fetched list, lowercased', async () => {
+    useCashWalletStore.setState({ linkedWallets: [{ id: 'stale', address: OTHER_ADDRESS }] });
+    mockListWallets.mockResolvedValue([{ id: 'wallet-1', address: ADDRESS }]);
+    const abortController = new AbortController();
+
+    await expect(checkWalletLink(ADDRESS, abortController)).resolves.toBe('linked');
+
+    expect(mockListWallets).toHaveBeenCalledWith(abortController);
+    expect(useCashWalletStore.getState().linkedWallets).toEqual([{ id: 'wallet-1', address: LOWERCASE_ADDRESS }]);
+  });
+
+  it('reports a fetched list that omits the address as needing a link', async () => {
+    mockListWallets.mockResolvedValue([{ id: 'other', address: OTHER_ADDRESS }]);
+
+    await expect(checkWalletLink(ADDRESS)).resolves.toBe('needsLink');
+  });
+});
+
+describe('linkWalletWithSignature', () => {
+  it('signs the lowercase link message and posts the timestamp it signed, not a fresher one', async () => {
+    // Signing takes real time, so a body timestamp read from the clock a second time would diverge.
+    mockSignPersonalMessage.mockImplementation(async () => {
+      nowMs += UNLOCK_DELAY_MS;
+      return { result: SIGNATURE };
+    });
+
+    await linkWalletWithSignature(ADDRESS);
+
+    expect(mockSignPersonalMessage).toHaveBeenCalledWith(
+      `rainbow/${USER_ID}/link-wallet/${LOWERCASE_ADDRESS}/${TIMESTAMP}`,
+      expect.anything(),
+      expect.anything()
+    );
+    expect(mockLinkWallet).toHaveBeenCalledWith(
+      {
+        address: LOWERCASE_ADDRESS,
+        signature: { hexSignature: SIGNATURE, method: 'WALLET_SIGNATURE_METHOD_ETH_PERSONAL_SIGN', timestamp: String(TIMESTAMP) },
+      },
+      undefined
+    );
+    expect(useCashWalletStore.getState().linkedWallets).toEqual([{ id: 'wallet-1', address: LOWERCASE_ADDRESS }]);
+  });
+
+  it('mints the timestamp after the wallet unlock, so a slow prompt does not age the signature', async () => {
+    mockLoadWallet.mockImplementation(async () => {
+      nowMs += UNLOCK_DELAY_MS;
+      return {};
+    });
+    const unlockedTimestamp = TIMESTAMP + UNLOCK_DELAY_MS / 1000;
+
+    await linkWalletWithSignature(ADDRESS);
+
+    expect(mockSignPersonalMessage).toHaveBeenCalledWith(
+      `rainbow/${USER_ID}/link-wallet/${LOWERCASE_ADDRESS}/${unlockedTimestamp}`,
+      expect.anything(),
+      expect.anything()
+    );
+    expect(mockLinkWallet).toHaveBeenCalledWith(
+      expect.objectContaining({ signature: expect.objectContaining({ timestamp: String(unlockedTimestamp) }) }),
+      undefined
+    );
+  });
+
+  it('loads the signer for the checksummed address it was given', async () => {
+    await linkWalletWithSignature(ADDRESS);
+
+    expect(mockLoadWallet).toHaveBeenCalledWith(expect.objectContaining({ address: ADDRESS }));
+  });
+
+  it('rejects without signing when no account is recorded', async () => {
+    useCashAccountStore.setState({ userId: null });
+
+    await expect(linkWalletWithSignature(ADDRESS)).rejects.toThrow('No cash account recorded on this device');
+
+    expect(mockSignPersonalMessage).not.toHaveBeenCalled();
+    expect(mockLinkWallet).not.toHaveBeenCalled();
+  });
+
+  it('does not post when the wallet cannot be loaded', async () => {
+    mockLoadWallet.mockResolvedValue(null);
+
+    await expect(linkWalletWithSignature(ADDRESS)).rejects.toThrow(WalletSignatureError);
+
+    expect(mockLinkWallet).not.toHaveBeenCalled();
+  });
+
+  it('does not post when signing fails', async () => {
+    mockSignPersonalMessage.mockResolvedValue({ error: new Error('user rejected') });
+
+    await expect(linkWalletWithSignature(ADDRESS)).rejects.toThrow(WalletSignatureError);
+
+    expect(mockLinkWallet).not.toHaveBeenCalled();
+    expect(useCashWalletStore.getState().linkedWallets).toEqual([]);
+  });
+
+  it('does not record the wallet when the request fails', async () => {
+    mockLinkWallet.mockRejectedValue(new Error('signature invalid'));
+
+    await expect(linkWalletWithSignature(ADDRESS)).rejects.toThrow('signature invalid');
+
+    expect(useCashWalletStore.getState().linkedWallets).toEqual([]);
+  });
+});

--- a/src/features/cash/services/walletLinkService.ts
+++ b/src/features/cash/services/walletLinkService.ts
@@ -1,0 +1,70 @@
+import { IS_TESTING } from 'react-native-dotenv';
+import { type Address } from 'viem';
+
+import { ChainId } from '@/features/network/types/backendNetworks';
+import { getProvider } from '@/handlers/web3';
+import { loadWallet, signPersonalMessage } from '@/model/wallet';
+
+import { useCashAccountStore } from '../stores/cashAccountStore';
+import { hasLinkedWalletInCache, useCashWalletStore, type LinkedWallet } from '../stores/cashWalletStore';
+import { ensureAccessToken } from './cashSignInService';
+import { linkWallet, listWallets, WalletSignatureMethod, type RampWallet } from './rampClient';
+
+export type WalletLinkStatus = 'linked' | 'needsLink';
+
+/**
+ * Failure to produce the signature. `loadWallet` and `signPersonalMessage` have both already told
+ * the user (a cancel is silent by design, a real failure gets an alert or the wallet error sheet),
+ * so callers must stay quiet on this one.
+ */
+export class WalletSignatureError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'WalletSignatureError';
+  }
+}
+
+function normalize({ id, address }: RampWallet): LinkedWallet {
+  return { id, address: address.toLowerCase() };
+}
+
+/** The exact string the backend rebuilds to recover the signer; see the `/ramp/wallets/link` spec. */
+function buildLinkMessage({ userId, address, timestamp }: { userId: string; address: string; timestamp: number }): string {
+  return `rainbow/${userId}/link-wallet/${address}/${timestamp}`;
+}
+
+export async function checkWalletLink(address: Address, abortController?: AbortController | null): Promise<WalletLinkStatus> {
+  if (IS_TESTING === 'true') return 'linked';
+
+  // Ahead of the cache lookup: the same token authorizes the buy order that follows either way.
+  await ensureAccessToken('addCash');
+  if (hasLinkedWalletInCache(address)) return 'linked';
+
+  const wallets = await listWallets(abortController);
+  useCashWalletStore.getState().setLinkedWallets(wallets.map(normalize));
+  return hasLinkedWalletInCache(address) ? 'linked' : 'needsLink';
+}
+
+export async function linkWalletWithSignature(address: Address, abortController?: AbortController | null): Promise<void> {
+  const { userId } = useCashAccountStore.getState();
+  if (!userId) throw new Error('No cash account recorded on this device');
+
+  const signedAddress = address.toLowerCase();
+
+  const provider = getProvider({ chainId: ChainId.base });
+  const signer = await loadWallet({ address, provider });
+  if (!signer) throw new WalletSignatureError('Failed to load wallet');
+
+  const timestamp = Math.floor(Date.now() / 1000);
+  const signed = await signPersonalMessage(buildLinkMessage({ userId, address: signedAddress, timestamp }), provider, signer);
+  if (!signed?.result) throw new WalletSignatureError(`Failed to sign the link message: ${signed?.error?.message ?? 'Unknown error'}`);
+
+  const wallet = await linkWallet(
+    {
+      address: signedAddress,
+      signature: { hexSignature: signed.result, method: WalletSignatureMethod.EthPersonalSign, timestamp: String(timestamp) },
+    },
+    abortController
+  );
+  useCashWalletStore.getState().addLinkedWallet(normalize(wallet));
+}

--- a/src/features/cash/stores/cashAccountStore.ts
+++ b/src/features/cash/stores/cashAccountStore.ts
@@ -1,6 +1,7 @@
 import { createBaseStore } from '@storesjs/stores';
 
 import { useCashAuthTokenStore } from './cashAuthTokenStore';
+import { useCashWalletStore } from './cashWalletStore';
 
 type CashAccountStore = {
   /** UserService account UUID, captured at passkey enrollment. Presence = an account with a passkey exists. */
@@ -9,16 +10,22 @@ type CashAccountStore = {
   clearUserId: () => void;
 };
 
-// A cached access token belongs to whichever account minted it — drop it whenever the record changes.
+// A cached access token and the linked wallets belong to whichever account they came from — drop
+// both whenever the record changes.
+function clearAccountScopedState(): void {
+  useCashAuthTokenStore.getState().clearToken();
+  useCashWalletStore.getState().clear();
+}
+
 export const useCashAccountStore = createBaseStore<CashAccountStore>(
   set => ({
     userId: null,
     setUserId: userId => {
-      useCashAuthTokenStore.getState().clearToken();
+      clearAccountScopedState();
       set({ userId });
     },
     clearUserId: () => {
-      useCashAuthTokenStore.getState().clearToken();
+      clearAccountScopedState();
       set({ userId: null });
     },
   }),

--- a/src/features/cash/stores/cashBuyOrderStore.test.ts
+++ b/src/features/cash/stores/cashBuyOrderStore.test.ts
@@ -1,3 +1,4 @@
+import { RainbowFetchError } from '@/framework/data/http/rainbowFetch';
 import { logger } from '@/logger';
 import { pendingTransactionsActions } from '@/state/pendingTransactions';
 
@@ -11,6 +12,7 @@ import {
   type CashBuyErrorCode,
   type CashBuyPhase,
 } from './cashBuyOrderStore';
+import { useCashWalletStore } from './cashWalletStore';
 
 jest.mock('@/logger', () => ({
   logger: { debug: jest.fn(), error: jest.fn(), warn: jest.fn() },
@@ -64,6 +66,11 @@ const FAILED_PAYMENT_ORDER: BuyOrder = { ...ORDER_COMMON, status: OrderStatus.Fa
 const FAILED_GENERIC_ORDER: BuyOrder = { ...ORDER_COMMON, status: OrderStatus.Failed, failureReason: OrderFailureReason.Unspecified };
 
 const SUBMIT_INPUT = { cardId: 'card-1', depositAmount: '50', walletAddress: '0xabc' };
+const LINKED_WALLET = { id: 'wallet-1', address: '0xabc' };
+
+function fetchError(status: number): RainbowFetchError {
+  return new RainbowFetchError({ message: 'not found', response: { status } as Response });
+}
 
 const store = useCashBuyOrderStore;
 const getState = () => store.getState();
@@ -72,6 +79,7 @@ const phase = () => selectCashBuyPhase(getState());
 beforeEach(() => {
   jest.clearAllMocks();
   store.setState({ spec: null, order: null, errorCode: null });
+  useCashWalletStore.getState().clear();
   createBuyOrderSpec.mockImplementation(({ cardId, depositAmount, walletAddress }) => ({
     cardId,
     depositAmount,
@@ -160,6 +168,33 @@ describe('submitBuyOrder', () => {
     expect(logger.error).toHaveBeenCalled();
     expect(getState()).toMatchObject({ errorCode: 'GENERIC', order: null, spec: null });
     expect(phase()).toBe('error');
+  });
+
+  // A 404 is the only handle the ramp surface gives on "the wallet you named is not linked", so it
+  // is the one failure that invalidates the cache. Every other failure leaves it alone.
+  const cacheOutcomes: { label: string; failure: unknown; cleared: boolean }[] = [
+    { label: 'a 404', failure: fetchError(404), cleared: true },
+    { label: 'a 500', failure: fetchError(500), cleared: false },
+    { label: 'a transport error with no response', failure: new Error('network down'), cleared: false },
+  ];
+
+  it.each(cacheOutcomes)('$label leaves the linked-wallet cache cleared=$cleared', async ({ failure, cleared }) => {
+    useCashWalletStore.setState({ linkedWallets: [LINKED_WALLET] });
+    createBuyOrder.mockRejectedValue(failure);
+
+    await getState().submitBuyOrder(SUBMIT_INPUT);
+
+    expect(useCashWalletStore.getState().linkedWallets).toEqual(cleared ? [] : [LINKED_WALLET]);
+    expect(phase()).toBe('error');
+  });
+
+  it('keeps the linked-wallet cache when the order is created', async () => {
+    useCashWalletStore.setState({ linkedWallets: [LINKED_WALLET] });
+    createBuyOrder.mockResolvedValue(PENDING_ORDER);
+
+    await getState().submitBuyOrder(SUBMIT_INPUT);
+
+    expect(useCashWalletStore.getState().linkedWallets).toEqual([LINKED_WALLET]);
   });
 
   it('ignores a second submission while one is already in flight', async () => {

--- a/src/features/cash/stores/cashBuyOrderStore.ts
+++ b/src/features/cash/stores/cashBuyOrderStore.ts
@@ -5,8 +5,16 @@ import { logger, RainbowError } from '@/logger';
 import { pendingTransactionsActions } from '@/state/pendingTransactions';
 
 import { cashOrderService } from '../services/cashOrderService';
-import { isTerminalOrderStatus, OrderFailureReason, OrderStatus, type BuyOrder, type BuyOrderSpec } from '../services/rampClient';
+import {
+  isNotFoundError,
+  isTerminalOrderStatus,
+  OrderFailureReason,
+  OrderStatus,
+  type BuyOrder,
+  type BuyOrderSpec,
+} from '../services/rampClient';
 import { buildCashPurchaseTransaction } from '../utils/buildCashPurchaseTransaction';
+import { useCashWalletStore } from './cashWalletStore';
 
 export type CashBuyPhase = 'idle' | 'pending' | 'error' | 'success';
 export type CashBuyErrorCode = 'PAYMENT_REJECTED' | 'GENERIC';
@@ -88,6 +96,11 @@ export const useCashBuyOrderStore = createBaseStore<CashBuyOrderState>(
         logger.error(new RainbowError('[cashBuyOrderStore] createBuyOrder failed'), { error });
         analytics.track(analytics.event.cashBuyOrderFailed, { orderId: orderSpec.id, failureReason: null, errorCode: 'GENERIC' });
         set({ errorCode: 'GENERIC', order: null, spec: null });
+        // A 404 says the backend did not recognise something this order named, and the linked wallet
+        // is the part of that we cache — persisted, so a stale entry would fail every retry. Dropping
+        // it costs the next attempt one GET and lets that attempt gate on the truth; absence only
+        // ever means "ask the server".
+        if (isNotFoundError(error)) useCashWalletStore.getState().clear();
       }
     }
 

--- a/src/features/cash/stores/cashWalletStore.ts
+++ b/src/features/cash/stores/cashWalletStore.ts
@@ -1,0 +1,29 @@
+import { createBaseStore } from '@storesjs/stores';
+
+export type LinkedWallet = {
+  id: string;
+  address: string;
+};
+
+type CashWalletStore = {
+  linkedWallets: LinkedWallet[];
+  setLinkedWallets: (linkedWallets: LinkedWallet[]) => void;
+  addLinkedWallet: (linkedWallet: LinkedWallet) => void;
+  clear: () => void;
+};
+
+// A positive cache: an address missing here means "ask the server", never "not linked".
+export const useCashWalletStore = createBaseStore<CashWalletStore>(
+  set => ({
+    linkedWallets: [],
+    setLinkedWallets: linkedWallets => set({ linkedWallets }),
+    addLinkedWallet: linkedWallet => set(state => ({ linkedWallets: [...state.linkedWallets, linkedWallet] })),
+    clear: () => set({ linkedWallets: [] }),
+  }),
+  { storageKey: 'cashWallet' }
+);
+
+export function hasLinkedWalletInCache(address: string): boolean {
+  const normalized = address.toLowerCase();
+  return useCashWalletStore.getState().linkedWallets.some(wallet => wallet.address === normalized);
+}

--- a/src/languages/en_US.json
+++ b/src/languages/en_US.json
@@ -1578,7 +1578,21 @@
         "adding_cash": "Adding Cash",
         "buy_error_title": "Purchase Failed",
         "buy_error_generic": "Something went wrong. Try again",
-        "payment_rejected": "Your card declined this payment"
+        "payment_rejected": "Your card declined this payment",
+        "wallet_check_error_title": "Couldn’t Continue",
+        "wallet_check_error_generic": "We couldn’t check your wallet. Try again"
+      },
+      "add_wallet": {
+        "title": "Connect new wallet",
+        "description": "Connect %{address} to enable cash balance.",
+        "confirm": "Connect Wallet",
+        "cancel": "Cancel",
+        "error_title": "Couldn’t Add Wallet",
+        "error_description": "Something went wrong. Try again",
+        "retry": "Try Again",
+        "unsupported_title": "Can’t Add This Wallet",
+        "watching_description": "You’re watching this wallet, so it can’t sign. Import it to deposit into it.",
+        "hardware_description": "Hardware wallets can’t be added yet."
       },
       "deposit_setup": {
         "next": "Next",

--- a/src/navigation/Routes.android.tsx
+++ b/src/navigation/Routes.android.tsx
@@ -9,6 +9,7 @@ import WalletErrorSheet from '@/components/wallet-error/WalletErrorSheet';
 import AppIconUnlockSheet from '@/features/app-icon/screens/AppIconUnlockSheet';
 import BackupSheet from '@/features/backup/components/BackupSheet';
 import { AddCashSheet } from '@/features/cash/screens/add-cash-sheet/AddCashSheet';
+import { AddWalletSheet } from '@/features/cash/screens/add-wallet-sheet/AddWalletSheet';
 import { CashDepositIntroPanel } from '@/features/cash/screens/cash-deposit-intro-panel/CashDepositIntroPanel';
 import { CashDepositSetupScreen } from '@/features/cash/screens/cash-deposit-setup/CashDepositSetupScreen';
 import { PROFILES } from '@/features/config/constants/experimental';
@@ -288,6 +289,7 @@ function BSNavigator() {
       <BSStack.Screen component={CashDepositIntroPanel} name={Routes.CASH_DEPOSIT_INTRO_PANEL} />
       <BSStack.Screen component={CashDepositSetupScreen} name={Routes.CASH_DEPOSIT_SETUP_SCREEN} />
       <BSStack.Screen component={AddCashSheet} name={Routes.ADD_CASH_SHEET} />
+      <BSStack.Screen component={AddWalletSheet} name={Routes.CASH_ADD_WALLET_SHEET} />
       <BSStack.Screen component={PerpsTradeDetailsSheet} name={Routes.PERPS_TRADE_DETAILS_SHEET} />
       <BSStack.Screen component={PolymarketEventScreen} name={Routes.POLYMARKET_EVENT_SCREEN} />
       <BSStack.Screen component={PolymarketRedeemPositionSheet} name={Routes.POLYMARKET_MANAGE_POSITION_SHEET} />

--- a/src/navigation/Routes.ios.tsx
+++ b/src/navigation/Routes.ios.tsx
@@ -9,6 +9,7 @@ import WalletErrorSheet from '@/components/wallet-error/WalletErrorSheet';
 import AppIconUnlockSheet from '@/features/app-icon/screens/AppIconUnlockSheet';
 import BackupSheet from '@/features/backup/components/BackupSheet';
 import { AddCashSheet } from '@/features/cash/screens/add-cash-sheet/AddCashSheet';
+import { AddWalletSheet } from '@/features/cash/screens/add-wallet-sheet/AddWalletSheet';
 import { CashDepositIntroPanel } from '@/features/cash/screens/cash-deposit-intro-panel/CashDepositIntroPanel';
 import { CashDepositSetupScreen } from '@/features/cash/screens/cash-deposit-setup/CashDepositSetupScreen';
 import { PROFILES } from '@/features/config/constants/experimental';
@@ -313,6 +314,7 @@ function NativeStackNavigator() {
       <NativeStack.Screen component={CashDepositIntroPanel} name={Routes.CASH_DEPOSIT_INTRO_PANEL} {...panelConfig} />
       <NativeStack.Screen component={CashDepositSetupScreen} name={Routes.CASH_DEPOSIT_SETUP_SCREEN} {...perpsAccountStackConfig} />
       <NativeStack.Screen component={AddCashSheet} name={Routes.ADD_CASH_SHEET} {...panelConfig} />
+      <NativeStack.Screen component={AddWalletSheet} name={Routes.CASH_ADD_WALLET_SHEET} {...panelConfig} />
       <NativeStack.Screen
         component={PerpsTradeDetailsSheet}
         name={Routes.PERPS_TRADE_DETAILS_SHEET}

--- a/src/navigation/routesNames.ts
+++ b/src/navigation/routesNames.ts
@@ -74,6 +74,7 @@ const Routes = {
   CASH_SETUP_ALL_DONE: 'CashSetupAllDone',
   CASH_SETUP_CARD_DETAILS: 'CashSetupCardDetails',
   CASH_SETUP_CARD_ADDED: 'CashSetupCardAdded',
+  CASH_ADD_WALLET_SHEET: 'CashAddWalletSheet',
   RECEIVE_MODAL: 'ReceiveModal',
   REGISTER_ENS_NAVIGATOR: 'RegisterEnsNavigator',
   CHOOSE_BACKUP_SHEET: 'ChooseBackupSheet',

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -659,6 +659,12 @@ type RouteParams = {
         initialStep?: CashDepositSetupRoute;
       }
     | undefined;
+  [Routes.CASH_ADD_WALLET_SHEET]: {
+    walletAddress: Address;
+    cardId: string;
+    /** Fiat amount as a decimal string, e.g. "50". */
+    depositAmount: string;
+  };
   [Routes.PERPS_ACCOUNT_SCREEN]:
     | {
         scrollToTop?: boolean;


### PR DESCRIPTION
Fixes APP-3922

## What changed (plus any additional context for devs)

A deposit can only credit a wallet the Cash account has registered. Hold-to-add now resolves that first:

- address in the local cache → submit the order as before
- otherwise `GET /ramp/wallets`; if it isn't there → new `CASH_ADD_WALLET_SHEET`
- confirming signs `rainbow/{userId}/link-wallet/{address}/{unixSeconds}` (EIP-191), `POST`s `/ramp/wallets/link`, dismisses, and submits the order it was handed

## Screen recordings / screenshots

https://github.com/user-attachments/assets/3fce426d-7a32-4d4a-ab7a-1f71ebc5ee9a

https://github.com/user-attachments/assets/2c179885-00a2-4759-910a-1e987466f97d



## What to test

- **First wallet** — linked card, wallet that has never deposited: hold-to-add → confirmation screen → Add Wallet → biometric → deposit goes through. Hold again on the same wallet: no screen, no prompt.
- **Second wallet** — switch to another owned wallet; the screen appears again for that address.
