### PR TITLE
chore(e2e): remove dead env plumbing from the CI entry scripts

### DIFF
--- a/scripts/e2e-android-ci.sh
+++ b/scripts/e2e-android-ci.sh
@@ -2,13 +2,10 @@
 
 set -euo pipefail
 
-export PATH="$PATH":"$HOME/.maestro/bin"
 export MAESTRO_DISABLE_UPDATE_CHECK=true
 export MAESTRO_CLI_NO_ANALYTICS=true
 export MAESTRO_CLI_ANALYSIS_NOTIFICATION_DISABLED=true
 export MAESTRO_DRIVER_STARTUP_TIMEOUT=60000
-
-ARTIFACTS_FOLDER="${ARTIFACTS_FOLDER:-e2e-artifacts}"
 
 # Install the app
 echo "Install app"

--- a/scripts/e2e-ios-ci.sh
+++ b/scripts/e2e-ios-ci.sh
@@ -2,13 +2,10 @@
 
 set -euo pipefail
 
-export PATH="$PATH:$HOME/.maestro/bin"
 export MAESTRO_DISABLE_UPDATE_CHECK=true
 export MAESTRO_CLI_NO_ANALYTICS=true
 export MAESTRO_CLI_ANALYSIS_NOTIFICATION_DISABLED=true
 export MAESTRO_DRIVER_STARTUP_TIMEOUT=60000
-
-ARTIFACTS_FOLDER="${ARTIFACTS_FOLDER:-e2e-artifacts}"
 
 # Install the app on the simulator
 xcrun simctl install "$DEVICE_UDID" "$ARTIFACT_PATH_FOR_E2E"


### PR DESCRIPTION
Our Maestro E2E entry scripts carry two lines that no longer do anything. Both were load-bearing when the pipeline was written in #6478 (Apr 2025) and were stranded by later refactors:

* the `PATH` export pointing at the Maestro curl installer's bin directory, obsolete since we switched to `jdx/mise-action` in #7511 (May 2026). Nothing creates that directory on the runners now
* an `ARTIFACTS_FOLDER` default, left over from when these scripts handled artifacts themselves. It's assigned but never read, and never exported either, so the shared runner script that took that work over couldn't pick it up regardless

This change deletes both. The workflow-level `ARTIFACTS_FOLDER` that the upload steps read is a separate thing and stays.

Groundwork ahead of the Maestro 2.7.0 upgrade.