### PR TITLE
feat(cash): Add status half modals

### DIFF
--- a/e2e/flows/cash/Setup.yaml
+++ b/e2e/flows/cash/Setup.yaml
@@ -83,9 +83,15 @@ tags:
     text: 'Review your information'
 - assertVisible:
     text: 'Ada Lovelace'
-# Confirm submits KYC; the mock approves after ~1s, then the repeat loop walks the placeholder steps.
+# Confirm submits KYC; the mock approves after ~1s and the success sheet's Continue advances the flow.
 - tapOn:
     id: cash-setup-next
+- extendedWaitUntil:
+    visible:
+      id: cash-setup-kyc-success-continue
+    timeout: 10000
+- tapOn:
+    id: cash-setup-kyc-success-continue
 - extendedWaitUntil:
     visible:
       text: 'Add a Passkey'

--- a/src/features/cash/components/CashActionButton.tsx
+++ b/src/features/cash/components/CashActionButton.tsx
@@ -4,6 +4,7 @@ import { StyleSheet } from 'react-native';
 import ButtonPressAnimation from '@/components/animations/ButtonPressAnimation';
 import Spinner from '@/components/Spinner';
 import { Box, Text, useForegroundColor, type TextProps } from '@/design-system';
+import { opacity } from '@/framework/ui/utils/opacity';
 
 type CashActionButtonProps = {
   disabled?: boolean;
@@ -13,6 +14,7 @@ type CashActionButtonProps = {
   shadow?: boolean;
   testID: string;
   textSize?: TextProps['size'];
+  variant?: 'solid' | 'tinted' | 'plain';
 };
 
 export const CashActionButton = memo(function CashActionButton({
@@ -23,9 +25,11 @@ export const CashActionButton = memo(function CashActionButton({
   shadow = false,
   testID,
   textSize = '22pt',
+  variant = 'solid',
 }: CashActionButtonProps) {
   const blue = useForegroundColor('blue');
   const isDisabled = disabled || loading;
+  const textColor = variant === 'solid' ? 'white' : 'blue';
 
   return (
     <ButtonPressAnimation
@@ -38,17 +42,22 @@ export const CashActionButton = memo(function CashActionButton({
     >
       <Box
         alignItems="center"
-        background="blue"
+        background={variant === 'solid' ? 'blue' : undefined}
         borderRadius={24}
         height={{ custom: 48 }}
         justifyContent="center"
-        style={[shadow && styles.shadow, shadow && { shadowColor: blue }, isDisabled && styles.disabled]}
+        style={[
+          variant === 'tinted' && { backgroundColor: opacity(blue, 0.12), borderColor: opacity(blue, 0.04), borderWidth: 1.66 },
+          shadow && styles.shadow,
+          shadow && { shadowColor: blue },
+          isDisabled && styles.disabled,
+        ]}
         width="full"
       >
         {loading ? (
-          <Spinner color="white" size={24} />
+          <Spinner color={variant === 'solid' ? 'white' : blue} size={24} />
         ) : (
-          <Text align="center" color="white" size={textSize} weight="heavy">
+          <Text align="center" color={textColor} size={textSize} weight="heavy">
             {label}
           </Text>
         )}

--- a/src/features/cash/components/CashStatusHalfSheet.tsx
+++ b/src/features/cash/components/CashStatusHalfSheet.tsx
@@ -1,0 +1,124 @@
+import React, { memo } from 'react';
+import { StyleSheet, View } from 'react-native';
+
+import Animated, { Easing, FadeIn, FadeOut, LinearTransition, SlideInDown, SlideOutDown } from 'react-native-reanimated';
+
+import { AbsolutePortal } from '@/components/AbsolutePortal';
+import { PanelSheet } from '@/components/PanelSheet/PanelSheet';
+import { Box, Text } from '@/design-system';
+
+import { CashActionButton } from './CashActionButton';
+
+type HalfSheetAction = {
+  label: string;
+  onPress: () => void;
+  testID: string;
+};
+
+type CommonProps = {
+  description: string;
+  testID: string;
+  title: string;
+};
+
+type CashStatusHalfSheetProps = CommonProps &
+  (
+    | { status: 'inProgress' }
+    | { status: 'success'; action: HalfSheetAction; successIcon: string }
+    | { status: 'error'; primaryAction: HalfSheetAction; secondaryAction?: HalfSheetAction }
+  );
+
+const STATUS_ICONS = {
+  error: '􀁠',
+  inProgress: '􀖇',
+} as const;
+
+const STATUS_ICON_COLORS = {
+  error: 'red',
+  inProgress: 'blue',
+  success: 'green',
+} as const;
+
+const PANEL_ENTERING_ANIMATION = SlideInDown.springify().damping(70).mass(0.8).stiffness(500);
+const PANEL_EXITING_ANIMATION = SlideOutDown.springify().damping(70).mass(0.8).stiffness(500);
+const PANEL_RESIZE_ANIMATION = LinearTransition.duration(200).easing(Easing.inOut(Easing.ease));
+
+export const CashStatusHalfSheet = memo(function CashStatusHalfSheet(props: CashStatusHalfSheetProps) {
+  const icon = props.status === 'success' ? props.successIcon : STATUS_ICONS[props.status];
+  const iconColor = STATUS_ICON_COLORS[props.status];
+
+  return (
+    <AbsolutePortal>
+      <View accessibilityViewIsModal style={styles.overlay} testID={`${props.testID}-overlay`}>
+        <Animated.View entering={FadeIn.duration(200)} exiting={FadeOut.duration(200)} style={styles.backdrop} />
+        <Animated.View entering={PANEL_ENTERING_ANIMATION} exiting={PANEL_EXITING_ANIMATION} style={styles.panelHost}>
+          <PanelSheet handleProps={{ showBlur: false, top: 8 }} layoutAnimation={PANEL_RESIZE_ANIMATION} showTapToDismiss={false}>
+            <Animated.View entering={FadeIn.duration(160)} exiting={FadeOut.duration(160)} key={props.status}>
+              <Box paddingBottom={props.status === 'inProgress' ? '32px' : '20px'} paddingHorizontal="32px" paddingTop="52px">
+                <Box height={{ custom: 64 }} justifyContent="center">
+                  <Text color={iconColor} size="44pt" style={[styles.icon, props.status === 'error' && styles.errorIcon]} weight="heavy">
+                    {icon}
+                  </Text>
+                </Box>
+
+                <Box gap={24} paddingTop="32px">
+                  <Text color="label" size="26pt" weight="heavy">
+                    {props.title}
+                  </Text>
+                  <Text color="labelQuaternary" size="17pt / 135%" weight="bold">
+                    {props.description}
+                  </Text>
+                </Box>
+
+                {props.status === 'success' && (
+                  <Box paddingTop="32px">
+                    <CashActionButton label={props.action.label} onPress={props.action.onPress} shadow testID={props.action.testID} />
+                  </Box>
+                )}
+
+                {props.status === 'error' && (
+                  <Box gap={16} paddingTop="32px">
+                    <CashActionButton
+                      label={props.primaryAction.label}
+                      onPress={props.primaryAction.onPress}
+                      testID={props.primaryAction.testID}
+                      variant="tinted"
+                    />
+                    {props.secondaryAction && (
+                      <CashActionButton
+                        label={props.secondaryAction.label}
+                        onPress={props.secondaryAction.onPress}
+                        testID={props.secondaryAction.testID}
+                        variant="plain"
+                      />
+                    )}
+                  </Box>
+                )}
+              </Box>
+            </Animated.View>
+          </PanelSheet>
+        </Animated.View>
+      </View>
+    </AbsolutePortal>
+  );
+});
+
+const styles = StyleSheet.create({
+  backdrop: {
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: 'rgba(0, 0, 0, 0.44)',
+  },
+  errorIcon: {
+    fontSize: 46,
+  },
+  icon: {
+    fontSize: 54,
+    lineHeight: 64,
+  },
+  overlay: {
+    ...StyleSheet.absoluteFillObject,
+  },
+  panelHost: {
+    ...StyleSheet.absoluteFillObject,
+  },
+});

--- a/src/features/cash/screens/cash-deposit-setup/CashDepositSetupScreen.tsx
+++ b/src/features/cash/screens/cash-deposit-setup/CashDepositSetupScreen.tsx
@@ -4,6 +4,7 @@ import { StyleSheet } from 'react-native';
 import { useRoute, type RouteProp } from '@react-navigation/native';
 import { useListen } from '@storesjs/stores';
 
+import { AbsolutePortalRoot } from '@/components/AbsolutePortal';
 import { SPRING_CONFIGS } from '@/components/animations/animationConfigs';
 import { SmoothPager, usePagerNavigation } from '@/components/SmoothPager/SmoothPager';
 import { Box } from '@/design-system';
@@ -25,6 +26,8 @@ import { PasskeyStep } from './steps/PasskeyStep';
 import { PhoneStep } from './steps/PhoneStep';
 import { ReviewStep } from './steps/ReviewStep';
 import { SsnStep } from './steps/SsnStep';
+import { useAddPasskeyFlowStore } from './steps/useAddPasskeyFlow';
+import { useSubmitKycFlowStore } from './steps/useSubmitKycFlow';
 import { useSubmitPhoneFlowStore } from './steps/useSubmitPhoneFlow';
 
 const STEP_COMPONENTS: Record<CashDepositSetupRoute, React.ReactElement> = {
@@ -61,6 +64,8 @@ export const CashDepositSetupScreen = memo(function CashDepositSetupScreen() {
   useCleanup(() => {
     CashDepositSetupNavigation.resetNavigationState();
     useSubmitPhoneFlowStore.getState().reset();
+    useSubmitKycFlowStore.getState().reset();
+    useAddPasskeyFlowStore.getState().reset();
   });
 
   return (
@@ -84,6 +89,7 @@ export const CashDepositSetupScreen = memo(function CashDepositSetupScreen() {
           ))}
         </SmoothPager>
       ))}
+      <AbsolutePortalRoot />
     </Box>
   );
 });

--- a/src/features/cash/screens/cash-deposit-setup/steps/CardDetailsStep.tsx
+++ b/src/features/cash/screens/cash-deposit-setup/steps/CardDetailsStep.tsx
@@ -1,8 +1,10 @@
-import React, { memo, useEffect } from 'react';
+import React, { memo, useCallback, useEffect } from 'react';
+import { Keyboard } from 'react-native';
 
 import { BivoCardInput, BivoCVCInput, BivoTextInput } from '@bivoglobal/payment-react-native';
 
-import { Box, Text } from '@/design-system';
+import { Box } from '@/design-system';
+import { CashStatusHalfSheet } from '@/features/cash/components/CashStatusHalfSheet';
 import * as i18n from '@/languages';
 
 import { SetupStepLayout } from '../components/SetupStepLayout';
@@ -13,8 +15,8 @@ import { CARD_FIELD, useCardLinkFlow } from './useCardLinkFlow';
 const l = i18n.l.cash.deposit_setup.card_details;
 
 export const CardDetailsStep = memo(function CardLinkForm() {
-  const { state, bivoStore, isReady, onFieldStateChange, submit, retry } = useCardLinkFlow();
-  const { next } = useCashDepositSetupNavigation();
+  const { state, bivoStore, isReady, onFieldStateChange, reset, submit } = useCardLinkFlow();
+  const { next, back } = useCashDepositSetupNavigation();
   const textStyle = useSetupInputTextStyle();
 
   useEffect(() => {
@@ -23,62 +25,74 @@ export const CardDetailsStep = memo(function CardLinkForm() {
     }
   }, [next, state]);
 
-  if (state === 'submitError') {
-    return (
-      <SetupStepLayout actionLabel={i18n.t(l.try_again)} onAction={retry} title={i18n.t(l.title)}>
-        <Box paddingTop="24px">
-          <Text color="red" size="17pt" weight="semibold">
-            {i18n.t(l.submit_error)}
-          </Text>
-        </Box>
-      </SetupStepLayout>
-    );
-  }
-
   const submitting = state === 'submitting';
+  const cancel = useCallback(() => {
+    reset();
+    back();
+  }, [back, reset]);
+
+  // The number pads have no Done key, so an open keyboard would cover the status sheet with no way to close it.
+  const onSubmit = useCallback(() => {
+    Keyboard.dismiss();
+    submit();
+  }, [submit]);
 
   return (
-    <SetupStepLayout
-      actionDisabled={!isReady}
-      actionLoading={submitting}
-      backDisabled={submitting}
-      onAction={submit}
-      title={i18n.t(l.title)}
-    >
-      <Box paddingTop="24px">
-        <BivoCardInput
-          bivoStore={bivoStore}
-          fieldName={CARD_FIELD.number}
-          onStateChange={onFieldStateChange}
-          placeholder={i18n.t(l.card_number)}
-          textStyle={textStyle}
-        />
-        <Box flexDirection="row" gap={12}>
-          <BivoTextInput
+    <>
+      <SetupStepLayout actionDisabled={!isReady} backDisabled={submitting} onAction={onSubmit} title={i18n.t(l.title)}>
+        <Box paddingTop="24px">
+          <BivoCardInput
             bivoStore={bivoStore}
-            containerStyle={{ flex: 1 }}
-            fieldName={CARD_FIELD.expiry}
+            fieldName={CARD_FIELD.number}
             onStateChange={onFieldStateChange}
-            placeholder={i18n.t(l.expiry)}
+            placeholder={i18n.t(l.card_number)}
             textStyle={textStyle}
           />
-          <BivoCVCInput
+          <Box flexDirection="row" gap={12}>
+            <BivoTextInput
+              bivoStore={bivoStore}
+              containerStyle={{ flex: 1 }}
+              fieldName={CARD_FIELD.expiry}
+              onStateChange={onFieldStateChange}
+              placeholder={i18n.t(l.expiry)}
+              textStyle={textStyle}
+            />
+            <BivoCVCInput
+              bivoStore={bivoStore}
+              containerStyle={{ flex: 1 }}
+              fieldName={CARD_FIELD.cvc}
+              onStateChange={onFieldStateChange}
+              placeholder={i18n.t(l.cvc)}
+              textStyle={textStyle}
+            />
+          </Box>
+          <BivoTextInput
             bivoStore={bivoStore}
-            containerStyle={{ flex: 1 }}
-            fieldName={CARD_FIELD.cvc}
+            fieldName={CARD_FIELD.zip}
             onStateChange={onFieldStateChange}
-            placeholder={i18n.t(l.cvc)}
+            placeholder={i18n.t(l.zip)}
             textStyle={textStyle}
           />
         </Box>
-        <BivoTextInput
-          bivoStore={bivoStore}
-          fieldName={CARD_FIELD.zip}
-          onStateChange={onFieldStateChange}
-          placeholder={i18n.t(l.zip)}
-          textStyle={textStyle}
+      </SetupStepLayout>
+
+      {state === 'submitting' ? (
+        <CashStatusHalfSheet
+          description={i18n.t(l.adding_description)}
+          status="inProgress"
+          testID="cash-setup-card-adding"
+          title={i18n.t(l.adding_title)}
         />
-      </Box>
-    </SetupStepLayout>
+      ) : state === 'submitError' ? (
+        <CashStatusHalfSheet
+          description={i18n.t(l.error_description)}
+          primaryAction={{ label: i18n.t(l.edit_details), onPress: reset, testID: 'cash-setup-card-error-edit' }}
+          secondaryAction={{ label: i18n.t(i18n.l.button.cancel), onPress: cancel, testID: 'cash-setup-card-error-cancel' }}
+          status="error"
+          testID="cash-setup-card-error"
+          title={i18n.t(l.error_title)}
+        />
+      ) : null}
+    </>
   );
 });

--- a/src/features/cash/screens/cash-deposit-setup/steps/PasskeyStep.tsx
+++ b/src/features/cash/screens/cash-deposit-setup/steps/PasskeyStep.tsx
@@ -2,6 +2,7 @@ import React, { memo } from 'react';
 import { StyleSheet } from 'react-native';
 
 import { Box, Text } from '@/design-system';
+import { CashStatusHalfSheet } from '@/features/cash/components/CashStatusHalfSheet';
 import * as i18n from '@/languages';
 
 import { SetupStepLayout } from '../components/SetupStepLayout';
@@ -12,23 +13,37 @@ const l = i18n.l.cash.deposit_setup.passkey;
 const KEY_ICON = '􀟖';
 
 export const PasskeyStep = memo(function PasskeyStep() {
-  const { submitting, submit } = useAddPasskeyFlow();
+  const { reset, state, submit } = useAddPasskeyFlow();
+  const submitting = state === 'submitting';
 
   return (
-    <SetupStepLayout
-      actionLabel={i18n.t(l.action)}
-      actionLoading={submitting}
-      backDisabled={submitting}
-      onAction={submit}
-      subtitle={i18n.t(l.subtitle)}
-      title={i18n.t(l.title)}
-    >
-      <Box alignItems="center" height="full" justifyContent="center">
-        <Text align="center" color="blue" size="44pt" style={styles.keyIcon} weight="heavy">
-          {KEY_ICON}
-        </Text>
-      </Box>
-    </SetupStepLayout>
+    <>
+      <SetupStepLayout
+        actionLabel={i18n.t(l.action)}
+        actionLoading={submitting}
+        backDisabled={submitting}
+        onAction={submit}
+        subtitle={i18n.t(l.subtitle)}
+        title={i18n.t(l.title)}
+      >
+        <Box alignItems="center" height="full" justifyContent="center">
+          <Text align="center" color="blue" size="44pt" style={styles.keyIcon} weight="heavy">
+            {KEY_ICON}
+          </Text>
+        </Box>
+      </SetupStepLayout>
+
+      {state === 'error' && (
+        <CashStatusHalfSheet
+          description={i18n.t(l.error_description)}
+          primaryAction={{ label: i18n.t(l.try_again), onPress: submit, testID: 'cash-setup-passkey-error-retry' }}
+          secondaryAction={{ label: i18n.t(i18n.l.button.cancel), onPress: reset, testID: 'cash-setup-passkey-error-cancel' }}
+          status="error"
+          testID="cash-setup-passkey-error"
+          title={i18n.t(l.error_title)}
+        />
+      )}
+    </>
   );
 });
 

--- a/src/features/cash/screens/cash-deposit-setup/steps/ReviewStep.tsx
+++ b/src/features/cash/screens/cash-deposit-setup/steps/ReviewStep.tsx
@@ -2,6 +2,7 @@ import React, { memo, useCallback } from 'react';
 
 import ButtonPressAnimation from '@/components/animations/ButtonPressAnimation';
 import { Box, Separator, Text } from '@/design-system';
+import { CashStatusHalfSheet } from '@/features/cash/components/CashStatusHalfSheet';
 import * as i18n from '@/languages';
 import Routes from '@/navigation/routesNames';
 
@@ -9,9 +10,11 @@ import { formatDateOfBirth, formatUsSsnMasked } from '../../../services/cashSetu
 import { useCashSetupSessionStore } from '../../../stores/cashSetupSessionStore';
 import { CashDepositSetupNavigation } from '../cashDepositSetupNavigator';
 import { SetupStepLayout } from '../components/SetupStepLayout';
+import { useCashDepositSetupNavigation } from '../useCashDepositSetupNavigation';
 import { useSubmitKycFlow } from './useSubmitKycFlow';
 
 const l = i18n.l.cash.deposit_setup.review;
+const IDENTITY_VERIFIED_ICON = '􀯧';
 
 function ReviewRow({
   disabled,
@@ -50,50 +53,95 @@ function ReviewRow({
 export const ReviewStep = memo(function ReviewStep() {
   const identity = useCashSetupSessionStore(state => (state.session.status === 'phoneVerified' ? state.session.identity : null));
   const governmentId = useCashSetupSessionStore(state => (state.session.status === 'phoneVerified' ? state.session.governmentId : null));
-  const { submitting, submit } = useSubmitKycFlow();
+  const { next } = useCashDepositSetupNavigation();
+  const { reset, state, submit } = useSubmitKycFlow();
+  const submitting = state === 'submitting';
 
   const editIdentity = useCallback(() => CashDepositSetupNavigation.navigate(Routes.CASH_SETUP_IDENTITY), []);
   const editSsn = useCallback(() => CashDepositSetupNavigation.navigate(Routes.CASH_SETUP_SSN), []);
+  const continueAfterVerification = useCallback(() => {
+    reset();
+    next();
+  }, [reset, next]);
+  const editIdentityAfterFailure = useCallback(() => {
+    reset();
+    editIdentity();
+  }, [reset, editIdentity]);
 
   return (
-    <SetupStepLayout
-      actionDisabled={!identity || !governmentId}
-      actionLabel={i18n.t(l.confirm)}
-      actionLoading={submitting}
-      backDisabled={submitting}
-      onAction={submit}
-      subtitle={i18n.t(l.subtitle)}
-      title={i18n.t(l.title)}
-    >
-      {identity && governmentId && (
-        <Box paddingTop="24px">
-          <Box background="fillTertiary" borderRadius={20} paddingHorizontal="16px" paddingVertical="4px">
-            <ReviewRow
-              disabled={submitting}
-              label={i18n.t(l.name)}
-              onEdit={editIdentity}
-              testID="cash-setup-review-edit-identity"
-              value={`${identity.firstName} ${identity.lastName}`}
-            />
-            <Separator color="separatorTertiary" />
-            <ReviewRow
-              disabled={submitting}
-              label={i18n.t(l.date_of_birth)}
-              onEdit={editIdentity}
-              testID="cash-setup-review-edit-dob"
-              value={formatDateOfBirth(identity.dateOfBirth)}
-            />
-            <Separator color="separatorTertiary" />
-            <ReviewRow
-              disabled={submitting}
-              label={i18n.t(l.ssn)}
-              onEdit={editSsn}
-              testID="cash-setup-review-edit-ssn"
-              value={formatUsSsnMasked(governmentId.value)}
-            />
+    <>
+      <SetupStepLayout
+        actionDisabled={!identity || !governmentId}
+        actionLabel={i18n.t(l.confirm)}
+        backDisabled={submitting}
+        onAction={submit}
+        subtitle={i18n.t(l.subtitle)}
+        title={i18n.t(l.title)}
+      >
+        {identity && governmentId && (
+          <Box paddingTop="24px">
+            <Box background="fillTertiary" borderRadius={20} paddingHorizontal="16px" paddingVertical="4px">
+              <ReviewRow
+                disabled={submitting}
+                label={i18n.t(l.name)}
+                onEdit={editIdentity}
+                testID="cash-setup-review-edit-identity"
+                value={`${identity.firstName} ${identity.lastName}`}
+              />
+              <Separator color="separatorTertiary" />
+              <ReviewRow
+                disabled={submitting}
+                label={i18n.t(l.date_of_birth)}
+                onEdit={editIdentity}
+                testID="cash-setup-review-edit-dob"
+                value={formatDateOfBirth(identity.dateOfBirth)}
+              />
+              <Separator color="separatorTertiary" />
+              <ReviewRow
+                disabled={submitting}
+                label={i18n.t(l.ssn)}
+                onEdit={editSsn}
+                testID="cash-setup-review-edit-ssn"
+                value={formatUsSsnMasked(governmentId.value)}
+              />
+            </Box>
           </Box>
-        </Box>
-      )}
-    </SetupStepLayout>
+        )}
+      </SetupStepLayout>
+
+      {state === 'submitting' ? (
+        <CashStatusHalfSheet
+          description={i18n.t(l.verifying_description)}
+          status="inProgress"
+          testID="cash-setup-kyc-verifying"
+          title={i18n.t(l.verifying_title)}
+        />
+      ) : state === 'success' ? (
+        <CashStatusHalfSheet
+          action={{
+            label: i18n.t(i18n.l.button.continue),
+            onPress: continueAfterVerification,
+            testID: 'cash-setup-kyc-success-continue',
+          }}
+          description={i18n.t(l.verified_description)}
+          status="success"
+          successIcon={IDENTITY_VERIFIED_ICON}
+          testID="cash-setup-kyc-success"
+          title={i18n.t(l.verified_title)}
+        />
+      ) : state === 'error' ? (
+        <CashStatusHalfSheet
+          description={i18n.t(l.error_description)}
+          primaryAction={{
+            label: i18n.t(l.edit_details),
+            onPress: editIdentityAfterFailure,
+            testID: 'cash-setup-kyc-error-edit-details',
+          }}
+          status="error"
+          testID="cash-setup-kyc-error"
+          title={i18n.t(l.error_title)}
+        />
+      ) : null}
+    </>
   );
 });

--- a/src/features/cash/screens/cash-deposit-setup/steps/useAddPasskeyFlow.test.ts
+++ b/src/features/cash/screens/cash-deposit-setup/steps/useAddPasskeyFlow.test.ts
@@ -23,10 +23,6 @@ jest.mock('@/logger', () => ({
   RainbowError: class RainbowError extends Error {},
 }));
 
-jest.mock('@/helpers/alert', () => ({
-  WrappedAlert: { alert: jest.fn() },
-}));
-
 jest.mock('../../../services/userClient', () => ({
   addPasskey: jest.fn(),
   finishAddPasskey: jest.fn(),
@@ -67,6 +63,7 @@ const challenge = () => {
 beforeEach(() => {
   jest.clearAllMocks();
   (useCashAccountStore.getState as jest.Mock).mockReturnValue({ setUserId });
+  flow().reset();
   session().reset();
   session().setPhoneSubmitted({ challenge: { kind: 'signup', userId: 'user-1' }, phoneNationalNumber: '4155550100', resendAfter: 0 });
   session().setPhoneVerified(challenge(), { bootstrapToken: TOKEN, expiresAt: Date.now() + 60_000 });
@@ -123,6 +120,7 @@ describe('useAddPasskeyFlowStore.submit', () => {
     expect(track).toHaveBeenCalledWith('cash.passkey_failed', { reason: 'ceremony broke' });
     expect(setUserId).not.toHaveBeenCalled();
     expect(logger.error).toHaveBeenCalled();
+    expect(flow().state).toBe('error');
   });
 
   it('fails without storing the userId when FinishAddPasskey throws', async () => {

--- a/src/features/cash/screens/cash-deposit-setup/steps/useAddPasskeyFlow.ts
+++ b/src/features/cash/screens/cash-deposit-setup/steps/useAddPasskeyFlow.ts
@@ -3,8 +3,6 @@ import { useCallback } from 'react';
 import { createBaseStore, createStoreActions } from '@storesjs/stores';
 
 import { analytics } from '@/analytics';
-import { WrappedAlert as Alert } from '@/helpers/alert';
-import * as i18n from '@/languages';
 import { logger, RainbowError } from '@/logger';
 
 import { createPasskeyCredential, getPasskeyName, isPasskeyCancellation } from '../../../services/cashPasskeyService';
@@ -13,20 +11,23 @@ import { useCashAccountStore } from '../../../stores/cashAccountStore';
 import { useCashSetupSessionStore } from '../../../stores/cashSetupSessionStore';
 import { useCashDepositSetupNavigation } from '../useCashDepositSetupNavigation';
 
-export type AddPasskeyState = 'entry' | 'submitting';
+export type AddPasskeyState = 'entry' | 'submitting' | 'error';
 
 export type AddPasskeyResult = 'completed' | 'cancelled' | 'failed' | 'skipped';
 
 type AddPasskeyFlowStore = {
   state: AddPasskeyState;
+  reset: () => void;
   submit: () => Promise<AddPasskeyResult>;
 };
 
 export const useAddPasskeyFlowStore = createBaseStore<AddPasskeyFlowStore>((set, get) => ({
   state: 'entry',
 
+  reset: () => set({ state: 'entry' }),
+
   submit: async () => {
-    if (get().state !== 'entry') return 'skipped';
+    if (get().state === 'submitting') return 'skipped';
     const { session } = useCashSetupSessionStore.getState();
     if (session.status !== 'phoneVerified') return 'skipped';
 
@@ -40,29 +41,34 @@ export const useAddPasskeyFlowStore = createBaseStore<AddPasskeyFlowStore>((set,
 
       useCashAccountStore.getState().setUserId(userId);
       analytics.track(analytics.event.cashPasskeyAdded);
+      set({ state: 'entry' });
       return 'completed';
     } catch (e) {
-      if (isPasskeyCancellation(e)) return 'cancelled';
+      if (isPasskeyCancellation(e)) {
+        set({ state: 'entry' });
+        return 'cancelled';
+      }
       logger.error(new RainbowError('[useAddPasskeyFlow]: Failed to add passkey', e));
       analytics.track(analytics.event.cashPasskeyFailed, { reason: e instanceof Error ? e.message : String(e) });
+      set({ state: 'error' });
       return 'failed';
-    } finally {
-      set({ state: 'entry' });
     }
   },
 }));
 
 const addPasskeyFlowActions = createStoreActions(useAddPasskeyFlowStore);
 
-export function useAddPasskeyFlow(): { submitting: boolean; submit: () => Promise<void> } {
+export function useAddPasskeyFlow(): {
+  reset: () => void;
+  state: AddPasskeyState;
+  submit: () => Promise<void>;
+} {
   const { next } = useCashDepositSetupNavigation();
-  const submitting = useAddPasskeyFlowStore(state => state.state === 'submitting');
+  const state = useAddPasskeyFlowStore(state => state.state);
 
   const submit = useCallback(async () => {
-    const result = await addPasskeyFlowActions.submit();
-    if (result === 'completed') next();
-    else if (result === 'failed') Alert.alert(i18n.t(i18n.l.cash.deposit_setup.passkey.error));
+    if ((await addPasskeyFlowActions.submit()) === 'completed') next();
   }, [next]);
 
-  return { submitting, submit };
+  return { reset: addPasskeyFlowActions.reset, state, submit };
 }

--- a/src/features/cash/screens/cash-deposit-setup/steps/useCardLinkFlow.ts
+++ b/src/features/cash/screens/cash-deposit-setup/steps/useCardLinkFlow.ts
@@ -30,13 +30,13 @@ export type UseCardLinkFlow = {
   bivoStore: BivoSecureStore;
   isReady: boolean;
   onFieldStateChange: () => void;
+  reset: () => void;
   submit: () => void;
-  retry: () => void;
 };
 
 export function useCardLinkFlow(): UseCardLinkFlow {
   const [flowState, setFlowState] = useState<CardLinkState>('entry');
-  const [bivoStore, setBivoStore] = useState(createBivoStore);
+  const [bivoStore] = useState(createBivoStore);
   const [, onFieldStateChange] = useReducer(i => i + 1, 0);
   const abortRef = useRef<AbortController | null>(null);
 
@@ -72,10 +72,7 @@ export function useCardLinkFlow(): UseCardLinkFlow {
     }
   }, [bivoStore]);
 
-  const retry = useCallback(() => {
-    setBivoStore(createBivoStore());
-    setFlowState('entry');
-  }, []);
+  const reset = useCallback(() => setFlowState('entry'), []);
 
   useEffect(() => {
     return () => {
@@ -88,7 +85,7 @@ export function useCardLinkFlow(): UseCardLinkFlow {
     bivoStore,
     isReady,
     onFieldStateChange,
+    reset,
     submit,
-    retry,
   };
 }

--- a/src/features/cash/screens/cash-deposit-setup/steps/useSubmitKycFlow.test.ts
+++ b/src/features/cash/screens/cash-deposit-setup/steps/useSubmitKycFlow.test.ts
@@ -19,10 +19,6 @@ jest.mock('@/logger', () => ({
   RainbowError: class RainbowError extends Error {},
 }));
 
-jest.mock('@/helpers/alert', () => ({
-  WrappedAlert: { alert: jest.fn() },
-}));
-
 jest.mock('@/utils/delay', () => ({
   delay: jest.fn(() => Promise.resolve()),
 }));
@@ -37,10 +33,6 @@ jest.mock('../../../services/userClient', () => ({
   },
   getUserStatus: jest.fn(),
   submitOnboarding: jest.fn(),
-}));
-
-jest.mock('../useCashDepositSetupNavigation', () => ({
-  useCashDepositSetupNavigation: jest.fn(),
 }));
 
 const mockSubmitOnboarding = submitOnboarding as jest.Mock;
@@ -65,6 +57,7 @@ const challenge = () => {
 
 beforeEach(() => {
   jest.clearAllMocks();
+  flow().reset();
   session().reset();
   session().setPhoneSubmitted({ challenge: { kind: 'signup', userId: 'user-1' }, phoneNationalNumber: '4155550100', resendAfter: 0 });
   session().setPhoneVerified(challenge(), { bootstrapToken: TOKEN, expiresAt: Date.now() + 60_000 });
@@ -93,7 +86,7 @@ describe('useSubmitKycFlowStore.submit', () => {
     expect(submitOrder).toBeLessThan(trackApprovedOrder);
 
     expect(mockGetUserStatus).not.toHaveBeenCalled();
-    expect(flow().state).toBe('entry');
+    expect(flow().state).toBe('success');
   });
 
   it('polls while pending, then approves', async () => {
@@ -116,7 +109,7 @@ describe('useSubmitKycFlowStore.submit', () => {
     expect(mockGetUserStatus).toHaveBeenCalledTimes(POLL_ATTEMPTS);
     expect(track).toHaveBeenCalledWith('cash.kyc_failed', { reason: 'timeout' });
     expect(logger.error).toHaveBeenCalled();
-    expect(flow().state).toBe('entry');
+    expect(flow().state).toBe('error');
   });
 
   it.each([
@@ -139,7 +132,7 @@ describe('useSubmitKycFlowStore.submit', () => {
 
     expect(track).toHaveBeenCalledWith('cash.kyc_failed', { reason: 'network down' });
     expect(logger.error).toHaveBeenCalled();
-    expect(flow().state).toBe('entry');
+    expect(flow().state).toBe('error');
   });
 
   it('skips a second submit while one is in flight', async () => {

--- a/src/features/cash/screens/cash-deposit-setup/steps/useSubmitKycFlow.ts
+++ b/src/features/cash/screens/cash-deposit-setup/steps/useSubmitKycFlow.ts
@@ -1,18 +1,13 @@
-import { useCallback } from 'react';
-
 import { createBaseStore, createStoreActions } from '@storesjs/stores';
 
 import { analytics } from '@/analytics';
 import { time } from '@/framework/core/utils/time';
-import { WrappedAlert as Alert } from '@/helpers/alert';
-import * as i18n from '@/languages';
 import { logger, RainbowError } from '@/logger';
 import { delay } from '@/utils/delay';
 
 import { US_COUNTRY_CODE } from '../../../services/cashSetupIdentityService';
 import { getUserStatus, KycStatus, submitOnboarding } from '../../../services/userClient';
 import { useCashSetupSessionStore } from '../../../stores/cashSetupSessionStore';
-import { useCashDepositSetupNavigation } from '../useCashDepositSetupNavigation';
 
 export const KYC_POLL_INTERVAL_MS = time.seconds(3);
 export const KYC_POLL_BUDGET_MS = time.seconds(30);
@@ -26,20 +21,23 @@ const KYC_FAILURE_REASONS: Record<Exclude<KycStatus, KycStatus.Approved>, string
   [KycStatus.Review]: 'review',
 };
 
-export type SubmitKycState = 'entry' | 'submitting';
+export type SubmitKycState = 'entry' | 'submitting' | 'success' | 'error';
 
 export type SubmitKycResult = 'approved' | 'failed' | 'skipped';
 
 type SubmitKycFlowStore = {
   state: SubmitKycState;
+  reset: () => void;
   submit: () => Promise<SubmitKycResult>;
 };
 
 export const useSubmitKycFlowStore = createBaseStore<SubmitKycFlowStore>((set, get) => ({
   state: 'entry',
 
+  reset: () => set({ state: 'entry' }),
+
   submit: async () => {
-    if (get().state !== 'entry') return 'skipped';
+    if (get().state === 'submitting') return 'skipped';
     const { session } = useCashSetupSessionStore.getState();
     if (session.status !== 'phoneVerified' || !session.identity || !session.governmentId) return 'skipped';
 
@@ -58,32 +56,30 @@ export const useSubmitKycFlowStore = createBaseStore<SubmitKycFlowStore>((set, g
         const reason = KYC_FAILURE_REASONS[kycStatus];
         logger.error(new RainbowError(`[useSubmitKycFlow]: KYC not approved: ${reason}`));
         analytics.track(analytics.event.cashKycFailed, { reason });
+        set({ state: 'error' });
         return 'failed';
       }
 
       analytics.track(analytics.event.cashKycApproved);
+      set({ state: 'success' });
       return 'approved';
     } catch (e) {
       logger.error(new RainbowError('[useSubmitKycFlow]: Failed to submit KYC', e));
       analytics.track(analytics.event.cashKycFailed, { reason: e instanceof Error ? e.message : String(e) });
+      set({ state: 'error' });
       return 'failed';
-    } finally {
-      set({ state: 'entry' });
     }
   },
 }));
 
 const submitKycFlowActions = createStoreActions(useSubmitKycFlowStore);
 
-export function useSubmitKycFlow(): { submitting: boolean; submit: () => Promise<void> } {
-  const { next } = useCashDepositSetupNavigation();
-  const submitting = useSubmitKycFlowStore(state => state.state === 'submitting');
+export function useSubmitKycFlow(): {
+  reset: () => void;
+  state: SubmitKycState;
+  submit: () => Promise<SubmitKycResult>;
+} {
+  const state = useSubmitKycFlowStore(state => state.state);
 
-  const submit = useCallback(async () => {
-    const result = await submitKycFlowActions.submit();
-    if (result === 'approved') next();
-    else if (result === 'failed') Alert.alert(i18n.t(i18n.l.cash.deposit_setup.review.error));
-  }, [next]);
-
-  return { submitting, submit };
+  return { reset: submitKycFlowActions.reset, state, submit: submitKycFlowActions.submit };
 }

--- a/src/languages/en_US.json
+++ b/src/languages/en_US.json
@@ -1609,13 +1609,21 @@
           "date_of_birth": "Date of Birth",
           "ssn": "Social Security Number",
           "edit": "Edit",
-          "error": "We couldn’t verify your details. Please try again."
+          "verifying_title": "Verifying your identity...",
+          "verifying_description": "This can take up to a few minutes.",
+          "verified_title": "Identity verified",
+          "verified_description": "We found a match based on your details. Please review and confirm everything looks correct.",
+          "error_title": "We couldn’t verify your details",
+          "error_description": "Please double-check your details and try again.",
+          "edit_details": "Edit Details"
         },
         "passkey": {
           "title": "Add a Passkey",
           "subtitle": "Add a secure passkey to make signing in easier and keep your account protected.",
           "action": "Add Passkey",
-          "error": "We couldn’t add your passkey. Please try again."
+          "error_title": "Error adding passkey",
+          "error_description": "We couldn’t add your passkey. Please try again.",
+          "try_again": "Try Again"
         },
         "email": { "title": "Enter email" },
         "all_done": {
@@ -1629,8 +1637,11 @@
           "expiry": "MM / YY",
           "cvc": "CVC",
           "zip": "ZIP code",
-          "try_again": "Try again",
-          "submit_error": "We couldn't link your card. Please try again."
+          "adding_title": "Adding card...",
+          "adding_description": "Talking to your card issuer...",
+          "error_title": "Error adding card",
+          "error_description": "Couldn’t add your card. Please check your details and try again.",
+          "edit_details": "Edit Card Details"
         },
         "card_added": {
           "title": "Card added",

--- a/src/navigation/Routes.android.tsx
+++ b/src/navigation/Routes.android.tsx
@@ -109,6 +109,7 @@ import {
   androidRecievePreset,
   appIconUnlockSheetPreset,
   bottomSheetPreset,
+  cashDepositSetupSheetPreset,
   emojiPreset,
   exchangePreset,
   expandedPreset,
@@ -287,7 +288,7 @@ function BSNavigator() {
       <BSStack.Screen component={PerpsAddToPositionSheet} name={Routes.PERPS_ADD_TO_POSITION_SHEET} />
       <BSStack.Screen component={PerpsAboutSheet} name={Routes.PERPS_ABOUT_SHEET} />
       <BSStack.Screen component={CashDepositIntroPanel} name={Routes.CASH_DEPOSIT_INTRO_PANEL} />
-      <BSStack.Screen component={CashDepositSetupScreen} name={Routes.CASH_DEPOSIT_SETUP_SCREEN} />
+      <BSStack.Screen component={CashDepositSetupScreen} name={Routes.CASH_DEPOSIT_SETUP_SCREEN} options={cashDepositSetupSheetPreset} />
       <BSStack.Screen component={AddCashSheet} name={Routes.ADD_CASH_SHEET} />
       <BSStack.Screen component={AddWalletSheet} name={Routes.CASH_ADD_WALLET_SHEET} />
       <BSStack.Screen component={PerpsTradeDetailsSheet} name={Routes.PERPS_TRADE_DETAILS_SHEET} />

--- a/src/navigation/Routes.ios.tsx
+++ b/src/navigation/Routes.ios.tsx
@@ -103,6 +103,7 @@ import {
   appIconUnlockSheetConfig,
   backupSheetConfig,
   basicSheetConfig,
+  cashDepositSetupConfig,
   checkIdentifierSheetConfig,
   claimAirdropSheetConfig,
   customGasSheetConfig,
@@ -312,7 +313,7 @@ function NativeStackNavigator() {
       <NativeStack.Screen component={PerpsExplainSheet} name={Routes.PERPS_EXPLAIN_SHEET} {...perpsExplainSheetConfig} />
       <NativeStack.Screen component={PerpsAboutSheet} name={Routes.PERPS_ABOUT_SHEET} {...panelConfig} />
       <NativeStack.Screen component={CashDepositIntroPanel} name={Routes.CASH_DEPOSIT_INTRO_PANEL} {...panelConfig} />
-      <NativeStack.Screen component={CashDepositSetupScreen} name={Routes.CASH_DEPOSIT_SETUP_SCREEN} {...perpsAccountStackConfig} />
+      <NativeStack.Screen component={CashDepositSetupScreen} name={Routes.CASH_DEPOSIT_SETUP_SCREEN} {...cashDepositSetupConfig} />
       <NativeStack.Screen component={AddCashSheet} name={Routes.ADD_CASH_SHEET} {...panelConfig} />
       <NativeStack.Screen component={AddWalletSheet} name={Routes.CASH_ADD_WALLET_SHEET} {...panelConfig} />
       <NativeStack.Screen

--- a/src/navigation/config.tsx
+++ b/src/navigation/config.tsx
@@ -659,6 +659,22 @@ export const perpsAccountStackConfig: PartialNavigatorConfigOptions = {
   }),
 };
 
+export const cashDepositSetupConfig: PartialNavigatorConfigOptions = {
+  options: ({ route: { params = {} } }) => ({
+    ...buildCoolModalConfig({
+      ...params,
+      backgroundOpacity: 1,
+      cornerRadius: 'device',
+      headerHeight: safeAreaInsetValues.top + 68,
+      springDamping: 1,
+      topOffset: 0,
+      transitionDuration: 0.3,
+    }),
+    dismissable: false,
+    gestureEnabled: false,
+  }),
+};
+
 export const perpsDepositWithdrawalConfig: PartialNavigatorConfigOptions = {
   options: ({ route: { params = {} } }) => ({
     ...buildCoolModalConfig({

--- a/src/navigation/effects.tsx
+++ b/src/navigation/effects.tsx
@@ -448,6 +448,10 @@ export const tokenLauncherSheetPreset = {
   enablePanDownToClose: false,
 };
 
+export const cashDepositSetupSheetPreset = {
+  enablePanDownToClose: false,
+};
+
 export const hardwareWalletTxNavigatorPreset = {
   height: HARDWARE_WALLET_TX_NAVIGATOR_SHEET_HEIGHT,
   backdropOpacity: 1,


### PR DESCRIPTION
Fixes APP-3921

## What changed (plus any additional context for devs)

Adds `CashStatusHalfSheet` — a floating half sheet for the cash deposit setup flow with three variants: **in progress** (hourglass), **success** (configurable icon + primary action), and **error** (one or two actions) — and wires it into three flows:

- **Review (KYC submit):** the CTA spinner + failure alert are replaced by the sheet. Verifying → "Identity verified" (Continue advances to the next step — approval no longer auto-advances) or an error sheet with Edit Details. The failure copy no longer suggests trying "a different deposit method" (there are none — that Figma copy assumed an Other Methods action we don't ship); it now reads "Please double-check your details and try again."
- **Passkey:** enrollment failure shows the error sheet (Try Again / Cancel) instead of a native alert.
- **Card details:** "Adding card..." while linking, and the full-screen inline error is replaced by an error sheet (Edit Card Details keeps the entered values / Cancel goes back). 

The setup screen itself is also no longer swipe-dismissable — from the phone step to the end, the only exits are the flow's own back and Cancel controls:

- **iOS:** new `cashDepositSetupConfig` (the visuals of `perpsAccountStackConfig` it previously borrowed, plus `dismissable: false, gestureEnabled: false`, same combo as `tokenLauncherConfig`). This only disables the pan gesture — programmatic dismissal (Cancel/back) is unaffected.
- **Android:** new `cashDepositSetupSheetPreset = { enablePanDownToClose: false }`, the `tokenLauncherSheetPreset` pattern.

Thorough check for where we should show back/cancel will be done in [APP-3906](https://linear.app/rainbow/issue/APP-3906/investigate-do-we-want-to-disable-go-back-both-software-and-hardware)

Implementation notes:

- The sheet renders through `AbsolutePortal` into a local `AbsolutePortalRoot` mounted in `CashDepositSetupScreen` (same approach as `Swap.tsx`). The overlay sits above the `SmoothPager`, so swipe-to-go-back can't pass through while a sheet is up, and steps don't need positioning wrappers.
- It dismisses the keyboard on mount — on the card step the iOS number pads have no Done key, so an open keyboard would otherwise cover the sheet with no way to close it.
- Presentation: backdrop fades while the panel slides up from / down to the bottom edge (springified with the pager's `snappyMediumSpringConfig`). Between statuses (in progress → success/error) the panel stays mounted: content crossfades and the panel resizes with a timed, non-bouncing transition.
- The KYC and passkey stores now own their terminal states (`success`/`error`) with a `reset()` action, matching the `useSubmitPhoneFlow` pattern (all four setup flows now share one state-machine shape). Resets are registered in the screen's `useCleanup` so stale sheets can't leak into a re-entered flow via the kept-mounted pager pages. `useCardLinkFlow`'s `retry` is renamed to `reset` to match.
- `CashActionButton` gained a `variant` prop (`solid` / `tinted` / `plain`); the sheet's error buttons reuse it instead of a bespoke button.
- Generic Cancel/Continue labels use the canonical `l.button.*` keys; e2e `Setup.yaml` taps the new Continue button on the KYC success sheet.

## Screen recordings / screenshots

https://github.com/user-attachments/assets/160c3073-e19c-4934-8774-02fcbf76eb06


https://github.com/user-attachments/assets/45aefbf4-ec78-427f-956c-5f1aef7c8df3



## What to test

- Review step → Confirm: verifying sheet appears, then "Identity verified"; Continue advances to Add a Passkey. On KYC failure: error sheet → Edit Details returns to the identity step.
- Passkey step: fail enrollment → error sheet; Try Again re-runs the ceremony, Cancel dismisses back to the step.
- Card details: submit with the keyboard open → keyboard dismisses and "Adding card..." shows; on failure, Edit Card Details returns to the form with values intact, Cancel goes back; success still lands on Card added.
- While any sheet is up, swiping back on the pager should do nothing.
- Anywhere in the setup flow (both platforms), pulling the screen down should not dismiss it; back and Cancel still exit as before.