### PR TITLE
chore(e2e): pin anvil via mise

### DIFF
--- a/.github/workflows/android-e2e.yml
+++ b/.github/workflows/android-e2e.yml
@@ -122,15 +122,10 @@ jobs:
           mv rainbow-env/dotenv .env
           rm -rf rainbow-env
 
-      - name: Install Maestro
+      - name: Install Maestro and Anvil
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
-          install_args: maestro
-
-      - name: Install Anvil
-        uses: foundry-rs/foundry-toolchain@c7450ba673e133f5ee30098b3b54f444d3a2ca2d # v1.8.0
-        with:
-          version: stable
+          install_args: maestro foundry
 
       - name: Download and Unpack APK artifact
         run: |

--- a/.github/workflows/ios-e2e.yml
+++ b/.github/workflows/ios-e2e.yml
@@ -85,15 +85,10 @@ jobs:
           mv rainbow-env/dotenv .env
           rm -rf rainbow-env
 
-      - name: Install Maestro
+      - name: Install Maestro and Anvil
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
-          install_args: maestro
-
-      - name: Install Anvil
-        uses: foundry-rs/foundry-toolchain@c7450ba673e133f5ee30098b3b54f444d3a2ca2d # v1.8.0
-        with:
-          version: stable
+          install_args: maestro foundry
 
       - name: Download and Unpack IPA artifact
         run: |

--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,6 @@
 [tools]
 maestro = "cli-2.7.0"
+foundry = "1.7.1"
 
 [settings]
 # Node and Ruby stay pinned in .node-version/.ruby-version so actions/setup-node


### PR DESCRIPTION
CI installs Anvil through the foundry-toolchain action with `version: stable`. The action is SHA-pinned so the block reads as pinned at a glance, but the binary it fetches is whatever the newest foundry release happens to be. A foundry release can therefore change how our tests behave between one develop run and the next.  It's also missing from local setup. `mise install` gives you Maestro but not anvil, so a fresh checkout can't run the transaction tests until you install foundry separately, and nothing keeps that version in step with CI.

This change moves anvil into `mise.toml` alongside Maestro, following #7511, so a single pin covers CI and local and `mise install` is enough to run the suite. 

`1.7.1` is what `stable` resolves to today, so no behaviour change expected, and it drops an action from our supply chain. `install_args` names both tools rather than installing everything in the config, since we enable idiomatic version files for node and ruby and a bare `miseinstall` would pull those in and collide with `actions/setup-node`.

Ref APP-3954