### PR TITLE
feat(e2e): surface per-test results and retry-passes in the run summary

### DIFF
--- a/.github/workflows/android-e2e.yml
+++ b/.github/workflows/android-e2e.yml
@@ -101,6 +101,7 @@ jobs:
       ANDROID_EMULATOR_CORES: 4
       ANDROID_EMULATOR_RAM_SIZE: 8192
       ARTIFACTS_FOLDER: e2e-artifacts
+      RESULTS_FOLDER: e2e-results
       ARCH: x86_64
       ANDROID_EMULATOR_WAIT_TIME_BEFORE_KILL: 60
     steps:
@@ -171,6 +172,41 @@ jobs:
         with:
           name: artifacts-${{ matrix.shard-index }}
           path: ${{ env.ARTIFACTS_FOLDER }}
+
+      - name: Upload results
+        if: ${{ always() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: e2e-results-${{ matrix.shard-index }}
+          path: ${{ env.RESULTS_FOLDER }}
+          if-no-files-found: warn
+
+  results:
+    name: E2E results
+    needs: e2e-tests
+    if: ${{ !cancelled() && needs.e2e-tests.result != 'skipped' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Setup Node
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+        with:
+          node-version-file: '.node-version'
+
+      - name: Download shard results
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          pattern: e2e-results-*
+          merge-multiple: true
+          path: e2e-results
+
+      - name: Render summary
+        run: node tools/e2e-summary/index.ts e2e-results
 
   perf-tests:
     name: Perf Tests

--- a/.github/workflows/ios-e2e.yml
+++ b/.github/workflows/ios-e2e.yml
@@ -66,6 +66,7 @@ jobs:
       SHARD_TOTAL: 4
       SHARD_INDEX: ${{ matrix.shard-index }}
       ARTIFACTS_FOLDER: e2e-artifacts
+      RESULTS_FOLDER: e2e-results
     steps:
       - name: Checkout repo
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -123,6 +124,41 @@ jobs:
         with:
           name: artifacts-${{ matrix.shard-index }}
           path: ${{ env.ARTIFACTS_FOLDER }}
+
+      - name: Upload results
+        if: ${{ always() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: e2e-results-${{ matrix.shard-index }}
+          path: ${{ env.RESULTS_FOLDER }}
+          if-no-files-found: warn
+
+  results:
+    name: E2E results
+    needs: e2e-tests
+    if: ${{ !cancelled() && needs.e2e-tests.result != 'skipped' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Setup Node
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+        with:
+          node-version-file: '.node-version'
+
+      - name: Download shard results
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          pattern: e2e-results-*
+          merge-multiple: true
+          path: e2e-results
+
+      - name: Render summary
+        run: node tools/e2e-summary/index.ts e2e-results
 
   notify-failure:
     name: Notify Slack on failure

--- a/.gitignore
+++ b/.gitignore
@@ -132,6 +132,7 @@ web-build/
 
 # E2E CI
 e2e-artifacts/
+e2e-results/
 anvil.log
 
 .rnef/

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,7 +2,7 @@ module.exports = {
   preset: 'react-native',
   setupFiles: ['./config/test/jest-setup.js'],
   testMatch: ['**/*.(spec|test).[tj]s?(x)'],
-  testPathIgnorePatterns: ['node_modules', 'e2e', '\\.disabled\\.[jt]sx?$'],
+  testPathIgnorePatterns: ['node_modules', '/e2e/', '\\.disabled\\.[jt]sx?$'],
   transformIgnorePatterns: [
     'node_modules/(?!((jest-)?react-native|imgix-core-js|react-native-payments|@react-native-firebase|@react-native(-community)?|react-native-reanimated|react-native-markdown-display|react-native-mmkv)/)',
   ],

--- a/scripts/e2e-run.sh
+++ b/scripts/e2e-run.sh
@@ -4,10 +4,12 @@ set -euo pipefail
 source .env
 
 ARTIFACTS_FOLDER=e2e-artifacts
+RESULTS_FOLDER=e2e-results
 FLOW="e2e/flows"
 ARGS=()
 SHARD_TOTAL=1
 SHARD_INDEX=0
+SHARD_LABEL=1
 TEST_FILES=()
 ANVIL_PID=""
 PLATFORM=""
@@ -98,6 +100,7 @@ while [[ $# -gt 0 ]]; do
     --shard-index)
       # Ensure SHARD_INDEX is zero-based.
       SHARD_INDEX=$(( $2 - 1 ))
+      SHARD_LABEL="$2"
       shift
       ;;
     --platform)
@@ -118,8 +121,47 @@ while [[ $# -gt 0 ]]; do
   shift
 done
 
+RESULTS_FILE="$RESULTS_FOLDER/shard-$SHARD_LABEL.jsonl"
+
+json_string() {
+  local s=${1//\\/\\\\}
+  printf '"%s"' "${s//\"/\\\"}"
+}
+
+json_string_or_null() {
+  if [ -z "${1:-}" ]; then printf 'null'; else json_string "$1"; fi
+}
+
+json_number_or_null() {
+  if [ -z "${1:-}" ]; then printf 'null'; else printf '%s' "$1"; fi
+}
+
+test_id() {
+  local id=${1#e2e/flows/}
+  printf '%s' "${id%.yaml}"
+}
+
+# Every test is recorded as "planned" before the run starts, then superseded by
+# an appended row when it finishes; the reader keeps the last row per test. So a
+# shard killed partway through leaves its unrun tests as "planned" rather than
+# leaving them out of the file altogether.
+record() {
+  printf '{"shard":%s,"platform":%s,"test":%s,"status":%s,"attempts":%s,"duration":%s,"failure_class":null,"artifact_dir":%s}\n' \
+    "$SHARD_LABEL" "$(json_string "$PLATFORM")" "$(json_string "$1")" "$(json_string "$2")" \
+    "$(json_number_or_null "${3:-}")" "$(json_number_or_null "${4:-}")" "$(json_string_or_null "${5:-}")" \
+    >> "$RESULTS_FILE"
+}
+
+record_planned() {
+  local file
+  for file in ${TEST_FILES[@]+"${TEST_FILES[@]}"}; do
+    record "$(test_id "$file")" planned
+  done
+}
+
 # Cleanup previous artifacts.
-rm -rf "$ARTIFACTS_FOLDER"
+rm -rf "$ARTIFACTS_FOLDER" "$RESULTS_FOLDER"
+mkdir -p "$RESULTS_FOLDER"
 
 # Handle test discovery and sharding.
 if [[ -f "$FLOW" ]]; then
@@ -135,13 +177,15 @@ else
 
   if [[ $SHARD_TOTAL -gt 1 ]]; then
     if [[ ${#TEST_FILES[@]} -eq 0 ]]; then
-      echo "⚠️ No tests selected for shard $SHARD_INDEX out of $SHARD_TOTAL"
+      echo "⚠️ No tests selected for shard $SHARD_LABEL out of $SHARD_TOTAL"
       exit 0
     fi
     echo "🧪 Running shard $((SHARD_INDEX + 1))/$SHARD_TOTAL:"
     printf ' - %s\n' "${TEST_FILES[@]}"
   fi
 fi
+
+record_planned
 
 # Start Anvil only if any test path includes "transaction".
 NEEDS_ANVIL=false
@@ -169,10 +213,13 @@ fi
 EXIT_CODE=0
 for TEST_FILE in "${TEST_FILES[@]}"; do
   TEST_NAME=$(basename "${TEST_FILE%.*}")
+  TEST_ID=$(test_id "$TEST_FILE")
   echo "🚀 Running test: $TEST_NAME"
 
   SUCCESS=false
   SHOULD_RECORD=false
+  RESULT_DIR=""
+  TEST_START_TIME=$(date +%s)
   for ATTEMPT in $(seq 1 "$MAX_ATTEMPTS"); do
     echo "🔁 Attempt $ATTEMPT for $TEST_NAME"
 
@@ -209,7 +256,8 @@ for TEST_FILE in "${TEST_FILES[@]}"; do
         stop_recording "$DEBUG_OUTPUT"
       fi
 
-      mv "$DEBUG_OUTPUT" "$ARTIFACTS_FOLDER/maestro/✅-$TEST_NAME-$ATTEMPT"
+      RESULT_DIR="✅-$TEST_NAME-$ATTEMPT"
+      mv "$DEBUG_OUTPUT" "$ARTIFACTS_FOLDER/maestro/$RESULT_DIR"
       break
     else
       END_TIME=$(date +%s)
@@ -222,7 +270,8 @@ for TEST_FILE in "${TEST_FILES[@]}"; do
         stop_recording "$DEBUG_OUTPUT"
       fi
 
-      mv "$DEBUG_OUTPUT" "$ARTIFACTS_FOLDER/maestro/❌-$TEST_NAME-$ATTEMPT"
+      RESULT_DIR="❌-$TEST_NAME-$ATTEMPT"
+      mv "$DEBUG_OUTPUT" "$ARTIFACTS_FOLDER/maestro/$RESULT_DIR"
 
       # Enable recording for subsequent attempts after failure
       if [ "$RECORD_ON_FAILURE" = "true" ]; then
@@ -232,11 +281,18 @@ for TEST_FILE in "${TEST_FILES[@]}"; do
   done
 
 
-  if ! $SUCCESS; then
+  TEST_DURATION=$(( $(date +%s) - TEST_START_TIME ))
+
+  if $SUCCESS; then
+    if [[ $ATTEMPT -eq 1 ]]; then STATUS=passed; else STATUS=retried; fi
+  else
+    STATUS=failed
     echo "❌ Failed after $MAX_ATTEMPTS attempt(s): $TEST_NAME"
     echo
     EXIT_CODE=1
   fi
+
+  record "$TEST_ID" "$STATUS" "$ATTEMPT" "$TEST_DURATION" "$RESULT_DIR"
 done
 
 

--- a/tools/e2e-summary/__snapshots__/index.test.ts.snap
+++ b/tools/e2e-summary/__snapshots__/index.test.ts.snap
@@ -1,17 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`rendering links the run artifacts when running inside Actions 1`] = `
-"**1 passed** · slowest shard 1m 14s · [artifacts](https://github.com/rainbow-me/rainbow/actions/runs/30336051803#artifacts)
-
-|  | Test | Shard | Attempts | Time |
-| :-- | :-- | --: | --: | --: |
-| ✅ | \`screens/Home\` | 1 | 1 | 1m 14s |
-
-"
-`;
-
 exports[`rendering names the tests a killed shard never got to 1`] = `
-"**1 did not run · 1 passed** · slowest shard 1m 14s
+"**1 did not run · 1 passed**
 
 |  | Test | Shard | Attempts | Time |
 | :-- | :-- | --: | --: | --: |
@@ -22,7 +12,7 @@ exports[`rendering names the tests a killed shard never got to 1`] = `
 `;
 
 exports[`rendering reports an all-green run 1`] = `
-"**2 passed** · slowest shard 3m 26s
+"**2 passed**
 
 |  | Test | Shard | Attempts | Time |
 | :-- | :-- | --: | --: | --: |
@@ -39,7 +29,7 @@ exports[`rendering says so plainly when no shard reported anything 1`] = `
 `;
 
 exports[`rendering skips a half-written row without losing the rest of the file 1`] = `
-"**1 passed** · slowest shard 1m 14s
+"**1 passed**
 
 |  | Test | Shard | Attempts | Time |
 | :-- | :-- | --: | --: | --: |
@@ -49,7 +39,7 @@ exports[`rendering skips a half-written row without losing the rest of the file 
 `;
 
 exports[`rendering sorts failures and retries above passes, merging every shard file 1`] = `
-"**1 failed · 1 retried · 1 passed** · slowest shard 4m 52s
+"**1 failed · 1 retried · 1 passed**
 
 |  | Test | Shard | Attempts | Time |
 | :-- | :-- | --: | --: | --: |

--- a/tools/e2e-summary/__snapshots__/index.test.ts.snap
+++ b/tools/e2e-summary/__snapshots__/index.test.ts.snap
@@ -1,0 +1,61 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`rendering links the run artifacts when running inside Actions 1`] = `
+"**1 passed** · slowest shard 1m 14s · [artifacts](https://github.com/rainbow-me/rainbow/actions/runs/30336051803#artifacts)
+
+|  | Test | Shard | Attempts | Time |
+| :-- | :-- | --: | --: | --: |
+| ✅ | \`screens/Home\` | 1 | 1 | 1m 14s |
+
+"
+`;
+
+exports[`rendering names the tests a killed shard never got to 1`] = `
+"**1 did not run · 1 passed** · slowest shard 1m 14s
+
+|  | Test | Shard | Attempts | Time |
+| :-- | :-- | --: | --: | --: |
+| 🚫 | \`settings/ManualBackup\` | 1 |  |  |
+| ✅ | \`screens/Home\` | 1 | 1 | 1m 14s |
+
+"
+`;
+
+exports[`rendering reports an all-green run 1`] = `
+"**2 passed** · slowest shard 3m 26s
+
+|  | Test | Shard | Attempts | Time |
+| :-- | :-- | --: | --: | --: |
+| ✅ | \`onboarding/CreateWallet\` | 1 | 1 | 2m 12s |
+| ✅ | \`screens/Home\` | 1 | 1 | 1m 14s |
+
+"
+`;
+
+exports[`rendering says so plainly when no shard reported anything 1`] = `
+"No e2e results were reported. Look into the shard jobs instead.
+
+"
+`;
+
+exports[`rendering skips a half-written row without losing the rest of the file 1`] = `
+"**1 passed** · slowest shard 1m 14s
+
+|  | Test | Shard | Attempts | Time |
+| :-- | :-- | --: | --: | --: |
+| ✅ | \`screens/Home\` | 1 | 1 | 1m 14s |
+
+"
+`;
+
+exports[`rendering sorts failures and retries above passes, merging every shard file 1`] = `
+"**1 failed · 1 retried · 1 passed** · slowest shard 4m 52s
+
+|  | Test | Shard | Attempts | Time |
+| :-- | :-- | --: | --: | --: |
+| ❌ | \`transactions/WrapTransaction\` | 2 | 3 | 4m 12s |
+| ⚠️ | \`cash/SetupResume\` | 1 | 2 | 2m 07s |
+| ✅ | \`screens/Home\` | 2 | 1 | 40s |
+
+"
+`;

--- a/tools/e2e-summary/index.test.ts
+++ b/tools/e2e-summary/index.test.ts
@@ -54,16 +54,6 @@ describe('rendering', () => {
     expect(result.stdout).toMatchSnapshot();
   });
 
-  it('links the run artifacts when running inside Actions', () => {
-    const dir = ledgers({ 'shard-1.jsonl': [row('screens/Home', 'passed', { attempts: 1, duration: 74 })] });
-    const stdout = run([dir], {
-      GITHUB_SERVER_URL: 'https://github.com',
-      GITHUB_REPOSITORY: 'rainbow-me/rainbow',
-      GITHUB_RUN_ID: '30336051803',
-    }).stdout;
-    expect(stdout).toMatchSnapshot();
-  });
-
   it('says so plainly when no shard reported anything', () => {
     expect(run([ledgers({})]).stdout).toMatchSnapshot();
   });
@@ -115,8 +105,8 @@ function ledgers(files: Record<string, string[]>): string {
   return dir;
 }
 
-// GitHub sets GITHUB_* in CI, which would change the rendered output and split
-// snapshots between local and CI runs, so every case declares what it wants.
+// GitHub sets GITHUB_STEP_SUMMARY in CI, which would divert output to a file and
+// empty every snapshot, so each case declares the environment it wants.
 function run(args: string[], extraEnv: Record<string, string> = {}) {
   const env: NodeJS.ProcessEnv = { ...process.env, ...extraEnv };
   for (const key of Object.keys(env)) {

--- a/tools/e2e-summary/index.test.ts
+++ b/tools/e2e-summary/index.test.ts
@@ -1,0 +1,126 @@
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+// Driven as a CLI rather than by importing the render functions: the contract is
+// "ledger files on disk in, markdown out", so reading and merging the per-shard
+// files is part of what needs pinning, as are the exit codes.
+const CLI = join(__dirname, 'index.ts');
+
+describe('rendering', () => {
+  it('reports an all-green run', () => {
+    const dir = ledgers({
+      'shard-1.jsonl': [
+        row('screens/Home', 'planned'),
+        row('onboarding/CreateWallet', 'planned'),
+        row('screens/Home', 'passed', { attempts: 1, duration: 74 }),
+        row('onboarding/CreateWallet', 'passed', { attempts: 1, duration: 132 }),
+      ],
+    });
+    expect(run([dir]).stdout).toMatchSnapshot();
+  });
+
+  it('sorts failures and retries above passes, merging every shard file', () => {
+    const dir = ledgers({
+      'shard-1.jsonl': [row('cash/SetupResume', 'planned'), row('cash/SetupResume', 'retried', { attempts: 2, duration: 127 })],
+      'shard-2.jsonl': [
+        row('screens/Home', 'planned', { shard: 2 }),
+        row('transactions/WrapTransaction', 'planned', { shard: 2 }),
+        row('screens/Home', 'passed', { shard: 2, attempts: 1, duration: 40 }),
+        row('transactions/WrapTransaction', 'failed', { shard: 2, attempts: 3, duration: 252 }),
+      ],
+    });
+    expect(run([dir]).stdout).toMatchSnapshot();
+  });
+
+  it('names the tests a killed shard never got to', () => {
+    const dir = ledgers({
+      'shard-1.jsonl': [
+        row('screens/Home', 'planned'),
+        row('settings/ManualBackup', 'planned'),
+        row('screens/Home', 'passed', { attempts: 1, duration: 74 }),
+      ],
+    });
+    expect(run([dir]).stdout).toMatchSnapshot();
+  });
+
+  it('skips a half-written row without losing the rest of the file', () => {
+    const dir = ledgers({
+      'shard-1.jsonl': [row('screens/Home', 'passed', { attempts: 1, duration: 74 }), '{"shard":1,"test":"cash/Set'],
+    });
+    const result = run([dir]);
+    expect(result.status).toBe(0);
+    expect(result.stdout).toMatchSnapshot();
+  });
+
+  it('links the run artifacts when running inside Actions', () => {
+    const dir = ledgers({ 'shard-1.jsonl': [row('screens/Home', 'passed', { attempts: 1, duration: 74 })] });
+    const stdout = run([dir], {
+      GITHUB_SERVER_URL: 'https://github.com',
+      GITHUB_REPOSITORY: 'rainbow-me/rainbow',
+      GITHUB_RUN_ID: '30336051803',
+    }).stdout;
+    expect(stdout).toMatchSnapshot();
+  });
+
+  it('says so plainly when no shard reported anything', () => {
+    expect(run([ledgers({})]).stdout).toMatchSnapshot();
+  });
+});
+
+describe('reporting is never fatal', () => {
+  it('exits 0 and explains itself when the results directory is missing', () => {
+    const result = run([join(tmpdir(), 'summary-does-not-exist')]);
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('Could not render the e2e summary');
+  });
+
+  it('writes to the step summary instead of stdout when Actions provides one', () => {
+    const dir = ledgers({ 'shard-1.jsonl': [row('screens/Home', 'passed', { attempts: 1, duration: 74 })] });
+    const summary = join(mkdtempSync(join(tmpdir(), 'summary-out-')), 'summary.md');
+    const result = run([dir], { GITHUB_STEP_SUMMARY: summary });
+    expect(result.stdout).toBe('');
+    expect(readFileSync(summary, 'utf8')).toContain('| ✅ | `screens/Home` | 1 | 1 | 1m 14s |');
+  });
+});
+
+describe('being called wrong is fatal', () => {
+  it('exits non-zero with usage when no results directory is given', () => {
+    const result = run([]);
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('usage: node tools/e2e-summary/index.ts <resultsDir>');
+  });
+});
+
+function row(test: string, status: string, over: Record<string, unknown> = {}): string {
+  return JSON.stringify({
+    shard: 1,
+    platform: 'ios',
+    test,
+    status,
+    attempts: null,
+    duration: null,
+    failure_class: null,
+    artifact_dir: null,
+    ...over,
+  });
+}
+
+function ledgers(files: Record<string, string[]>): string {
+  const dir = mkdtempSync(join(tmpdir(), 'summary-'));
+  for (const [name, lines] of Object.entries(files)) {
+    writeFileSync(join(dir, name), lines.length > 0 ? `${lines.join('\n')}\n` : '');
+  }
+  return dir;
+}
+
+// GitHub sets GITHUB_* in CI, which would change the rendered output and split
+// snapshots between local and CI runs, so every case declares what it wants.
+function run(args: string[], extraEnv: Record<string, string> = {}) {
+  const env: NodeJS.ProcessEnv = { ...process.env, ...extraEnv };
+  for (const key of Object.keys(env)) {
+    if (key.startsWith('GITHUB_') && !(key in extraEnv)) delete env[key];
+  }
+  return spawnSync(process.execPath, [CLI, ...args], { encoding: 'utf8', env });
+}

--- a/tools/e2e-summary/index.ts
+++ b/tools/e2e-summary/index.ts
@@ -1,0 +1,152 @@
+/**
+ * Renders the per-shard e2e ledgers written by `scripts/e2e-run.sh` into a
+ * single markdown table for `$GITHUB_STEP_SUMMARY`.
+ *
+ * Usage: node tools/e2e-summary/index.ts <resultsDir>
+ */
+import { appendFileSync, readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+// Most severe first: this order is the table's sort order, the headline's order,
+// and the whitelist for statuses read off disk.
+const ORDER = ['failed', 'planned', 'retried', 'passed'] as const;
+
+type Status = (typeof ORDER)[number];
+
+type Row = {
+  status: Status;
+  test: string;
+  shard: number;
+  attempts: number | null;
+  duration: number | null;
+};
+
+const EMOJI: Record<Status, string> = { failed: '❌', planned: '🚫', retried: '⚠️', passed: '✅' };
+const LABEL: Record<Status, string> = { failed: 'failed', planned: 'did not run', retried: 'retried', passed: 'passed' };
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function isStatus(value: unknown): value is Status {
+  return ORDER.some(status => status === value);
+}
+
+function readLedgers(dir: string): Record<string, unknown>[] {
+  return readdirSync(dir)
+    .filter(name => name.endsWith('.jsonl'))
+    .flatMap(name =>
+      readFileSync(join(dir, name), 'utf8')
+        .split('\n')
+        .filter(line => line.trim() !== '')
+        .flatMap(line => {
+          try {
+            const parsed: unknown = JSON.parse(line);
+            return isRecord(parsed) ? [parsed] : [];
+          } catch {
+            console.error(`skipping unparseable line in ${name}: ${line}`);
+            return [];
+          }
+        })
+    );
+}
+
+// Ledger rows are uniform and append-only, so the last row for a test wins. One
+// still reading "planned" was never superseded by a finished row, which is what a
+// test that never ran looks like.
+function toRows(records: Record<string, unknown>[]): Row[] {
+  const rows = new Map<string, Row>();
+
+  for (const record of records) {
+    if (typeof record.test !== 'string' || !isStatus(record.status)) continue;
+    rows.set(record.test, {
+      status: record.status,
+      test: record.test,
+      shard: typeof record.shard === 'number' ? record.shard : 0,
+      attempts: typeof record.attempts === 'number' ? record.attempts : null,
+      duration: typeof record.duration === 'number' ? record.duration : null,
+    });
+  }
+
+  return [...rows.values()].sort((a, b) => ORDER.indexOf(a.status) - ORDER.indexOf(b.status) || a.test.localeCompare(b.test));
+}
+
+function formatDuration(seconds: number): string {
+  if (seconds < 60) return `${seconds}s`;
+  return `${Math.floor(seconds / 60)}m ${String(seconds % 60).padStart(2, '0')}s`;
+}
+
+function slowestShard(rows: Row[]): number | null {
+  const totals = new Map<number, number>();
+  for (const row of rows) {
+    if (row.duration === null) continue;
+    totals.set(row.shard, (totals.get(row.shard) ?? 0) + row.duration);
+  }
+  return totals.size === 0 ? null : Math.max(...totals.values());
+}
+
+function artifactsLink(): string | null {
+  const { GITHUB_SERVER_URL, GITHUB_REPOSITORY, GITHUB_RUN_ID } = process.env;
+  if (!GITHUB_SERVER_URL || !GITHUB_REPOSITORY || !GITHUB_RUN_ID) return null;
+  return `[artifacts](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}#artifacts)`;
+}
+
+function render(rows: Row[]): string {
+  if (rows.length === 0) {
+    return 'No e2e results were reported. Look into the shard jobs instead.\n';
+  }
+
+  const counts = rows.reduce<Partial<Record<Status, number>>>((acc, row) => ({ ...acc, [row.status]: (acc[row.status] ?? 0) + 1 }), {});
+  const headline = ORDER.filter(status => counts[status])
+    .map(status => `${counts[status]} ${LABEL[status]}`)
+    .join(' · ');
+
+  const slowest = slowestShard(rows);
+  const parts = [`**${headline}**`];
+  if (slowest !== null) parts.push(`slowest shard ${formatDuration(slowest)}`);
+  const link = artifactsLink();
+  if (link) parts.push(link);
+
+  const table = [
+    '|  | Test | Shard | Attempts | Time |',
+    '| :-- | :-- | --: | --: | --: |',
+    ...rows.map(row => {
+      const cells = [
+        EMOJI[row.status],
+        `\`${row.test}\``,
+        String(row.shard),
+        row.attempts === null ? '' : String(row.attempts),
+        row.duration === null ? '' : formatDuration(row.duration),
+      ];
+      return `| ${cells.join(' | ')} |`;
+    }),
+  ];
+
+  return `${parts.join(' · ')}\n\n${table.join('\n')}\n`;
+}
+
+function main(): void {
+  const dir = process.argv[2];
+  if (!dir) {
+    console.error('usage: node tools/e2e-summary/index.ts <resultsDir>');
+    process.exit(1);
+  }
+
+  let markdown: string;
+
+  try {
+    markdown = render(toRows(readLedgers(dir)));
+  } catch (error) {
+    markdown = `Could not render the e2e summary: \`${error instanceof Error ? error.message : String(error)}\`\n`;
+    console.error(error);
+  }
+
+  const summaryPath = process.env.GITHUB_STEP_SUMMARY;
+  if (summaryPath) {
+    appendFileSync(summaryPath, markdown);
+  } else {
+    console.log(markdown);
+  }
+}
+
+main();

--- a/tools/e2e-summary/index.ts
+++ b/tools/e2e-summary/index.ts
@@ -76,21 +76,6 @@ function formatDuration(seconds: number): string {
   return `${Math.floor(seconds / 60)}m ${String(seconds % 60).padStart(2, '0')}s`;
 }
 
-function slowestShard(rows: Row[]): number | null {
-  const totals = new Map<number, number>();
-  for (const row of rows) {
-    if (row.duration === null) continue;
-    totals.set(row.shard, (totals.get(row.shard) ?? 0) + row.duration);
-  }
-  return totals.size === 0 ? null : Math.max(...totals.values());
-}
-
-function artifactsLink(): string | null {
-  const { GITHUB_SERVER_URL, GITHUB_REPOSITORY, GITHUB_RUN_ID } = process.env;
-  if (!GITHUB_SERVER_URL || !GITHUB_REPOSITORY || !GITHUB_RUN_ID) return null;
-  return `[artifacts](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}#artifacts)`;
-}
-
 function render(rows: Row[]): string {
   if (rows.length === 0) {
     return 'No e2e results were reported. Look into the shard jobs instead.\n';
@@ -100,12 +85,6 @@ function render(rows: Row[]): string {
   const headline = ORDER.filter(status => counts[status])
     .map(status => `${counts[status]} ${LABEL[status]}`)
     .join(' · ');
-
-  const slowest = slowestShard(rows);
-  const parts = [`**${headline}**`];
-  if (slowest !== null) parts.push(`slowest shard ${formatDuration(slowest)}`);
-  const link = artifactsLink();
-  if (link) parts.push(link);
 
   const table = [
     '|  | Test | Shard | Attempts | Time |',
@@ -122,7 +101,7 @@ function render(rows: Row[]): string {
     }),
   ];
 
-  return `${parts.join(' · ')}\n\n${table.join('\n')}\n`;
+  return `**${headline}**\n\n${table.join('\n')}\n`;
 }
 
 function main(): void {


### PR DESCRIPTION
A e2e run's results currently exist only as text scattered through four parallel shard logs. Finding what failed means opening all four and scrolling for emoji, so it takes time to tell whether a red run is my change, the suite, or the runner, and even what is actually failing. In practice we usually re-run instead of reading, and a real break can sit long looking like noise becuase of this.

Retries make that worse. When a test fails the suite quietly runs it again, up to three times, and reports success if any attempt passes. Green currently means "passed eventually", and nothing tells that apart from "passed". Nothing is recorded anywhere either, so we have no history to say which test is getting worse or which one to fix first.

With this change each shard now records what it planned to run and how each test finished, and a final job collects those into one table at the top of the run's Summary page. Rows sort by how much attention they need, failed first and passed last, with attempt counts and durations. iOS and Android get a table each, since they are separate workflows.

Example from a [run on this PR](https://github.com/rainbow-me/rainbow/actions/runs/30658423025?pr=7704):
<img width="400"  alt="image" src="https://github.com/user-attachments/assets/3b98f73d-9b36-4707-8c47-f11be9ba9876" />
