### PR TITLE
refactor(e2e): move test wallet funding out of the app

### DIFF
--- a/e2e/flows/transactions/EditContact.yaml
+++ b/e2e/flows/transactions/EditContact.yaml
@@ -11,10 +11,6 @@ tags:
 - runFlow: ../../utils/Prepare.yaml
 - runFlow: ../../utils/ImportWalletWithKey.yaml
 
-# Send ETH to test wallet
-- tapOn:
-    id: fund-test-wallet-button
-
 # Connect to Anvil (test network)
 - tapOn:
     id: dev-button-anvil

--- a/e2e/flows/transactions/SendNft.yaml
+++ b/e2e/flows/transactions/SendNft.yaml
@@ -11,10 +11,6 @@ tags:
 - runFlow: ../../utils/Prepare.yaml
 - runFlow: ../../utils/ImportWalletWithKey.yaml
 
-# Send ETH to test wallet
-- tapOn:
-    id: fund-test-wallet-button
-
 # Connect to Anvil (test network)
 - tapOn:
     id: dev-button-anvil

--- a/e2e/flows/transactions/SendTransaction.yaml
+++ b/e2e/flows/transactions/SendTransaction.yaml
@@ -11,10 +11,6 @@ tags:
 - runFlow: ../../utils/Prepare.yaml
 - runFlow: ../../utils/ImportWalletWithKey.yaml
 
-# Send ETH to test wallet
-- tapOn:
-    id: fund-test-wallet-button
-
 # Connect to Anvil (test network)
 - tapOn:
     id: dev-button-anvil

--- a/e2e/flows/transactions/SwapERC20Transaction.yaml.disabled
+++ b/e2e/flows/transactions/SwapERC20Transaction.yaml.disabled
@@ -11,10 +11,6 @@ tags:
 - runFlow: ../../utils/Prepare.yaml
 - runFlow: ../../utils/ImportWalletWithKey.yaml
 
-# Send ETH to test wallet
-- tapOn:
-    id: fund-test-wallet-button
-
 # Connect to Anvil (test network)
 - tapOn:
     id: dev-button-anvil

--- a/e2e/flows/transactions/SwapTransaction.yaml
+++ b/e2e/flows/transactions/SwapTransaction.yaml
@@ -18,10 +18,6 @@ tags:
 - runFlow: ../../utils/Prepare.yaml
 - runFlow: ../../utils/ImportWalletWithKey.yaml
 
-# Send ETH to test wallet
-- tapOn:
-    id: fund-test-wallet-button
-
 # Connect to Anvil (test network)
 - tapOn:
     id: dev-button-anvil

--- a/e2e/flows/transactions/WrapTransaction.yaml
+++ b/e2e/flows/transactions/WrapTransaction.yaml
@@ -18,10 +18,6 @@ tags:
 - runFlow: ../../utils/Prepare.yaml
 - runFlow: ../../utils/ImportWalletWithKey.yaml
 
-# Send ETH to test wallet
-- tapOn:
-    id: fund-test-wallet-button
-
 # Connect to Anvil (test network)
 - tapOn:
     id: dev-button-anvil

--- a/scripts/e2e-run.sh
+++ b/scripts/e2e-run.sh
@@ -6,6 +6,8 @@ source .env
 ARTIFACTS_FOLDER=e2e-artifacts
 RESULTS_FOLDER=e2e-results
 FLOW="e2e/flows"
+ANVIL_RPC="http://127.0.0.1:8545"
+TEST_WALLET_BALANCE_WEI="0x1158e460913d00000" # 20 ETH
 ARGS=()
 SHARD_TOTAL=1
 SHARD_INDEX=0
@@ -206,7 +208,28 @@ if $NEEDS_ANVIL; then
   mkdir -p "$ARTIFACTS_FOLDER/anvil"
   ./scripts/anvil.sh --host 0.0.0.0 > "$ARTIFACTS_FOLDER/anvil/mainnet.log" 2>&1 &
   ANVIL_PID=$!
-  sleep 5
+
+  # Wait for the chain to answer rather than assuming it is up, since funding below
+  # depends on it. A fork can take a while to hydrate on a cold RPC cache.
+  ANVIL_READY=false
+  for _ in $(seq 1 60); do
+    if cast block-number --rpc-url "$ANVIL_RPC" > /dev/null 2>&1; then
+      ANVIL_READY=true
+      break
+    fi
+    sleep 1
+  done
+  if ! $ANVIL_READY; then
+    echo "❌ Anvil did not become ready. See $ARTIFACTS_FOLDER/anvil/mainnet.log"
+    exit 1
+  fi
+
+  # Fund the wallet the tests import. Derive the address from the key rather than
+  # hardcoding it, so changing the key cannot fund the wrong account and leave every
+  # transaction test failing on insufficient funds, several steps from the cause.
+  TEST_WALLET_ADDRESS=$(cast wallet address --private-key "$DEV_PKEY")
+  cast rpc anvil_setBalance "$TEST_WALLET_ADDRESS" "$TEST_WALLET_BALANCE_WEI" --rpc-url "$ANVIL_RPC" > /dev/null
+  echo "💰 Funded $TEST_WALLET_ADDRESS with $(cast to-unit "$TEST_WALLET_BALANCE_WEI" ether) ETH"
 fi
 
 # Run tests with retries.

--- a/src/helpers/RainbowContext.tsx
+++ b/src/helpers/RainbowContext.tsx
@@ -1,9 +1,5 @@
 import React, { createContext, useCallback, useEffect, useMemo, useState, type PropsWithChildren } from 'react';
-import { Platform } from 'react-native';
 
-import { JsonRpcProvider } from '@ethersproject/providers';
-import { parseEther } from '@ethersproject/units';
-import { Wallet } from '@ethersproject/wallet';
 import { useSharedValue } from 'react-native-reanimated';
 
 import { IS_DEV, IS_TEST } from '@/env';
@@ -70,37 +66,14 @@ export default function RainbowContextWrapper({ children }: PropsWithChildren) {
     Navigation.handleAction(Routes.WALLET_SCREEN);
   }, [setConnectedToAnvil]);
 
-  const fundTestWallet = useCallback(async () => {
-    if (!IS_TEST) return;
-    const RPC_URL = Platform.OS === 'android' ? 'http://10.0.2.2:8545' : 'http://127.0.0.1:8545';
-    try {
-      const provider = new JsonRpcProvider(RPC_URL);
-      const wallet = new Wallet('0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80', provider);
-      const testWalletAddress = '0x4d14289265eb7c166cF111A76B6D742e3b85dF85';
-      await wallet.sendTransaction({
-        to: testWalletAddress,
-        value: parseEther('20'),
-      });
-    } catch (e) {
-      logger.error(new RainbowError('error funding test wallet'), {
-        message: e instanceof Error ? e.message : String(e),
-      });
-    }
-  }, []);
-
   return (
     <RainbowContext.Provider value={initialValue}>
       {children}
       {showReloadButton && IS_DEV && <DevButton color={colors.red} initialDisplacement={200} />}
       {((showConnectToAnvilButton && IS_DEV) || IS_TEST) && (
-        <>
-          <DevButton color={colors.purple} onPress={connectToAnvil} initialDisplacement={150} testID={'dev-button-anvil'} size={20}>
-            <Emoji>👷</Emoji>
-          </DevButton>
-          <DevButton color={colors.green} onPress={fundTestWallet} initialDisplacement={100} testID={'fund-test-wallet-button'} size={20}>
-            <Emoji>💰</Emoji>
-          </DevButton>
-        </>
+        <DevButton color={colors.purple} onPress={connectToAnvil} initialDisplacement={150} testID={'dev-button-anvil'} size={20}>
+          <Emoji>👷</Emoji>
+        </DevButton>
       )}
       {showSwitchModeButton && IS_DEV && (
         <DevButton color={colors.dark} onPress={() => setTheme(isDarkMode ? 'light' : 'dark')}>


### PR DESCRIPTION
The app ships a callback and a floating dev button whose only job is to give the imported wallet ETH on our local chain during e2e. The transaction flows tap that button as a step, so funding the chain is a UI interaction that can miss; when it does the test carries on and fails several steps later on insufficient funds, nowhere near the cause. Its recipient is a hardcoded address too, free to drift from the key the flows actually import. The button is no use outside e2e either. It renders in a dev build behind a debug flag but returns early unless `IS_TEST`, and the local chains are only added to the network list under `IS_TEST`, so a dev build has nothing to fund.

This change moves funding into the test runner, which derives the address from the key the flows import and sets the balance over local RPC before any test starts. The app no longer knows a test wallet exists, and those flows lose a step. Same address and same amount as today, so results should be unchanged; the difference is that the wallet is funded before the app launches rather than partway through each flow.

The runner also waits for the chain to answer rather than sleeping and hoping, since funding depends on it being up. It uses `cast` for the first time, which ships alongside `anvil` under either install path, and #7708 pins that toolchain.
