### PR TITLE
chore(e2e): upgrade Maestro 2.0.10 -> 2.7.0

### DIFF
--- a/e2e/flows/transactions/SwapTransaction.yaml
+++ b/e2e/flows/transactions/SwapTransaction.yaml
@@ -34,7 +34,13 @@ tags:
 # Select DAI as output token
 - tapOn: 'Find a token to buy'
 - inputText: 'DAI'
-- hideKeyboard
+# On Android the keyboard outlives this sheet and covers the swap settings panel
+# we open next. iOS dismisses it on its own, and Maestro can't dismiss it there.
+- runFlow:
+    when:
+      platform: Android
+    commands:
+      - hideKeyboard
 - tapOn:
     id: token-to-buy-dai-1
 - assertVisible: 'DAI.*'

--- a/e2e/flows/transactions/WrapTransaction.yaml
+++ b/e2e/flows/transactions/WrapTransaction.yaml
@@ -34,7 +34,13 @@ tags:
 # Select WETH as output token
 - tapOn: 'Find a token to buy'
 - inputText: 'Wrapped'
-- hideKeyboard
+# On Android the keyboard outlives this sheet and covers the swap settings panel
+# we open next. iOS dismisses it on its own, and Maestro can't dismiss it there.
+- runFlow:
+    when:
+      platform: Android
+    commands:
+      - hideKeyboard
 - tapOn:
     id: token-to-buy-wrapped-ether-1
 - assertVisible: 'WETH.*'

--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,5 @@
 [tools]
-maestro = "cli-2.0.10"
+maestro = "cli-2.7.0"
 
 [settings]
 # Node and Ruby stay pinned in .node-version/.ruby-version so actions/setup-node


### PR DESCRIPTION
Our Maestro pin is roughly 8 months behind. Much of what landed since our pin targets areas that would improve our suite: iOS view hierarchy retrieval on large element trees, the flaky Android port-forwarding thread, and false app-crash errors on launch.

The wins we should notice are:
* Android talking to the driver over a direct ADB socket instead of TCP port forwarding (upstream measured around 41% faster on a simple `assertVisible` flow)
* no more redundant device reads after read-only assertions, and 
* device logs plus crash and ANR reports landing in every flow's artifact bundle automatically
* automatic log capture on iOS (which we have none of today)

We currently capture logcat manually so after this change we're capturing it twice to two different files - a follow up PR will clean this up.

A few things worth mentioning: 

* The per-flow artifact bundle is restructured, so CI artifacts will look different next time we debug a failure. More importantly, the transport and settle changes shift timing throughout, and timing is how an e2e suite surfaces flakiness, so we'd need to keep an eye on the runs after merging this.
* `maestro studio` is gone from the CLI as of 2.6.0, replaced by a separate desktop app. Nothing in CI used it, but anyone who reaches for it locally will need the download.

Checked locally that all flows pass Maestros `check-syntax` under the new version and the workspace config still parses clean.