### PR TITLE
fix(sentry): request failures counted as app crashes in release health

### DIFF
--- a/src/logger/logger.test.ts
+++ b/src/logger/logger.test.ts
@@ -10,7 +10,6 @@ jest.mock('@sentry/react-native', () => ({
   addBreadcrumb: jest.fn(),
   captureException: jest.fn(),
   captureMessage: jest.fn(),
-  httpClientIntegration: jest.fn(),
   Severity: {
     Debug: 'debug',
     Info: 'info',

--- a/src/logger/sentry.ts
+++ b/src/logger/sentry.ts
@@ -68,7 +68,17 @@ export const defaultOptions: Sentry.ReactNativeOptions = {
   enableAutoSessionTracking: true,
   environment: ENVIRONMENT,
   ignoreErrors: IGNORED_ERRORS,
-  integrations: [Sentry.httpClientIntegration()], // http client integration will help us see payload / response from errored out requests to better understand the issue
+
+  // Sentry's automatic HTTP failure capture, off deliberately. It reports every failed response
+  // as `handled: false`, which native session accounting reads as an app crash, so our
+  // dependencies' 5xx responses would depress crash-free rate and, on iOS, end the session and
+  // start a replacement, inflating session counts too. The events it produces also carry no
+  // operation, no attempt count and no app context.
+  //
+  // HTTP failures should be reported by the code that makes the request instead, where the
+  // operation and the response are actually known and can be classified properly.
+  enableCaptureFailedRequests: false,
+
   maxBreadcrumbs: 10,
   tracesSampleRate: 0,
 };


### PR DESCRIPTION
Sentry's automatic HTTP failure capture reports every failed response as `handled: false`, and Sentrys native session accounting reads that as an app crash. A request returning a 500 therefore marks the session crashed, and on iOS it also ends the session and starts a replacement. This means our crash-free rate has been measuring our API dependencies' health rather than ours, and iOS session counts are inflated by roughly one extra session per failed request.

Besides this quirk, the automatic HTTP fail capure also don't earn it's cost. With `sendDefaultPii` off they carry only the URL, the method and the status, so there is no operation, no attempt count and no app context. Every one is titled `Error: HTTP Client Error with status code: 500` and grouped on stack similarity, which is how all of them ended up muted.

This change turns the capture off. Going forward the pattern we should follow is that all HTTP failures should be reported by the code making the request, where the operation and the response are known and can be classified. When this merges we temporarily lose client-side visibility on a few endpoints that no first-party code currently logs, including `aha.rainbow.me`, the swap quote path, RPC through viem and ethers, and part of hyperliquid. Follow-up PRs will report those from our own code with operation, status and failure classification attached, which these events never carried in the first place (so we'll make it even better!)

Ref APP-3950.