### PR TITLE
fix(i18n): first pass of frozen copy in English on cold start

### DIFF
--- a/src/__swaps__/screens/Swap/components/CopyPasteMenu.tsx
+++ b/src/__swaps__/screens/Swap/components/CopyPasteMenu.tsx
@@ -22,9 +22,6 @@ const menuOptionStyle = (pressed: boolean) =>
     opacity: pressed ? 0.9 : 1,
   }) as const;
 
-const copy = i18n.t(i18n.l.copy);
-const paste = i18n.t(i18n.l.paste);
-
 function CopyPasteMenuBubble({
   x,
   y,
@@ -54,7 +51,7 @@ function CopyPasteMenuBubble({
               onPress={onCopy}
               style={({ pressed }) => [onPaste && { borderTopRightRadius: 0, borderBottomRightRadius: 0 }, menuOptionStyle(pressed)]}
             >
-              <Text style={{ color: 'white' }}>{copy}</Text>
+              <Text style={{ color: 'white' }}>{i18n.t(i18n.l.copy)}</Text>
 
               <View style={{ position: 'absolute', bottom: -6, left: layout.width / 2 - 6 - arrowOffset }}>
                 <Svg width="12" height="6" viewBox="0 0 12 6">
@@ -71,7 +68,7 @@ function CopyPasteMenuBubble({
                   menuOptionStyle(pressed),
                 ]}
               >
-                <Text style={{ color: 'white' }}>{paste}</Text>
+                <Text style={{ color: 'white' }}>{i18n.t(i18n.l.paste)}</Text>
               </Pressable>
             )}
           </Animated.View>

--- a/src/__swaps__/screens/Swap/components/GasPanel.tsx
+++ b/src/__swaps__/screens/Swap/components/GasPanel.tsx
@@ -258,10 +258,6 @@ const setGasPanelState = (update: Partial<GasPanelState>) => {
   });
 };
 
-const likely_to_fail = i18n.t(i18n.l.gas.likely_to_fail);
-const higher_than_suggested = i18n.t(i18n.l.gas.higher_than_suggested);
-const lower_than_suggested = i18n.t(i18n.l.gas.lower_than_suggested);
-
 const useMaxBaseFeeWarning = (maxBaseFee: string | undefined) => {
   const chainId = useSwapsStore(s => s.inputAsset?.chainId || ChainId.mainnet);
   const { data: suggestions } = useMeteorologySuggestions({ chainId, enabled: !!maxBaseFee });
@@ -270,14 +266,14 @@ const useMaxBaseFeeWarning = (maxBaseFee: string | undefined) => {
   if (!maxBaseFee) return null;
 
   // likely to get stuck if less than 20% of current base fee
-  if (lessThan(maxBaseFee, multiply(currentBaseFee, 0.2))) return likely_to_fail;
+  if (lessThan(maxBaseFee, multiply(currentBaseFee, 0.2))) return i18n.t(i18n.l.gas.likely_to_fail);
 
   // suggestions
   const { urgent, normal } = suggestions || {};
   const highThreshold = urgent?.maxBaseFee && multiply(urgent.maxBaseFee, 1.1);
   const lowThreshold = normal?.maxBaseFee && multiply(normal.maxBaseFee, 0.9);
-  if (highThreshold && greaterThan(maxBaseFee, highThreshold)) return higher_than_suggested;
-  if (lowThreshold && lessThan(maxBaseFee, lowThreshold)) return lower_than_suggested;
+  if (highThreshold && greaterThan(maxBaseFee, highThreshold)) return i18n.t(i18n.l.gas.higher_than_suggested);
+  if (lowThreshold && lessThan(maxBaseFee, lowThreshold)) return i18n.t(i18n.l.gas.lower_than_suggested);
 
   return null;
 };

--- a/src/__swaps__/screens/Swap/components/ReviewPanel.tsx
+++ b/src/__swaps__/screens/Swap/components/ReviewPanel.tsx
@@ -51,22 +51,16 @@ import { NavigationSteps, useSwapContext } from '../providers/swap-provider';
 import { EstimatedSwapGasFee, EstimatedSwapGasFeeSlot } from './EstimatedSwapGasFee';
 import { UnmountOnAnimatedReaction } from './UnmountOnAnimatedReaction';
 
-const UNKNOWN_LABEL = i18n.t(i18n.l.swap.unknown);
-const REVIEW_LABEL = i18n.t(i18n.l.expanded_state.swap_details.review);
-const NETWORK_LABEL = i18n.t(i18n.l.settings.network);
 const MINIMUM_RECEIVED_LABEL = i18n.t(i18n.l.expanded_state.swap_details_v2.minimum_received);
 const MAXIMUM_SOLD_LABEL = i18n.t(i18n.l.expanded_state.swap_details_v2.maximum_sold);
-const RAINBOW_FEE_LABEL = i18n.t(i18n.l.expanded_state.swap_details_v2.rainbow_fee);
-const MAX_SLIPPAGE_LABEL = i18n.t(i18n.l.exchange.slippage_tolerance);
-const ESTIMATED_NETWORK_FEE_LABEL = i18n.t(i18n.l.gas.network_fee);
-const SMART_WALLET_ACTIVATION_FEE_LABEL = i18n.t(i18n.l.expanded_state.swap_details_v2.smart_wallet_activation_fee);
 
 const RainbowFee = () => {
   const { isDarkMode } = useColorMode();
   const { isFetching, isQuoteStale, quote } = useSwapContext();
 
+  const unknownLabel = i18n.t(i18n.l.swap.unknown);
   const index = useSharedValue(0);
-  const rainbowFee = useSharedValue<string[]>([UNKNOWN_LABEL, UNKNOWN_LABEL]);
+  const rainbowFee = useSharedValue<string[]>([unknownLabel, unknownLabel]);
 
   const feeToDisplay = useDerivedValue(() => {
     return rainbowFee.value[index.value];
@@ -164,7 +158,7 @@ export const SlippageRow = () => {
           </TextIcon>
           <Inline horizontalSpace="4px" alignVertical="center">
             <Text color="labelTertiary" weight="semibold" size="15pt">
-              {MAX_SLIPPAGE_LABEL}
+              {i18n.t(i18n.l.exchange.slippage_tolerance)}
             </Text>
             <Bleed space="12px">
               <ButtonPressAnimation onPress={openSlippageExplainer} scaleTo={0.8}>
@@ -303,7 +297,7 @@ export function ReviewPanel() {
     <Box as={Animated.View} paddingHorizontal="12px" zIndex={12} style={[styles, { flex: 1 }]} testID="review-panel" width="full">
       <Stack alignHorizontal="center" space="24px">
         <Text align="center" weight="heavy" color="label" size="20pt" style={{ paddingBottom: 4 }}>
-          {REVIEW_LABEL}
+          {i18n.t(i18n.l.expanded_state.swap_details.review)}
         </Text>
 
         <Box gap={24} justifyContent="space-between" width="full">
@@ -313,7 +307,7 @@ export function ReviewPanel() {
                 􀤆
               </TextIcon>
               <Text color="labelTertiary" weight="semibold" size="15pt">
-                {NETWORK_LABEL}
+                {i18n.t(i18n.l.settings.network)}
               </Text>
             </Inline>
 
@@ -359,7 +353,7 @@ export function ReviewPanel() {
                   􀘾
                 </TextIcon>
                 <Text color="labelTertiary" weight="semibold" size="15pt">
-                  {RAINBOW_FEE_LABEL}
+                  {i18n.t(i18n.l.expanded_state.swap_details_v2.rainbow_fee)}
                 </Text>
               </Box>
             </Column>
@@ -454,7 +448,7 @@ function GasLabel() {
 
   return (
     <Text color="labelTertiary" size="13pt" weight="bold">
-      {willDelegate ? SMART_WALLET_ACTIVATION_FEE_LABEL : ESTIMATED_NETWORK_FEE_LABEL}
+      {willDelegate ? i18n.t(i18n.l.expanded_state.swap_details_v2.smart_wallet_activation_fee) : i18n.t(i18n.l.gas.network_fee)}
     </Text>
   );
 }

--- a/src/__swaps__/screens/Swap/components/SearchInput.tsx
+++ b/src/__swaps__/screens/Swap/components/SearchInput.tsx
@@ -8,9 +8,6 @@ import { SearchInput as BaseSearchInput } from '@/components/token-search/Search
 import * as i18n from '@/languages';
 import { useUserAssetsStore } from '@/state/assets/userAssets';
 
-const FIND_A_TOKEN_TO_BUY_LABEL = i18n.t(i18n.l.swap.find_a_token_to_buy);
-const SEARCH_YOUR_TOKENS_LABEL = i18n.t(i18n.l.swap.search_your_tokens);
-
 const onOutputSearchQueryChange = (text: string) => useSwapsSearchStore.setState({ searchQuery: text });
 
 export const SearchInput = ({
@@ -44,7 +41,7 @@ export const SearchInput = ({
       onCancelOrClosePressWorklet={onCancelOrClosePressWorklet}
       onSearchFocusWorklet={onSearchFocusWorklet}
       onSearchQueryChange={output ? onOutputSearchQueryChange : onInputSearchQueryChange}
-      placeholder={output ? FIND_A_TOKEN_TO_BUY_LABEL : SEARCH_YOUR_TOKENS_LABEL}
+      placeholder={output ? i18n.t(i18n.l.swap.find_a_token_to_buy) : i18n.t(i18n.l.swap.search_your_tokens)}
       enablePaste={output}
       showButtonWhenNoAsset={output}
       isSearchFocused={isSearchFocused}

--- a/src/__swaps__/screens/Swap/components/SwapSlider.tsx
+++ b/src/__swaps__/screens/Swap/components/SwapSlider.tsx
@@ -40,7 +40,6 @@ type SwapSliderProps = {
 
 const SWAP_TITLE_LABEL = i18n.t(i18n.l.swap.modal_types.swap);
 const BRIDGE_TITLE_LABEL = i18n.t(i18n.l.swap.modal_types.bridge);
-const MAX_LABEL = i18n.t(i18n.l.swap.max);
 const NO_BALANCE_LABEL = i18n.t(i18n.l.swap.no_balance);
 
 export const SwapSlider = ({
@@ -460,7 +459,7 @@ export const SwapSlider = ({
                   style={{ margin: -12, padding: 12 }}
                 >
                   <AnimatedText align="center" size="15pt" style={maxTextColor} weight="heavy">
-                    {MAX_LABEL}
+                    {i18n.t(i18n.l.swap.max)}
                   </AnimatedText>
                 </GestureHandlerButton>
               </Column>

--- a/src/__swaps__/screens/Swap/components/TokenList/TokenToBuyList.tsx
+++ b/src/__swaps__/screens/Swap/components/TokenList/TokenToBuyList.tsx
@@ -48,37 +48,51 @@ interface SectionHeaderProp {
 
 const SECTION_HEADER_INFO: { [id in AssetToBuySectionId]: SectionHeaderProp } = {
   popular: {
-    title: i18n.t(i18n.l.token_search.section_header.popular),
+    get title() {
+      return i18n.t(i18n.l.token_search.section_header.popular);
+    },
     symbol: '􀙬',
     color: 'rgba(255, 88, 77, 1)',
   },
   recent: {
-    title: i18n.t(i18n.l.token_search.section_header.recent),
+    get title() {
+      return i18n.t(i18n.l.token_search.section_header.recent);
+    },
     symbol: '􀐫',
     color: 'rgba(38, 143, 255, 1)',
   },
   favorites: {
-    title: i18n.t(i18n.l.token_search.section_header.favorites),
+    get title() {
+      return i18n.t(i18n.l.token_search.section_header.favorites);
+    },
     symbol: '􀋃',
     color: 'rgba(255, 218, 36, 1)',
   },
   bridge: {
-    title: i18n.t(i18n.l.token_search.section_header.bridge),
+    get title() {
+      return i18n.t(i18n.l.token_search.section_header.bridge);
+    },
     symbol: '􀊝',
     color: undefined,
   },
   verified: {
-    title: i18n.t(i18n.l.token_search.section_header.verified),
+    get title() {
+      return i18n.t(i18n.l.token_search.section_header.verified);
+    },
     symbol: '􀇻',
     color: 'rgba(38, 143, 255, 1)',
   },
   unverified: {
-    title: i18n.t(i18n.l.token_search.section_header.unverified),
+    get title() {
+      return i18n.t(i18n.l.token_search.section_header.unverified);
+    },
     symbol: '􀇿',
     color: 'rgba(255, 218, 36, 1)',
   },
   other_networks: {
-    title: i18n.t(i18n.l.token_search.section_header.on_other_networks),
+    get title() {
+      return i18n.t(i18n.l.token_search.section_header.on_other_networks);
+    },
     symbol: '􀊫',
     color: palettes.dark.foregroundColors.blue,
   },

--- a/src/__swaps__/screens/Swap/providers/swap-provider.tsx
+++ b/src/__swaps__/screens/Swap/providers/swap-provider.tsx
@@ -81,7 +81,6 @@ const selectToken = i18n.t(i18n.l.swap.actions.select_token);
 const insufficientFunds = i18n.t(i18n.l.swap.actions.insufficient_funds);
 const insufficient = i18n.t(i18n.l.swap.actions.insufficient);
 const quoteError = i18n.t(i18n.l.swap.actions.quote_error);
-const sponsorshipUnavailable = i18n.t(i18n.l.swap.sponsorship_unavailable);
 
 type ConfirmButtonProps = {
   label: string;
@@ -355,7 +354,7 @@ export const SwapProvider = ({ children }: SwapProviderProps) => {
 
           if (isInsufficientSponsorBalanceError(errorMessage)) {
             backendNetworksActions.disableSponsorshipUntilNextFetch(parameters.chainId);
-            Alert.alert(i18n.t(i18n.l.swap.error_executing_swap), sponsorshipUnavailable);
+            Alert.alert(i18n.t(i18n.l.swap.error_executing_swap), i18n.t(i18n.l.swap.sponsorship_unavailable));
             return;
           }
 

--- a/src/components/ContactRowInfoButton.js
+++ b/src/components/ContactRowInfoButton.js
@@ -65,7 +65,9 @@ const ContactRowActionsEnum = {
 const ContactRowActions = {
   [ContactRowActionsEnum.copyAddress]: {
     actionKey: ContactRowActionsEnum.copyAddress,
-    actionTitle: i18n.t(i18n.l.wallet.copy_address),
+    get actionTitle() {
+      return i18n.t(i18n.l.wallet.copy_address);
+    },
     icon: {
       iconType: 'SYSTEM',
       iconValue: 'doc.on.doc',

--- a/src/components/Discover/DiscoverSearchBar.tsx
+++ b/src/components/Discover/DiscoverSearchBar.tsx
@@ -13,10 +13,6 @@ import deviceUtils from '@/utils/deviceUtils';
 
 import { NAVBAR_HORIZONTAL_INSET } from '../navbar/Navbar';
 
-const placeholderText = deviceUtils.isNarrowPhone
-  ? i18n.t(i18n.l.discover.search.search_ethereum_short)
-  : i18n.t(i18n.l.discover.search.search_ethereum);
-
 export function DiscoverSearchBar() {
   const { colors } = useTheme();
   const { onTapSearch, cancelSearch } = useDiscoverScreenContext();
@@ -36,7 +32,11 @@ export function DiscoverSearchBar() {
             clearTextOnFocus={false}
             isDiscover
             onFocus={onTapSearch}
-            placeholderText={placeholderText}
+            placeholderText={
+              deviceUtils.isNarrowPhone
+                ? i18n.t(i18n.l.discover.search.search_ethereum_short)
+                : i18n.t(i18n.l.discover.search.search_ethereum)
+            }
             testID="discover-search"
           />
         </Box>

--- a/src/components/Transactions/TransactionDetailsRow.tsx
+++ b/src/components/Transactions/TransactionDetailsRow.tsx
@@ -60,30 +60,44 @@ export const TransactionDetailsRow = ({ chainId, detailType, onPress, value }: T
 const infoForDetailType: { [key: string]: DetailInfo } = {
   chain: {
     icon: '􀤆',
-    label: i18n.t(i18n.l.walletconnect.simulation.details_card.types.chain),
+    get label() {
+      return i18n.t(i18n.l.walletconnect.simulation.details_card.types.chain);
+    },
   },
   contract: {
     icon: '􀉆',
-    label: i18n.t(i18n.l.walletconnect.simulation.details_card.types.contract),
+    get label() {
+      return i18n.t(i18n.l.walletconnect.simulation.details_card.types.contract);
+    },
   },
   to: {
     icon: '􀉩',
-    label: i18n.t(i18n.l.walletconnect.simulation.details_card.types.to),
+    get label() {
+      return i18n.t(i18n.l.walletconnect.simulation.details_card.types.to);
+    },
   },
   function: {
     icon: '􀡅',
-    label: i18n.t(i18n.l.walletconnect.simulation.details_card.types.function),
+    get label() {
+      return i18n.t(i18n.l.walletconnect.simulation.details_card.types.function);
+    },
   },
   sourceCodeVerification: {
     icon: '􀕹',
-    label: i18n.t(i18n.l.walletconnect.simulation.details_card.types.source_code),
+    get label() {
+      return i18n.t(i18n.l.walletconnect.simulation.details_card.types.source_code);
+    },
   },
   dateCreated: {
     icon: '􀉉',
-    label: i18n.t(i18n.l.walletconnect.simulation.details_card.types.contract_created),
+    get label() {
+      return i18n.t(i18n.l.walletconnect.simulation.details_card.types.contract_created);
+    },
   },
   nonce: {
     icon: '􀆃',
-    label: i18n.t(i18n.l.walletconnect.simulation.details_card.types.nonce),
+    get label() {
+      return i18n.t(i18n.l.walletconnect.simulation.details_card.types.nonce);
+    },
   },
 };

--- a/src/components/Transactions/constants.ts
+++ b/src/components/Transactions/constants.ts
@@ -67,35 +67,45 @@ export const infoForEventType: { [key: string]: EventInfo } = {
     amountPrefix: '- ',
     icon: '􀁷',
     iconColor: 'red',
-    label: i18n.t(i18n.l.walletconnect.simulation.simulation_card.event_row.types.send),
+    get label() {
+      return i18n.t(i18n.l.walletconnect.simulation.simulation_card.event_row.types.send);
+    },
     textColor: 'red',
   },
   receive: {
     amountPrefix: '+ ',
     icon: '􀁹',
     iconColor: 'green',
-    label: i18n.t(i18n.l.walletconnect.simulation.simulation_card.event_row.types.receive),
+    get label() {
+      return i18n.t(i18n.l.walletconnect.simulation.simulation_card.event_row.types.receive);
+    },
     textColor: 'green',
   },
   approve: {
     amountPrefix: '',
     icon: '􀎤',
     iconColor: 'green',
-    label: i18n.t(i18n.l.walletconnect.simulation.simulation_card.event_row.types.approve),
+    get label() {
+      return i18n.t(i18n.l.walletconnect.simulation.simulation_card.event_row.types.approve);
+    },
     textColor: 'label',
   },
   revoke: {
     amountPrefix: '',
     icon: '􀎠',
     iconColor: 'red',
-    label: i18n.t(i18n.l.walletconnect.simulation.simulation_card.event_row.types.revoke),
+    get label() {
+      return i18n.t(i18n.l.walletconnect.simulation.simulation_card.event_row.types.revoke);
+    },
     textColor: 'label',
   },
   failed: {
     amountPrefix: '',
     icon: '􀇿',
     iconColor: 'red',
-    label: i18n.t(i18n.l.walletconnect.simulation.simulation_card.titles.likely_to_fail),
+    get label() {
+      return i18n.t(i18n.l.walletconnect.simulation.simulation_card.titles.likely_to_fail);
+    },
     textColor: 'red',
   },
   insufficientBalance: {

--- a/src/components/exchangeAssetRowContextMenuProps.ts
+++ b/src/components/exchangeAssetRowContextMenuProps.ts
@@ -33,7 +33,9 @@ const CoinRowActionsEnum = {
 const CoinRowActions = {
   [CoinRowActionsEnum.copyAddress]: {
     actionKey: CoinRowActionsEnum.copyAddress,
-    actionTitle: i18n.t(i18n.l.wallet.action.copy_contract_address),
+    get actionTitle() {
+      return i18n.t(i18n.l.wallet.action.copy_contract_address);
+    },
     icon: {
       iconType: 'SYSTEM',
       iconValue: Platform.OS === 'ios' ? 'doc.on.doc' : null,

--- a/src/components/expanded-state/unique-token/UniqueTokenExpandedStateHeader.tsx
+++ b/src/components/expanded-state/unique-token/UniqueTokenExpandedStateHeader.tsx
@@ -117,7 +117,9 @@ const FamilyActionsEnum = {
 const FamilyActions = {
   [FamilyActionsEnum.viewCollection]: {
     actionKey: FamilyActionsEnum.viewCollection,
-    actionTitle: i18n.t(i18n.l.expanded_state.unique_expanded.view_collection),
+    get actionTitle() {
+      return i18n.t(i18n.l.expanded_state.unique_expanded.view_collection);
+    },
     icon: {
       iconType: 'SYSTEM',
       iconValue: 'rectangle.grid.2x2.fill',
@@ -125,7 +127,9 @@ const FamilyActions = {
   },
   [FamilyActionsEnum.collectionWebsite]: {
     actionKey: FamilyActionsEnum.collectionWebsite,
-    actionTitle: i18n.t(i18n.l.expanded_state.unique_expanded.collection_website),
+    get actionTitle() {
+      return i18n.t(i18n.l.expanded_state.unique_expanded.collection_website);
+    },
     icon: {
       iconType: 'SYSTEM',
       iconValue: 'safari.fill',
@@ -133,7 +137,9 @@ const FamilyActions = {
   },
   [FamilyActionsEnum.discord]: {
     actionKey: FamilyActionsEnum.discord,
-    actionTitle: i18n.t(i18n.l.expanded_state.unique_expanded.discord),
+    get actionTitle() {
+      return i18n.t(i18n.l.expanded_state.unique_expanded.discord);
+    },
     icon: {
       iconType: 'SYSTEM',
       iconValue: 'ellipsis.bubble.fill',
@@ -141,7 +147,9 @@ const FamilyActions = {
   },
   [FamilyActionsEnum.twitter]: {
     actionKey: FamilyActionsEnum.twitter,
-    actionTitle: i18n.t(i18n.l.expanded_state.unique_expanded.twitter),
+    get actionTitle() {
+      return i18n.t(i18n.l.expanded_state.unique_expanded.twitter);
+    },
     icon: {
       iconType: 'SYSTEM',
       iconValue: 'at.circle.fill',

--- a/src/components/unique-token/Tag.js
+++ b/src/components/unique-token/Tag.js
@@ -39,7 +39,9 @@ const getViewTraitOnNftMarketplaceAction = marketplaceName => {
 
 const openTraitURLInBrowserAction = {
   actionKey: PropertyActionsEnum.openURL,
-  actionTitle: i18n.t(i18n.l.expanded_state.unique_expanded.open_in_web_browser),
+  get actionTitle() {
+    return i18n.t(i18n.l.expanded_state.unique_expanded.open_in_web_browser);
+  },
   icon: {
     iconType: 'SYSTEM',
     iconValue: 'safari.fill',

--- a/src/features/ens/utils/helpers.ts
+++ b/src/features/ens/utils/helpers.ts
@@ -115,8 +115,12 @@ export const textRecordFields = {
       maxLength: 50,
     },
     key: ENS_RECORDS.name,
-    label: i18n.t(i18n.l.profiles.create.name),
-    placeholder: i18n.t(i18n.l.profiles.create.name_placeholder),
+    get label() {
+      return i18n.t(i18n.l.profiles.create.name);
+    },
+    get placeholder() {
+      return i18n.t(i18n.l.profiles.create.name_placeholder);
+    },
   },
   [ENS_RECORDS.description]: {
     id: 'bio',
@@ -125,8 +129,12 @@ export const textRecordFields = {
       multiline: true,
     },
     key: ENS_RECORDS.description,
-    label: i18n.t(i18n.l.profiles.create.bio),
-    placeholder: i18n.t(i18n.l.profiles.create.bio_placeholder),
+    get label() {
+      return i18n.t(i18n.l.profiles.create.bio);
+    },
+    get placeholder() {
+      return i18n.t(i18n.l.profiles.create.bio_placeholder);
+    },
   },
   [ENS_RECORDS.url]: {
     id: 'website',
@@ -135,10 +143,16 @@ export const textRecordFields = {
       maxLength: 100,
     },
     key: ENS_RECORDS.url,
-    label: i18n.t(i18n.l.profiles.create.website),
-    placeholder: i18n.t(i18n.l.profiles.create.website_placeholder),
+    get label() {
+      return i18n.t(i18n.l.profiles.create.website);
+    },
+    get placeholder() {
+      return i18n.t(i18n.l.profiles.create.website_placeholder);
+    },
     validation: {
-      message: i18n.t(i18n.l.profiles.create.invalid_website),
+      get message() {
+        return i18n.t(i18n.l.profiles.create.invalid_website);
+      },
       validator: value => /[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_+.~#?&//=]*)/.test(value),
     },
   },
@@ -148,13 +162,19 @@ export const textRecordFields = {
       maxLength: 16,
     },
     key: ENS_RECORDS.twitter,
-    label: i18n.t(i18n.l.profiles.create.twitter),
-    placeholder: i18n.t(i18n.l.profiles.create.username_placeholder),
+    get label() {
+      return i18n.t(i18n.l.profiles.create.twitter);
+    },
+    get placeholder() {
+      return i18n.t(i18n.l.profiles.create.username_placeholder);
+    },
     startsWith: '@',
     validation: {
-      message: i18n.t(i18n.l.profiles.create.invalid_username, {
-        app: i18n.t(i18n.l.profiles.create.twitter),
-      }),
+      get message() {
+        return i18n.t(i18n.l.profiles.create.invalid_username, {
+          app: i18n.t(i18n.l.profiles.create.twitter),
+        });
+      },
       validator: value => /^\w*$/.test(value),
     },
   },
@@ -165,10 +185,16 @@ export const textRecordFields = {
       maxLength: 50,
     },
     key: ENS_RECORDS.email,
-    label: i18n.t(i18n.l.profiles.create.email),
-    placeholder: i18n.t(i18n.l.profiles.create.email_placeholder),
+    get label() {
+      return i18n.t(i18n.l.profiles.create.email);
+    },
+    get placeholder() {
+      return i18n.t(i18n.l.profiles.create.email_placeholder);
+    },
     validation: {
-      message: i18n.t(i18n.l.profiles.create.invalid_email),
+      get message() {
+        return i18n.t(i18n.l.profiles.create.invalid_email);
+      },
       validator: value => /^\S+@\S+\.\S+$/.test(value),
     },
   },
@@ -178,13 +204,19 @@ export const textRecordFields = {
       maxLength: 30,
     },
     key: ENS_RECORDS.instagram,
-    label: i18n.t(i18n.l.profiles.create.instagram),
-    placeholder: i18n.t(i18n.l.profiles.create.username_placeholder),
+    get label() {
+      return i18n.t(i18n.l.profiles.create.instagram);
+    },
+    get placeholder() {
+      return i18n.t(i18n.l.profiles.create.username_placeholder);
+    },
     startsWith: '@',
     validation: {
-      message: i18n.t(i18n.l.profiles.create.invalid_username, {
-        app: i18n.t(i18n.l.profiles.create.instagram),
-      }),
+      get message() {
+        return i18n.t(i18n.l.profiles.create.invalid_username, {
+          app: i18n.t(i18n.l.profiles.create.instagram),
+        });
+      },
       validator: value => /^([\w.])*$/.test(value),
     },
   },
@@ -194,13 +226,19 @@ export const textRecordFields = {
       maxLength: 50,
     },
     key: ENS_RECORDS.discord,
-    label: i18n.t(i18n.l.profiles.create.discord),
-    placeholder: i18n.t(i18n.l.profiles.create.username_placeholder),
+    get label() {
+      return i18n.t(i18n.l.profiles.create.discord);
+    },
+    get placeholder() {
+      return i18n.t(i18n.l.profiles.create.username_placeholder);
+    },
     startsWith: '@',
     validation: {
-      message: i18n.t(i18n.l.profiles.create.invalid_username, {
-        app: i18n.t(i18n.l.profiles.create.discord),
-      }),
+      get message() {
+        return i18n.t(i18n.l.profiles.create.invalid_username, {
+          app: i18n.t(i18n.l.profiles.create.discord),
+        });
+      },
       validator: value => /^(\w)+#[0-9]{4}$/.test(value),
     },
   },
@@ -210,13 +248,19 @@ export const textRecordFields = {
       maxLength: 20,
     },
     key: ENS_RECORDS.github,
-    label: i18n.t(i18n.l.profiles.create.github),
-    placeholder: i18n.t(i18n.l.profiles.create.username_placeholder),
+    get label() {
+      return i18n.t(i18n.l.profiles.create.github);
+    },
+    get placeholder() {
+      return i18n.t(i18n.l.profiles.create.username_placeholder);
+    },
     startsWith: '@',
     validation: {
-      message: i18n.t(i18n.l.profiles.create.invalid_username, {
-        app: i18n.t(i18n.l.profiles.create.github),
-      }),
+      get message() {
+        return i18n.t(i18n.l.profiles.create.invalid_username, {
+          app: i18n.t(i18n.l.profiles.create.github),
+        });
+      },
       validator: value => /^([\w.-])*$/.test(value),
     },
   },
@@ -227,14 +271,20 @@ export const textRecordFields = {
       multiline: true,
     },
     key: ENS_RECORDS.BTC,
-    label: i18n.t(i18n.l.profiles.create.btc),
-    placeholder: i18n.t(i18n.l.profiles.create.wallet_placeholder, {
-      coin: i18n.t(i18n.l.profiles.create.btc),
-    }),
+    get label() {
+      return i18n.t(i18n.l.profiles.create.btc);
+    },
+    get placeholder() {
+      return i18n.t(i18n.l.profiles.create.wallet_placeholder, {
+        coin: i18n.t(i18n.l.profiles.create.btc),
+      });
+    },
     validation: {
-      message: i18n.t(i18n.l.profiles.create.invalid_asset, {
-        coin: ENS_RECORDS.BTC,
-      }),
+      get message() {
+        return i18n.t(i18n.l.profiles.create.invalid_asset, {
+          coin: ENS_RECORDS.BTC,
+        });
+      },
       validator: value => validateCoinRecordValue(value, ENS_RECORDS.BTC),
     },
   },
@@ -244,13 +294,19 @@ export const textRecordFields = {
       maxLength: 16,
     },
     key: ENS_RECORDS.snapchat,
-    label: i18n.t(i18n.l.profiles.create.snapchat),
-    placeholder: i18n.t(i18n.l.profiles.create.username_placeholder),
+    get label() {
+      return i18n.t(i18n.l.profiles.create.snapchat);
+    },
+    get placeholder() {
+      return i18n.t(i18n.l.profiles.create.username_placeholder);
+    },
     startsWith: '@',
     validation: {
-      message: i18n.t(i18n.l.profiles.create.invalid_username, {
-        app: i18n.t(i18n.l.profiles.create.snapchat),
-      }),
+      get message() {
+        return i18n.t(i18n.l.profiles.create.invalid_username, {
+          app: i18n.t(i18n.l.profiles.create.snapchat),
+        });
+      },
       validator: value => /^([\w.])*$/.test(value),
     },
   },
@@ -260,13 +316,19 @@ export const textRecordFields = {
       maxLength: 30,
     },
     key: ENS_RECORDS.telegram,
-    label: i18n.t(i18n.l.profiles.create.telegram),
-    placeholder: i18n.t(i18n.l.profiles.create.username_placeholder),
+    get label() {
+      return i18n.t(i18n.l.profiles.create.telegram);
+    },
+    get placeholder() {
+      return i18n.t(i18n.l.profiles.create.username_placeholder);
+    },
     startsWith: '@',
     validation: {
-      message: i18n.t(i18n.l.profiles.create.invalid_username, {
-        app: i18n.t(i18n.l.profiles.create.telegram),
-      }),
+      get message() {
+        return i18n.t(i18n.l.profiles.create.invalid_username, {
+          app: i18n.t(i18n.l.profiles.create.telegram),
+        });
+      },
       validator: value => /^([\w#.])*$/.test(value),
     },
   },
@@ -276,13 +338,19 @@ export const textRecordFields = {
       maxLength: 30,
     },
     key: ENS_RECORDS.reddit,
-    label: i18n.t(i18n.l.profiles.create.reddit),
-    placeholder: i18n.t(i18n.l.profiles.create.username_placeholder),
+    get label() {
+      return i18n.t(i18n.l.profiles.create.reddit);
+    },
+    get placeholder() {
+      return i18n.t(i18n.l.profiles.create.username_placeholder);
+    },
     startsWith: '@',
     validation: {
-      message: i18n.t(i18n.l.profiles.create.invalid_username, {
-        app: i18n.t(i18n.l.profiles.create.reddit),
-      }),
+      get message() {
+        return i18n.t(i18n.l.profiles.create.invalid_username, {
+          app: i18n.t(i18n.l.profiles.create.reddit),
+        });
+      },
       validator: value => /^([\w#.])*$/.test(value),
     },
   },
@@ -292,8 +360,12 @@ export const textRecordFields = {
       maxLength: 42,
     },
     key: ENS_RECORDS.pronouns,
-    label: i18n.t(i18n.l.profiles.create.pronouns),
-    placeholder: i18n.t(i18n.l.profiles.create.pronouns_placeholder),
+    get label() {
+      return i18n.t(i18n.l.profiles.create.pronouns);
+    },
+    get placeholder() {
+      return i18n.t(i18n.l.profiles.create.pronouns_placeholder);
+    },
   },
   [ENS_RECORDS.notice]: {
     id: 'notice',
@@ -301,8 +373,12 @@ export const textRecordFields = {
       maxLength: 100,
     },
     key: ENS_RECORDS.notice,
-    label: i18n.t(i18n.l.profiles.create.notice),
-    placeholder: i18n.t(i18n.l.profiles.create.notice_placeholder),
+    get label() {
+      return i18n.t(i18n.l.profiles.create.notice);
+    },
+    get placeholder() {
+      return i18n.t(i18n.l.profiles.create.notice_placeholder);
+    },
   },
   [ENS_RECORDS.keywords]: {
     id: 'keywords',
@@ -310,8 +386,12 @@ export const textRecordFields = {
       maxLength: 100,
     },
     key: ENS_RECORDS.keywords,
-    label: i18n.t(i18n.l.profiles.create.keywords),
-    placeholder: i18n.t(i18n.l.profiles.create.keywords_placeholder),
+    get label() {
+      return i18n.t(i18n.l.profiles.create.keywords);
+    },
+    get placeholder() {
+      return i18n.t(i18n.l.profiles.create.keywords_placeholder);
+    },
   },
   [ENS_RECORDS.LTC]: {
     id: 'ltc',
@@ -319,14 +399,20 @@ export const textRecordFields = {
       maxLength: 64,
     },
     key: ENS_RECORDS.LTC,
-    label: i18n.t(i18n.l.profiles.create.ltc),
-    placeholder: i18n.t(i18n.l.profiles.create.wallet_placeholder, {
-      coin: i18n.t(i18n.l.profiles.create.ltc),
-    }),
+    get label() {
+      return i18n.t(i18n.l.profiles.create.ltc);
+    },
+    get placeholder() {
+      return i18n.t(i18n.l.profiles.create.wallet_placeholder, {
+        coin: i18n.t(i18n.l.profiles.create.ltc),
+      });
+    },
     validation: {
-      message: i18n.t(i18n.l.profiles.create.invalid_asset, {
-        coin: ENS_RECORDS.LTC,
-      }),
+      get message() {
+        return i18n.t(i18n.l.profiles.create.invalid_asset, {
+          coin: ENS_RECORDS.LTC,
+        });
+      },
       validator: value => validateCoinRecordValue(value, ENS_RECORDS.LTC),
     },
   },
@@ -336,14 +422,20 @@ export const textRecordFields = {
       maxLength: 34,
     },
     key: ENS_RECORDS.DOGE,
-    label: i18n.t(i18n.l.profiles.create.doge),
-    placeholder: i18n.t(i18n.l.profiles.create.wallet_placeholder, {
-      coin: i18n.t(i18n.l.profiles.create.doge),
-    }),
+    get label() {
+      return i18n.t(i18n.l.profiles.create.doge);
+    },
+    get placeholder() {
+      return i18n.t(i18n.l.profiles.create.wallet_placeholder, {
+        coin: i18n.t(i18n.l.profiles.create.doge),
+      });
+    },
     validation: {
-      message: i18n.t(i18n.l.profiles.create.invalid_asset, {
-        coin: ENS_RECORDS.DOGE,
-      }),
+      get message() {
+        return i18n.t(i18n.l.profiles.create.invalid_asset, {
+          coin: ENS_RECORDS.DOGE,
+        });
+      },
       validator: value => validateCoinRecordValue(value, ENS_RECORDS.DOGE),
     },
   },
@@ -351,10 +443,16 @@ export const textRecordFields = {
     id: 'contenthash',
     inputProps: {},
     key: ENS_RECORDS.contenthash,
-    label: i18n.t(i18n.l.profiles.create.content),
-    placeholder: i18n.t(i18n.l.profiles.create.content_placeholder),
+    get label() {
+      return i18n.t(i18n.l.profiles.create.content);
+    },
+    get placeholder() {
+      return i18n.t(i18n.l.profiles.create.content_placeholder);
+    },
     validation: {
-      message: i18n.t(i18n.l.profiles.create.invalid_content_hash),
+      get message() {
+        return i18n.t(i18n.l.profiles.create.invalid_content_hash);
+      },
       validator: value => validateContentHashRecordValue(value),
     },
   },

--- a/src/features/gas/utils/gas.ts
+++ b/src/features/gas/utils/gas.ts
@@ -70,20 +70,28 @@ const GAS_EMOJIS: {
 const GAS_TRENDS = {
   [FALLING]: {
     color: colors.green,
-    label: `􀄱 ${i18n.t(i18n.l.gas.card.falling)}`,
+    get label() {
+      return `􀄱 ${i18n.t(i18n.l.gas.card.falling)}`;
+    },
   },
   [NO_TREND]: { color: colors.appleBlue, label: '' },
   [RISING]: {
     color: colors.orange,
-    label: `􀰾  ${i18n.t(i18n.l.gas.card.rising)}`,
+    get label() {
+      return `􀰾  ${i18n.t(i18n.l.gas.card.rising)}`;
+    },
   },
   [STABLE]: {
     color: colors.yellowFavorite,
-    label: `􀆮  ${i18n.t(i18n.l.gas.card.stable)}`,
+    get label() {
+      return `􀆮  ${i18n.t(i18n.l.gas.card.stable)}`;
+    },
   },
   [SURGING]: {
     color: colors.red,
-    label: `􀇿  ${i18n.t(i18n.l.gas.card.surging)}`,
+    get label() {
+      return `􀇿  ${i18n.t(i18n.l.gas.card.surging)}`;
+    },
   },
 };
 

--- a/src/features/king-of-the-hill/screens/KingOfTheHillExplainSheet.tsx
+++ b/src/features/king-of-the-hill/screens/KingOfTheHillExplainSheet.tsx
@@ -16,8 +16,6 @@ const GRADIENT_COLORS = ['#8754C8', '#EE431D', '#FFF000', '#02ADDE'];
 const PANEL_INNER_WIDTH = 332;
 
 const translations = i18n.l.king_of_hill.explain_sheet;
-const nextButtonLabel = i18n.t(translations.next);
-const gotItButtonLabel = i18n.t(translations.got_it);
 
 const STEPS: ExplainerSheetStep[] = [
   {
@@ -83,8 +81,8 @@ export function KingOfTheHillExplainSheet() {
           </GradientText>
         )}
         gradientColors={GRADIENT_COLORS}
-        nextButtonLabel={nextButtonLabel}
-        completeButtonLabel={gotItButtonLabel}
+        nextButtonLabel={i18n.t(translations.next)}
+        completeButtonLabel={i18n.t(translations.got_it)}
       />
     </ColorModeProvider>
   );

--- a/src/features/perps/withdrawalConfig.ts
+++ b/src/features/perps/withdrawalConfig.ts
@@ -19,10 +19,16 @@ export const PERPS_WITHDRAWAL_CONFIG = createWithdrawalConfig({
   executor: executePerpsWithdrawal,
 
   infoCard: {
-    description: i18n.t(i18n.l.perps.withdraw.info_card_subtitle),
+    get description() {
+      return i18n.t(i18n.l.perps.withdraw.info_card_subtitle);
+    },
     title: {
-      highlighted: i18n.t(i18n.l.perps.withdraw.info_card_title_suffix),
-      prefix: i18n.t(i18n.l.perps.withdraw.info_card_title_prefix),
+      get highlighted() {
+        return i18n.t(i18n.l.perps.withdraw.info_card_title_suffix);
+      },
+      get prefix() {
+        return i18n.t(i18n.l.perps.withdraw.info_card_title_prefix);
+      },
     },
   },
 

--- a/src/features/wallet-connect/components/WalletConnectV2ListItem.tsx
+++ b/src/features/wallet-connect/components/WalletConnectV2ListItem.tsx
@@ -33,8 +33,6 @@ const CONTAINER_PADDING = 15;
 const VENDOR_LOGO_ICON_SIZE = 50;
 export const WALLET_CONNECT_LIST_ITEM_HEIGHT = VENDOR_LOGO_ICON_SIZE + CONTAINER_PADDING * 2;
 
-const androidContextMenuActions = [i18n.t(i18n.l.walletconnect.switch_wallet), i18n.t(i18n.l.walletconnect.disconnect)];
-
 const SessionRow = styled(Row)({
   alignItems: 'center',
   justifyContent: 'flex-start',
@@ -109,7 +107,7 @@ export function WalletConnectV2ListItem({ session, reload }: { session: SessionT
   const onPressAndroid = useCallback(() => {
     showActionSheetWithOptions(
       {
-        options: androidContextMenuActions,
+        options: [i18n.t(i18n.l.walletconnect.switch_wallet), i18n.t(i18n.l.walletconnect.disconnect)],
         title: dappName,
       },
       async index => {

--- a/src/hooks/useSelectImageMenu.tsx
+++ b/src/hooks/useSelectImageMenu.tsx
@@ -20,7 +20,9 @@ type Action = 'library' | 'nft';
 const items = {
   library: {
     actionKey: 'library',
-    actionTitle: i18n.t(i18n.l.profiles.create.upload_photo),
+    get actionTitle() {
+      return i18n.t(i18n.l.profiles.create.upload_photo);
+    },
     icon: {
       imageValue: {
         systemName: 'photo.on.rectangle.angled',
@@ -30,7 +32,9 @@ const items = {
   },
   nft: {
     actionKey: 'nft',
-    actionTitle: i18n.t(i18n.l.profiles.create.choose_nft),
+    get actionTitle() {
+      return i18n.t(i18n.l.profiles.create.choose_nft);
+    },
     icon: {
       imageValue: {
         systemName: 'square.grid.2x2',
@@ -41,7 +45,9 @@ const items = {
   },
   remove: {
     actionKey: 'remove',
-    actionTitle: i18n.t(i18n.l.profiles.create.remove),
+    get actionTitle() {
+      return i18n.t(i18n.l.profiles.create.remove);
+    },
     icon: {
       imageValue: {
         systemName: 'trash',

--- a/src/model/wallet.ts
+++ b/src/model/wallet.ts
@@ -187,7 +187,11 @@ export const allWalletsVersion = 1.0;
 export const DEFAULT_HD_PATH = `m/44'/60'/0'/0`;
 export const DEFAULT_WALLET_NAME = 'My Wallet';
 
-const authenticationPrompt = { title: i18n.t(i18n.l.wallet.authenticate.please) };
+const authenticationPrompt = {
+  get title() {
+    return i18n.t(i18n.l.wallet.authenticate.please);
+  },
+};
 
 export const createdWithBiometricError = 'createdWithBiometricError';
 

--- a/src/screens/SettingsSheet/utils.ts
+++ b/src/screens/SettingsSheet/utils.ts
@@ -63,15 +63,15 @@ export const checkLocalWalletsForBackupStatus = (backups: CloudBackups): WalletB
 };
 
 export const titleForBackupState: Partial<Record<CloudBackupState, string>> = {
-  [CloudBackupState.Initializing]: i18n.t(i18n.l.back_up.cloud.syncing_cloud_store, {
-    cloudPlatformName: cloudPlatform,
-  }),
-  [CloudBackupState.Syncing]: i18n.t(i18n.l.back_up.cloud.syncing_cloud_store, {
-    cloudPlatformName: cloudPlatform,
-  }),
-  [CloudBackupState.Fetching]: i18n.t(i18n.l.back_up.cloud.fetching_backups, {
-    cloudPlatformName: cloudPlatform,
-  }),
+  get [CloudBackupState.Initializing]() {
+    return i18n.t(i18n.l.back_up.cloud.syncing_cloud_store, { cloudPlatformName: cloudPlatform });
+  },
+  get [CloudBackupState.Syncing]() {
+    return i18n.t(i18n.l.back_up.cloud.syncing_cloud_store, { cloudPlatformName: cloudPlatform });
+  },
+  get [CloudBackupState.Fetching]() {
+    return i18n.t(i18n.l.back_up.cloud.fetching_backups, { cloudPlatformName: cloudPlatform });
+  },
 };
 
 export const isWalletBackedUpForCurrentAccount = ({ backupType, backedUp, backupFile }: Partial<RainbowWallet>) => {

--- a/src/screens/SpeedUpAndCancelSheet.tsx
+++ b/src/screens/SpeedUpAndCancelSheet.tsx
@@ -100,14 +100,22 @@ const SPEED_UP = 'speed_up';
 // i18n
 
 const title = {
-  [CANCEL_TX]: i18n.t(i18n.l.wallet.transaction.speed_up.cancel_tx_title),
-  [SPEED_UP]: i18n.t(i18n.l.wallet.transaction.speed_up.speed_up_title),
+  get [CANCEL_TX]() {
+    return i18n.t(i18n.l.wallet.transaction.speed_up.cancel_tx_title);
+  },
+  get [SPEED_UP]() {
+    return i18n.t(i18n.l.wallet.transaction.speed_up.speed_up_title);
+  },
 };
 // i18n
 
 const text = {
-  [CANCEL_TX]: i18n.t(i18n.l.wallet.transaction.speed_up.cancel_tx_text),
-  [SPEED_UP]: i18n.t(i18n.l.wallet.transaction.speed_up.speed_up_text),
+  get [CANCEL_TX]() {
+    return i18n.t(i18n.l.wallet.transaction.speed_up.cancel_tx_text);
+  },
+  get [SPEED_UP]() {
+    return i18n.t(i18n.l.wallet.transaction.speed_up.speed_up_text);
+  },
 };
 
 const calcGasParamRetryValue = (prevWeiValue: BigNumberish) => {

--- a/src/screens/WalletConnectRedirectSheet.tsx
+++ b/src/screens/WalletConnectRedirectSheet.tsx
@@ -35,13 +35,27 @@ const emojisMap = {
 };
 
 const titlesMap = {
-  'connect': i18n.t(i18n.l.walletconnect.titles.connect),
-  'timedOut': i18n.t(i18n.l.walletconnect.titles.reject),
-  'reject': i18n.t(i18n.l.walletconnect.titles.reject),
-  'sign': i18n.t(i18n.l.walletconnect.titles.sign),
-  'sign-canceled': i18n.t(i18n.l.walletconnect.titles.sign_canceled),
-  'transaction': i18n.t(i18n.l.walletconnect.titles.transaction_sent),
-  'transaction-canceled': i18n.t(i18n.l.walletconnect.titles.transaction_canceled),
+  get 'connect'() {
+    return i18n.t(i18n.l.walletconnect.titles.connect);
+  },
+  get 'timedOut'() {
+    return i18n.t(i18n.l.walletconnect.titles.reject);
+  },
+  get 'reject'() {
+    return i18n.t(i18n.l.walletconnect.titles.reject);
+  },
+  get 'sign'() {
+    return i18n.t(i18n.l.walletconnect.titles.sign);
+  },
+  get 'sign-canceled'() {
+    return i18n.t(i18n.l.walletconnect.titles.sign_canceled);
+  },
+  get 'transaction'() {
+    return i18n.t(i18n.l.walletconnect.titles.transaction_sent);
+  },
+  get 'transaction-canceled'() {
+    return i18n.t(i18n.l.walletconnect.titles.transaction_canceled);
+  },
 };
 
 function WalletConnectRedirectSheet() {

--- a/src/screens/rewards/constants.ts
+++ b/src/screens/rewards/constants.ts
@@ -15,6 +15,10 @@ export const LIGHT_RANK_1_GRADIENT_COLORS = ['#E2B730', '#CF9500'] as const;
 export const LIGHT_RANK_2_GRADIENT_COLORS = ['#ABAFB6', '#81858B'] as const;
 export const LIGHT_RANK_3_GRADIENT_COLORS = ['#D48834', '#AA5820'] as const;
 export const STATS_TITLES = {
-  [RewardStatsActionType.Swap]: i18n.t(i18n.l.rewards.swapped),
-  [RewardStatsActionType.Bridge]: i18n.t(i18n.l.rewards.bridged),
+  get [RewardStatsActionType.Swap]() {
+    return i18n.t(i18n.l.rewards.swapped);
+  },
+  get [RewardStatsActionType.Bridge]() {
+    return i18n.t(i18n.l.rewards.bridged);
+  },
 };

--- a/src/screens/token-launcher/components/LinksSection.tsx
+++ b/src/screens/token-launcher/components/LinksSection.tsx
@@ -35,8 +35,12 @@ export const LINK_SETTINGS = {
     Icon: () => <Icon name="x" color={'white'} size={26} />,
     iconBackgroundColor: '#000000',
     primaryColor: '#000000',
-    placeholder: i18n.t(i18n.l.token_launcher.links.x.placeholder),
-    displayName: i18n.t(i18n.l.token_launcher.links.x.name),
+    get placeholder() {
+      return i18n.t(i18n.l.token_launcher.links.x.placeholder);
+    },
+    get displayName() {
+      return i18n.t(i18n.l.token_launcher.links.x.name);
+    },
     type: 'x',
   },
   telegram: {
@@ -49,8 +53,12 @@ export const LINK_SETTINGS = {
     ),
     iconBackgroundColor: '#24A1DE',
     primaryColor: '#24A1DE',
-    placeholder: i18n.t(i18n.l.token_launcher.links.telegram.placeholder),
-    displayName: i18n.t(i18n.l.token_launcher.links.telegram.name),
+    get placeholder() {
+      return i18n.t(i18n.l.token_launcher.links.telegram.placeholder);
+    },
+    get displayName() {
+      return i18n.t(i18n.l.token_launcher.links.telegram.name);
+    },
     type: 'telegram',
   },
   farcaster: {
@@ -61,8 +69,12 @@ export const LINK_SETTINGS = {
     ),
     iconBackgroundColor: '#855DCD',
     primaryColor: '#855DCD',
-    placeholder: i18n.t(i18n.l.token_launcher.links.farcaster.placeholder),
-    displayName: i18n.t(i18n.l.token_launcher.links.farcaster.name),
+    get placeholder() {
+      return i18n.t(i18n.l.token_launcher.links.farcaster.placeholder);
+    },
+    get displayName() {
+      return i18n.t(i18n.l.token_launcher.links.farcaster.name);
+    },
     type: 'farcaster',
   },
   website: {
@@ -80,8 +92,12 @@ export const LINK_SETTINGS = {
     ),
     iconBackgroundColor: colors.appleBlue,
     primaryColor: '#fff',
-    placeholder: i18n.t(i18n.l.token_launcher.links.website.placeholder),
-    displayName: i18n.t(i18n.l.token_launcher.links.website.name),
+    get placeholder() {
+      return i18n.t(i18n.l.token_launcher.links.website.placeholder);
+    },
+    get displayName() {
+      return i18n.t(i18n.l.token_launcher.links.website.name);
+    },
     type: 'website',
   },
   other: {
@@ -92,8 +108,12 @@ export const LINK_SETTINGS = {
     ),
     iconBackgroundColor: '#000000',
     primaryColor: '#000000',
-    placeholder: i18n.t(i18n.l.token_launcher.links.other.placeholder),
-    displayName: i18n.t(i18n.l.token_launcher.links.other.name),
+    get placeholder() {
+      return i18n.t(i18n.l.token_launcher.links.other.placeholder);
+    },
+    get displayName() {
+      return i18n.t(i18n.l.token_launcher.links.other.name);
+    },
     type: 'other' as const,
   },
 } satisfies Record<

--- a/src/systems/funding/components/deposit/DepositTokenList.tsx
+++ b/src/systems/funding/components/deposit/DepositTokenList.tsx
@@ -44,7 +44,6 @@ type DepositTokenListProps = {
 // ============ Constants ====================================================== //
 
 const COIN_ROW_HEIGHT = 60;
-const allText = i18n.t(i18n.l.exchange.all_networks);
 
 // ============ Chain Selection ================================================ //
 
@@ -64,7 +63,7 @@ const ChainSelection = memo(function ChainSelection({ onChainSelected, selectedC
     }
   }, [accountColor, isDarkMode]);
 
-  const chainName = !selectedChainId ? allText : chainLabels[selectedChainId];
+  const chainName = !selectedChainId ? i18n.t(i18n.l.exchange.all_networks) : chainLabels[selectedChainId];
 
   const navigateToNetworkSelector = useCallback(() => {
     Keyboard.dismiss();


### PR DESCRIPTION
`i18n.t()` resolves against whatever locale is active when it runs, and the user's language is applied asynchronously at boot after being read from storage. Any translation evaluated at module scope therefore runs during bundle evaluation, before the app knows the language: it resolves against the English default and stays frozen there for the life of the process.

This change makes 145 of the 257 buggy sites resolve at the point of use rather than once at import. Two mechanical shapes cover all of them;
* a translated object property becomes a getter returning the same expression, and
* a standalone const is moved to where it's used

Cold starting in a non-English language should now render translated copy across ENS profile creation, transaction simulation cards, WalletConnect, gas, NFT menus, token launcher links, settings and backup, rewards, and speed-up/cancel.

Note that nothing here pushes a re-render when the language changes. But where a re-render does happen the copy now follows it, which it couldn't before: the tab navigator is already keyed on language, so an in-app switch remounts it and those screens come back translated, whereas previously remounting did nothing for a value frozen at module scope. Screens that stay mounted across a switch are still stale, and that's a _different_ issue to fix.

Also the remaining sites need different treatment and follow separately: most are read on the UI thread inside worklets where `i18n.t` can't run, and a few use translated copy as data identity or persist it.

Ref APP-3947.