### PR TITLE
fix(e2e): run summary looks complete when a shard reports nothing

### DIFF
--- a/.github/workflows/android-e2e.yml
+++ b/.github/workflows/android-e2e.yml
@@ -10,6 +10,7 @@ permissions: {}
 
 env:
   PR_NUMBER: ${{ github.event.pull_request.number }}
+  SHARD_TOTAL: 4
 
 jobs:
   build:
@@ -94,7 +95,6 @@ jobs:
       cancel-in-progress: false
 
     env:
-      SHARD_TOTAL: 4
       SHARD_INDEX: ${{ matrix.shard-index }}
       ANDROID_EMULATOR_API_LEVEL: 31
       ANDROID_EMULATOR_PROFILE: pixel_6
@@ -206,7 +206,7 @@ jobs:
           path: e2e-results
 
       - name: Render summary
-        run: node tools/e2e-summary/index.ts e2e-results
+        run: node tools/e2e-summary/index.ts e2e-results "$SHARD_TOTAL"
 
   perf-tests:
     name: Perf Tests

--- a/.github/workflows/ios-e2e.yml
+++ b/.github/workflows/ios-e2e.yml
@@ -9,6 +9,7 @@ permissions: {}
 
 env:
   NODE_OPTIONS: '--max-old-space-size=6144'
+  SHARD_TOTAL: 4
 
 jobs:
   # iOS build job
@@ -63,7 +64,6 @@ jobs:
       cancel-in-progress: false
     timeout-minutes: 30
     env:
-      SHARD_TOTAL: 4
       SHARD_INDEX: ${{ matrix.shard-index }}
       ARTIFACTS_FOLDER: e2e-artifacts
       RESULTS_FOLDER: e2e-results
@@ -158,7 +158,7 @@ jobs:
           path: e2e-results
 
       - name: Render summary
-        run: node tools/e2e-summary/index.ts e2e-results
+        run: node tools/e2e-summary/index.ts e2e-results "$SHARD_TOTAL"
 
   notify-failure:
     name: Notify Slack on failure

--- a/scripts/e2e-run.sh
+++ b/scripts/e2e-run.sh
@@ -163,6 +163,11 @@ record_planned() {
 rm -rf "$ARTIFACTS_FOLDER" "$RESULTS_FOLDER"
 mkdir -p "$RESULTS_FOLDER"
 
+# Created before anything can go wrong, so that a missing ledger means the shard
+# never got this far rather than that it had nothing to say. The summary reports
+# on that difference.
+: > "$RESULTS_FILE"
+
 # Handle test discovery and sharding.
 if [[ -f "$FLOW" ]]; then
   echo "🧪 Running single test file: $FLOW"

--- a/tools/e2e-summary/__snapshots__/index.test.ts.snap
+++ b/tools/e2e-summary/__snapshots__/index.test.ts.snap
@@ -49,3 +49,44 @@ exports[`rendering sorts failures and retries above passes, merging every shard 
 
 "
 `;
+
+exports[`shards that never reported lists every missing shard when more than one is gone 1`] = `
+"**3 did not report · 1 passed**
+
+> [!WARNING]
+> Shards 1, 3, 4 uploaded nothing, so their tests are missing from this table entirely.
+
+|  | Test | Shard | Attempts | Time |
+| :-- | :-- | --: | --: | --: |
+| ❓ | _no results uploaded_ | 1 |  |  |
+| ❓ | _no results uploaded_ | 3 |  |  |
+| ❓ | _no results uploaded_ | 4 |  |  |
+| ✅ | \`screens/Home\` | 2 | 1 | 1m 14s |
+
+"
+`;
+
+exports[`shards that never reported names the shard whose ledger never arrived, and warns the table is partial 1`] = `
+"**1 did not report · 2 passed**
+
+> [!WARNING]
+> Shard 3 uploaded nothing, so its tests are missing from this table entirely.
+
+|  | Test | Shard | Attempts | Time |
+| :-- | :-- | --: | --: | --: |
+| ❓ | _no results uploaded_ | 3 |  |  |
+| ✅ | \`cash/SetupResume\` | 2 | 1 | 1m 31s |
+| ✅ | \`screens/Home\` | 1 | 1 | 1m 14s |
+
+"
+`;
+
+exports[`shards that never reported treats an empty ledger as having reported, since the shard wrote it before running anything 1`] = `
+"**1 passed**
+
+|  | Test | Shard | Attempts | Time |
+| :-- | :-- | --: | --: | --: |
+| ✅ | \`screens/Home\` | 1 | 1 | 1m 14s |
+
+"
+`;

--- a/tools/e2e-summary/index.test.ts
+++ b/tools/e2e-summary/index.test.ts
@@ -59,6 +59,41 @@ describe('rendering', () => {
   });
 });
 
+describe('shards that never reported', () => {
+  it('names the shard whose ledger never arrived, and warns the table is partial', () => {
+    const dir = ledgers({
+      'shard-1.jsonl': [row('screens/Home', 'passed', { attempts: 1, duration: 74 })],
+      'shard-2.jsonl': [row('cash/SetupResume', 'passed', { shard: 2, attempts: 1, duration: 91 })],
+    });
+    expect(run([dir, '3']).stdout).toMatchSnapshot();
+  });
+
+  it('lists every missing shard when more than one is gone', () => {
+    const dir = ledgers({ 'shard-2.jsonl': [row('screens/Home', 'passed', { shard: 2, attempts: 1, duration: 74 })] });
+    expect(run([dir, '4']).stdout).toMatchSnapshot();
+  });
+
+  it('treats an empty ledger as having reported, since the shard wrote it before running anything', () => {
+    const dir = ledgers({ 'shard-1.jsonl': [row('screens/Home', 'passed', { attempts: 1, duration: 74 })], 'shard-2.jsonl': [] });
+    const result = run([dir, '2']);
+    expect(result.stdout).not.toContain('did not report');
+    expect(result.stdout).toMatchSnapshot();
+  });
+
+  it('checks nothing when no shard count is given, so local single runs are unaffected', () => {
+    const dir = ledgers({ 'shard-1.jsonl': [row('screens/Home', 'passed', { attempts: 1, duration: 74 })] });
+    expect(run([dir]).stdout).not.toContain('did not report');
+  });
+
+  it('still reports the shards it does have when the count is wrong in the other direction', () => {
+    const dir = ledgers({
+      'shard-1.jsonl': [row('screens/Home', 'passed', { attempts: 1, duration: 74 })],
+      'shard-9.jsonl': [row('cash/SetupResume', 'passed', { shard: 9, attempts: 1, duration: 91 })],
+    });
+    expect(run([dir, '1']).stdout).toContain('cash/SetupResume');
+  });
+});
+
 describe('reporting is never fatal', () => {
   it('exits 0 and explains itself when the results directory is missing', () => {
     const result = run([join(tmpdir(), 'summary-does-not-exist')]);
@@ -79,7 +114,13 @@ describe('being called wrong is fatal', () => {
   it('exits non-zero with usage when no results directory is given', () => {
     const result = run([]);
     expect(result.status).toBe(1);
-    expect(result.stderr).toContain('usage: node tools/e2e-summary/index.ts <resultsDir>');
+    expect(result.stderr).toContain('usage: node tools/e2e-summary/index.ts <resultsDir> [expectedShards]');
+  });
+
+  it('exits non-zero when the shard count is not a number', () => {
+    const result = run([ledgers({}), 'four']);
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('expectedShards must be a non-negative integer');
   });
 });
 

--- a/tools/e2e-summary/index.ts
+++ b/tools/e2e-summary/index.ts
@@ -2,16 +2,21 @@
  * Renders the per-shard e2e ledgers written by `scripts/e2e-run.sh` into a
  * single markdown table for `$GITHUB_STEP_SUMMARY`.
  *
- * Usage: node tools/e2e-summary/index.ts <resultsDir>
+ * Usage: node tools/e2e-summary/index.ts <resultsDir> [expectedShards]
  */
-import { appendFileSync, readdirSync, readFileSync } from 'node:fs';
+import { appendFileSync, existsSync, readdirSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
-// Most severe first: this order is the table's sort order, the headline's order,
-// and the whitelist for statuses read off disk.
-const ORDER = ['failed', 'planned', 'retried', 'passed'] as const;
+// Most severe first: this order is the table's sort order and the headline's
+// order. `unreported` leads because it says the rest of the table is incomplete,
+// which has to be read before anything in it.
+const ORDER = ['unreported', 'failed', 'planned', 'retried', 'passed'] as const;
 
 type Status = (typeof ORDER)[number];
+
+// Everything a shard can write about a test. `unreported` is ours, synthesized
+// for a shard that wrote nothing, so it is deliberately not readable off disk.
+const REPORTABLE = ORDER.filter((status): status is Exclude<Status, 'unreported'> => status !== 'unreported');
 
 type Row = {
   status: Status;
@@ -21,15 +26,37 @@ type Row = {
   duration: number | null;
 };
 
-const EMOJI: Record<Status, string> = { failed: '❌', planned: '🚫', retried: '⚠️', passed: '✅' };
-const LABEL: Record<Status, string> = { failed: 'failed', planned: 'did not run', retried: 'retried', passed: 'passed' };
+const EMOJI: Record<Status, string> = { unreported: '❓', failed: '❌', planned: '🚫', retried: '⚠️', passed: '✅' };
+const LABEL: Record<Status, string> = {
+  unreported: 'did not report',
+  failed: 'failed',
+  planned: 'did not run',
+  retried: 'retried',
+  passed: 'passed',
+};
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null;
 }
 
 function isStatus(value: unknown): value is Status {
-  return ORDER.some(status => status === value);
+  return REPORTABLE.some(status => status === value);
+}
+
+function ledgerName(shard: number): string {
+  return `shard-${shard}.jsonl`;
+}
+
+// A shard writes its ledger before running anything, so an absent file means the
+// runner died before the script started or the upload found nothing. Either way
+// that shard's tests are missing from the table entirely, and without this the
+// table looks complete.
+function unreportedShards(dir: string, expected: number): number[] {
+  const shards = [];
+  for (let shard = 1; shard <= expected; shard++) {
+    if (!existsSync(join(dir, ledgerName(shard)))) shards.push(shard);
+  }
+  return shards;
 }
 
 function readLedgers(dir: string): Record<string, unknown>[] {
@@ -54,7 +81,7 @@ function readLedgers(dir: string): Record<string, unknown>[] {
 // Ledger rows are uniform and append-only, so the last row for a test wins. One
 // still reading "planned" was never superseded by a finished row, which is what a
 // test that never ran looks like.
-function toRows(records: Record<string, unknown>[]): Row[] {
+function toRows(records: Record<string, unknown>[], unreported: number[]): Row[] {
   const rows = new Map<string, Row>();
 
   for (const record of records) {
@@ -68,7 +95,15 @@ function toRows(records: Record<string, unknown>[]): Row[] {
     });
   }
 
-  return [...rows.values()].sort((a, b) => ORDER.indexOf(a.status) - ORDER.indexOf(b.status) || a.test.localeCompare(b.test));
+  for (const shard of unreported) {
+    rows.set(ledgerName(shard), { status: 'unreported', test: '_no results uploaded_', shard, attempts: null, duration: null });
+  }
+
+  // Test names are unique, so the shard tiebreak only ever orders the synthesized
+  // rows, which all carry the same text.
+  return [...rows.values()].sort(
+    (a, b) => ORDER.indexOf(a.status) - ORDER.indexOf(b.status) || a.test.localeCompare(b.test) || a.shard - b.shard
+  );
 }
 
 function formatDuration(seconds: number): string {
@@ -76,7 +111,7 @@ function formatDuration(seconds: number): string {
   return `${Math.floor(seconds / 60)}m ${String(seconds % 60).padStart(2, '0')}s`;
 }
 
-function render(rows: Row[]): string {
+function render(rows: Row[], unreported: number[]): string {
   if (rows.length === 0) {
     return 'No e2e results were reported. Look into the shard jobs instead.\n';
   }
@@ -92,7 +127,7 @@ function render(rows: Row[]): string {
     ...rows.map(row => {
       const cells = [
         EMOJI[row.status],
-        `\`${row.test}\``,
+        row.status === 'unreported' ? row.test : `\`${row.test}\``,
         String(row.shard),
         row.attempts === null ? '' : String(row.attempts),
         row.duration === null ? '' : formatDuration(row.duration),
@@ -101,20 +136,32 @@ function render(rows: Row[]): string {
     }),
   ];
 
-  return `**${headline}**\n\n${table.join('\n')}\n`;
+  const caveat =
+    unreported.length === 0
+      ? ''
+      : `> [!WARNING]\n> ${unreported.length === 1 ? `Shard ${unreported[0]} uploaded nothing, so its tests are` : `Shards ${unreported.join(', ')} uploaded nothing, so their tests are`} missing from this table entirely.\n\n`;
+
+  return `**${headline}**\n\n${caveat}${table.join('\n')}\n`;
 }
 
 function main(): void {
-  const dir = process.argv[2];
+  const [, , dir, expectedShards] = process.argv;
   if (!dir) {
-    console.error('usage: node tools/e2e-summary/index.ts <resultsDir>');
+    console.error('usage: node tools/e2e-summary/index.ts <resultsDir> [expectedShards]');
+    process.exit(1);
+  }
+
+  const expected = Number(expectedShards ?? 0);
+  if (!Number.isInteger(expected) || expected < 0) {
+    console.error(`expectedShards must be a non-negative integer, got: ${expectedShards}`);
     process.exit(1);
   }
 
   let markdown: string;
 
   try {
-    markdown = render(toRows(readLedgers(dir)));
+    const unreported = unreportedShards(dir, expected);
+    markdown = render(toRows(readLedgers(dir), unreported), unreported);
   } catch (error) {
     markdown = `Could not render the e2e summary: \`${error instanceof Error ? error.message : String(error)}\`\n`;
     console.error(error);


### PR DESCRIPTION
The run summary we added in #7704 renders whatever per-shard ledgers turn up and has no idea how many shards were expected. So a shard that dies before writing its ledger, or whose upload finds nothing and warns rather than failing, leaves a table that covers three shards as though three were the suite: complete-looking and all-green while the run is red. Whoever opens the artifact we tell them to look at gets a cleaner story than the truth. This is not the case the pre-written `planned` rows already handle. A shard that dies mid-run leaves its unfinished tests reading "did not run", which is exactly right. This is the gap on the other side of it, where the ledger never existed, so those tests appear nowhere at all.

WIth this change renderer now knows how many shards to expect, names the ones missing from the download, and warns above the table that it isn't the whole run. Each shard also writes its ledger before it can fail at anything, so an absent file means the shard never got started rather than that it had nothing to say; a shard that legitimately selects no tests now reports an empty ledger instead of reading as missing. The shard count moved up to workflow level so the results job reads the same count the matrix uses.

Exit codes are unchanged. The run is already red from the failed shard job; the point is that the summary shouldn't quietly disagree with it.

Ref APP-3954.