### PR TITLE
fix(sentry): redact identifiers from logged URLs and error messages

### DIFF
--- a/src/logger/logger.test.ts
+++ b/src/logger/logger.test.ts
@@ -386,3 +386,120 @@ describe('beforeSend filtering', () => {
     expect(result).toBe(dummyEvent);
   });
 });
+
+describe('redaction', () => {
+  const beforeSend = defaultOptions.beforeSend!;
+  const beforeBreadcrumb = defaultOptions.beforeBreadcrumb!;
+
+  test('strips the query string from request breadcrumbs', () => {
+    const breadcrumb = beforeBreadcrumb(
+      { category: 'xhr', type: 'http', data: { method: 'GET', url: `https://aha.rainbow.me/?address=0x${'a'.repeat(40)}` } },
+      {}
+    );
+
+    expect(breadcrumb?.data?.url).toBe('https://aha.rainbow.me');
+  });
+
+  test('drops a breadcrumb url it cannot parse rather than passing it through', () => {
+    const breadcrumb = beforeBreadcrumb({ category: 'xhr', type: 'http', data: { method: 'GET', url: 'not-a-url' } }, {});
+
+    expect(breadcrumb?.data).not.toHaveProperty('url');
+  });
+
+  test('leaves breadcrumbs without a url alone', () => {
+    const breadcrumb = beforeBreadcrumb({ category: 'console', message: 'hello' }, {});
+
+    expect(breadcrumb).toEqual({ category: 'console', message: 'hello' });
+  });
+
+  test('sanitises breadcrumbs on the event, which is where native ones arrive', () => {
+    const event: Sentry.ErrorEvent = {
+      type: undefined,
+      breadcrumbs: [
+        {
+          category: 'http',
+          data: { 'method': 'GET', 'url': `https://api.rainbow.me/v1/wallets/0x${'a'.repeat(40)}/positions`, 'http.query': 'currency=USD' },
+        },
+      ],
+    };
+
+    const result = beforeSend(event, {}) as Sentry.ErrorEvent;
+    const data = result.breadcrumbs?.[0]?.data;
+
+    expect(data?.url).toBe('https://api.rainbow.me/v1/wallets/:id/positions');
+    expect(data).not.toHaveProperty('http.query');
+  });
+
+  test('redacts exception values, which no url field covers', () => {
+    const event = { exception: { values: [{ value: `missing revert data for 0x${'a'.repeat(40)}` }] } } as Sentry.ErrorEvent;
+
+    const result = beforeSend(event, {}) as Sentry.ErrorEvent;
+
+    expect(result.exception?.values?.[0]?.value).toBe('missing revert data for [address]');
+  });
+
+  test('redacts a captureMessage event', () => {
+    const event = { message: `Failed to fetch balances for 0x${'a'.repeat(40)}` } as Sentry.ErrorEvent;
+
+    const result = beforeSend(event, {}) as Sentry.ErrorEvent;
+
+    expect(result.message).toBe('Failed to fetch balances for [address]');
+  });
+});
+
+/**
+ * One fixture with an address in every field that can carry a string, so coverage is asserted rather
+ * than imagined. A field left untouched below is a decision, not an oversight: add a field here when
+ * the SDK starts populating one, and the gap shows up as a failing expectation.
+ */
+describe('carrier coverage', () => {
+  const beforeSend = defaultOptions.beforeSend!;
+  const ADDRESS = `0x${'a'.repeat(40)}`;
+
+  const poisoned = () =>
+    ({
+      type: undefined,
+      message: `message ${ADDRESS}`,
+      exception: { values: [{ value: `exception ${ADDRESS}` }] },
+      breadcrumbs: [
+        {
+          category: 'console',
+          message: `breadcrumb ${ADDRESS}`,
+          data: {
+            'url': `https://api.rainbow.me/v1/wallets/${ADDRESS}/nfts`,
+            'http.query': `address=${ADDRESS}`,
+            'arguments': [`console arg ${ADDRESS}`],
+            'metadata': { nested: `nested ${ADDRESS}` },
+          },
+        },
+      ],
+      extra: { address: ADDRESS, apiErrors: [{ detail: `failed for ${ADDRESS}` }] },
+      tags: { note: `tag ${ADDRESS}` },
+      contexts: { app: { note: `context ${ADDRESS}` } },
+    }) as Sentry.ErrorEvent;
+
+  test('covers messages, exception values, breadcrumbs and metadata', () => {
+    const result = beforeSend(poisoned(), {}) as Sentry.ErrorEvent;
+    const data = result.breadcrumbs?.[0]?.data;
+
+    expect(result.message).toBe('message [address]');
+    expect(result.exception?.values?.[0]?.value).toBe('exception [address]');
+    expect(result.breadcrumbs?.[0]?.message).toBe('breadcrumb [address]');
+    expect(data?.url).toBe('https://api.rainbow.me/v1/wallets/:id/nfts');
+    expect(data?.metadata).toEqual({ nested: 'nested [address]' });
+    expect(data?.arguments).toEqual(['console arg [address]']);
+    expect(data).not.toHaveProperty('http.query');
+    expect(result.extra?.address).toBe('[address]');
+    expect(result.extra?.apiErrors).toEqual([{ detail: 'failed for [address]' }]);
+  });
+
+  test('leaves tags and contexts alone, which is deliberate', () => {
+    const result = beforeSend(poisoned(), {}) as Sentry.ErrorEvent;
+
+    // A tag value is low-cardinality by design, so rewriting one is likelier to break a deliberate
+    // tag than to catch a leak. Keeping identifiers out of tags is a convention, not enforced here.
+    expect(result.tags?.note).toBe(`tag ${ADDRESS}`);
+    // Contexts are SDK-owned: device model, os build, app version. Rewriting them mangles diagnostics.
+    expect(result.contexts?.app?.note).toBe(`context ${ADDRESS}`);
+  });
+});

--- a/src/logger/logger.test.ts
+++ b/src/logger/logger.test.ts
@@ -393,11 +393,11 @@ describe('redaction', () => {
 
   test('strips the query string from request breadcrumbs', () => {
     const breadcrumb = beforeBreadcrumb(
-      { category: 'xhr', type: 'http', data: { method: 'GET', url: `https://aha.rainbow.me/?address=0x${'a'.repeat(40)}` } },
+      { category: 'xhr', type: 'http', data: { method: 'GET', url: `https://api.example.com/?address=0x${'a'.repeat(40)}` } },
       {}
     );
 
-    expect(breadcrumb?.data?.url).toBe('https://aha.rainbow.me');
+    expect(breadcrumb?.data?.url).toBe('https://api.example.com');
   });
 
   test('drops a breadcrumb url it cannot parse rather than passing it through', () => {
@@ -418,7 +418,11 @@ describe('redaction', () => {
       breadcrumbs: [
         {
           category: 'http',
-          data: { 'method': 'GET', 'url': `https://api.rainbow.me/v1/wallets/0x${'a'.repeat(40)}/positions`, 'http.query': 'currency=USD' },
+          data: {
+            'method': 'GET',
+            'url': `https://api.example.com/v1/wallets/0x${'a'.repeat(40)}/positions`,
+            'http.query': 'currency=USD',
+          },
         },
       ],
     };
@@ -426,7 +430,7 @@ describe('redaction', () => {
     const result = beforeSend(event, {}) as Sentry.ErrorEvent;
     const data = result.breadcrumbs?.[0]?.data;
 
-    expect(data?.url).toBe('https://api.rainbow.me/v1/wallets/:id/positions');
+    expect(data?.url).toBe('https://api.example.com/v1/wallets/:id/positions');
     expect(data).not.toHaveProperty('http.query');
   });
 
@@ -466,7 +470,7 @@ describe('carrier coverage', () => {
           category: 'console',
           message: `breadcrumb ${ADDRESS}`,
           data: {
-            'url': `https://api.rainbow.me/v1/wallets/${ADDRESS}/nfts`,
+            'url': `https://api.example.com/v1/wallets/${ADDRESS}/nfts`,
             'http.query': `address=${ADDRESS}`,
             'arguments': [`console arg ${ADDRESS}`],
             'metadata': { nested: `nested ${ADDRESS}` },
@@ -485,7 +489,7 @@ describe('carrier coverage', () => {
     expect(result.message).toBe('message [address]');
     expect(result.exception?.values?.[0]?.value).toBe('exception [address]');
     expect(result.breadcrumbs?.[0]?.message).toBe('breadcrumb [address]');
-    expect(data?.url).toBe('https://api.rainbow.me/v1/wallets/:id/nfts');
+    expect(data?.url).toBe('https://api.example.com/v1/wallets/:id/nfts');
     expect(data?.metadata).toEqual({ nested: 'nested [address]' });
     expect(data?.arguments).toEqual(['console arg [address]']);
     expect(data).not.toHaveProperty('http.query');

--- a/src/logger/redactIdentifiers.test.ts
+++ b/src/logger/redactIdentifiers.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test } from '@jest/globals';
+
+import { redactIdentifiers } from '@/logger/redactIdentifiers';
+
+const ADDRESS = `0x${'a'.repeat(40)}`;
+const TX_HASH = `0x${'b'.repeat(64)}`;
+
+describe('redactIdentifiers', () => {
+  test('types the placeholder so the message stays readable', () => {
+    expect(redactIdentifiers(`Failed to fetch balances for ${ADDRESS}`)).toBe('Failed to fetch balances for [address]');
+    expect(redactIdentifiers(`Transaction ${TX_HASH} not found`)).toBe('Transaction [hash] not found');
+  });
+
+  test('collapses to one message regardless of which identifier appeared', () => {
+    const first = redactIdentifiers(`Failed to fetch balances for 0x${'1'.repeat(40)}`);
+    const second = redactIdentifiers(`Failed to fetch balances for 0x${'2'.repeat(40)}`);
+
+    expect(first).toBe(second);
+  });
+
+  test('catches a random-looking run, which is what a URL in a message looks like', () => {
+    const SOME_TOKEN = 'aB3dE5gH7jK9mN1pQ3sT5vW7yZ9bD2fH4jL6nP8rT0vX2zA4cE6gI8kM0oQ2sU4w';
+    const redacted = redactIdentifiers(`HTTP request failed. URL: https://api.example.com/v1/sessions/${SOME_TOKEN}. Status: 500`);
+
+    expect(redacted).not.toContain(SOME_TOKEN);
+    expect(redacted).toContain('[redacted]');
+    expect(redacted).toContain('Status: 500');
+  });
+
+  test('collapses the json-rpc request id, which increments per call', () => {
+    const body = (id: number) => `missing revert data (requestBody={"method":"eth_call","id":${id},"jsonrpc":"2.0"}, code=CALL_EXCEPTION)`;
+
+    expect(redactIdentifiers(body(42))).toBe(redactIdentifiers(body(43)));
+    expect(redactIdentifiers(body(42))).toContain('"id":[id]');
+  });
+
+  test('collapses the request id in its production form, which is escaped json', () => {
+    const body = (id: number) => String.raw`(error={\"requestBody\":\"{\"id\":${id},\"jsonrpc\":\"2.0\"}\"}, code=CALL_EXCEPTION)`;
+
+    expect(redactIdentifiers(body(42))).toBe(redactIdentifiers(body(51)));
+    expect(redactIdentifiers(body(42))).toContain(String.raw`\"id\":[id]`);
+  });
+
+  test('distinguishes a hash from an address rather than collapsing both', () => {
+    expect(redactIdentifiers(`${TX_HASH} from ${ADDRESS}`)).toBe('[hash] from [address]');
+  });
+
+  test('catches an identifier embedded in a composite key, where `\\b` would not', () => {
+    expect(redactIdentifiers(`[UniqueTokenImage] Error loading image: [object Object] for optimism_${ADDRESS}_0`)).toBe(
+      '[UniqueTokenImage] Error loading image: [object Object] for optimism_[address]_0'
+    );
+  });
+
+  test('reaches into a base64url token, whose separators break it into short runs', () => {
+    const redacted = redactIdentifiers('topic=jRZ5_E9kny-CmE_uVFXqko3Qwpk_Elzel74umip6cQd');
+
+    expect(redacted).not.toContain('uVFXqko3Qwpk');
+    expect(redacted).not.toContain('Elzel74umip6cQd');
+  });
+
+  test('keeps a function selector, which says which call failed and is not user data', () => {
+    expect(redactIdentifiers('execution reverted for selector 0x57b17a52')).toBe('execution reverted for selector 0x57b17a52');
+  });
+
+  test('leaves ordinary prose, short values and punctuated text alone', () => {
+    expect(redactIdentifiers('Failed to fetch NFT collections data')).toBe('Failed to fetch NFT collections data');
+    expect(redactIdentifiers('unknown chainID: undefined')).toBe('unknown chainID: undefined');
+    expect(redactIdentifiers('GET arc-graphql.rainbow.me 500')).toBe('GET arc-graphql.rainbow.me 500');
+  });
+});

--- a/src/logger/redactIdentifiers.test.ts
+++ b/src/logger/redactIdentifiers.test.ts
@@ -46,9 +46,7 @@ describe('redactIdentifiers', () => {
   });
 
   test('catches an identifier embedded in a composite key, where `\\b` would not', () => {
-    expect(redactIdentifiers(`[UniqueTokenImage] Error loading image: [object Object] for optimism_${ADDRESS}_0`)).toBe(
-      '[UniqueTokenImage] Error loading image: [object Object] for optimism_[address]_0'
-    );
+    expect(redactIdentifiers(`[ImageLoader] failed for optimism_${ADDRESS}_0`)).toBe('[ImageLoader] failed for optimism_[address]_0');
   });
 
   test('reaches into a base64url token, whose separators break it into short runs', () => {
@@ -65,6 +63,6 @@ describe('redactIdentifiers', () => {
   test('leaves ordinary prose, short values and punctuated text alone', () => {
     expect(redactIdentifiers('Failed to fetch NFT collections data')).toBe('Failed to fetch NFT collections data');
     expect(redactIdentifiers('unknown chainID: undefined')).toBe('unknown chainID: undefined');
-    expect(redactIdentifiers('GET arc-graphql.rainbow.me 500')).toBe('GET arc-graphql.rainbow.me 500');
+    expect(redactIdentifiers('GET graphql.example.com 500')).toBe('GET graphql.example.com 500');
   });
 });

--- a/src/logger/redactIdentifiers.ts
+++ b/src/logger/redactIdentifiers.ts
@@ -1,0 +1,31 @@
+/**
+ * Replaces identifier-shaped values in free text on its way to Sentry. Shape-based rather than a
+ * known-value list, because SDKs interpolate their own values into their own messages: e.g an ethers
+ * `CALL_EXCEPTION` carries the JSON-RPC request id, so one recurring failure reads as a different
+ * string every time. That costs titles and message search rather than grouping, which for these
+ * events keys on the stack.
+ *
+ * Not a secret filter, and must not be relied on as one. Anything below the length floor or
+ * containing punctuation passes straight through.
+ */
+const PATTERNS: [RegExp, string][] = [
+  // Boundaries are hand-written because `\b` counts `_` as a word character, so it skips the address
+  // in a composite key like `optimism_0x…_0`. The leading one is consumed, hence `$1` below.
+  [/0x[a-fA-F0-9]{64}(?![a-fA-F0-9])/g, '[hash]'],
+  [/0x[a-fA-F0-9]{40}(?![a-fA-F0-9])/g, '[address]'],
+  // json-rpc request id. Not a privacy rule; a request counter identifies nobody. ethers folds the
+  // whole request body into the message and its counter increments per call, so without this every
+  // retry of one failure gets a different title. The body arrives as escaped json inside the message,
+  // hence the optional backslash on each quote.
+  [/(\\?")id(\\?")\s*:\s*\d+/g, '$1id$2:[id]'],
+  // misc: api keys, request ids, encoded blobs. A letter and a digit are both required so prose is
+  // left alone. The floor is 12, measured against a day of production messages: 8 would eat 4-byte
+  // function selectors, and 16 lets base64url tokens through, since `-` and `_` break them into
+  // shorter runs. Widening the run to include `-` and `_` was tried and rejected: it eats error
+  // codes like `v5-errors-CALL_EXCEPTION`.
+  [/(^|[^A-Za-z0-9])((?=[A-Za-z0-9]*[0-9])(?=[A-Za-z0-9]*[A-Za-z])[A-Za-z0-9]{12,})(?![A-Za-z0-9])/g, '$1[redacted]'],
+];
+
+export function redactIdentifiers(text: string): string {
+  return PATTERNS.reduce((redacted, [pattern, placeholder]) => redacted.replace(pattern, placeholder), text);
+}

--- a/src/logger/sanitizeUrl.test.ts
+++ b/src/logger/sanitizeUrl.test.ts
@@ -9,33 +9,29 @@ const RANDOM_SEGMENT = 'aB3dE5gH7jK9mN1pQ3sT5vW7yZ9bD2fH4jL6nP8rT0vX2zA4cE6gI8kM
 
 describe('sanitizeUrl', () => {
   test('keeps the origin and static route words', () => {
-    expect(sanitizeUrl('https://platform.p.rainbow.me/v1/rewards/GetAirdropBalance')).toBe(
-      'https://platform.p.rainbow.me/v1/rewards/GetAirdropBalance'
-    );
+    expect(sanitizeUrl('https://api.example.com/v1/rewards/GetBalance')).toBe('https://api.example.com/v1/rewards/GetBalance');
   });
 
-  test('drops the query string, which is where addresses and GraphQL documents travel', () => {
-    expect(sanitizeUrl(`https://aha.rainbow.me/?address=${WALLET_ADDRESS}`)).toBe('https://aha.rainbow.me');
-    expect(sanitizeUrl('https://arc-graphql.rainbow.me/graphql?query=%7Bfoo%7D&operationName=getNftCollections')).toBe(
-      'https://arc-graphql.rainbow.me/graphql'
+  test('drops the query string, which carries values the path does not', () => {
+    expect(sanitizeUrl(`https://api.example.com/?address=${WALLET_ADDRESS}`)).toBe('https://api.example.com');
+    expect(sanitizeUrl('https://graphql.example.com/graphql?query=%7Bfoo%7D&operationName=getNftCollections')).toBe(
+      'https://graphql.example.com/graphql'
     );
   });
 
   test('templates the user data that paths legitimately carry', () => {
-    expect(sanitizeUrl(`https://api.rainbow.me/v1/wallets/${WALLET_ADDRESS}/positions`)).toBe(
-      'https://api.rainbow.me/v1/wallets/:id/positions'
+    expect(sanitizeUrl(`https://api.example.com/v1/wallets/${WALLET_ADDRESS}/positions`)).toBe(
+      'https://api.example.com/v1/wallets/:id/positions'
     );
-    expect(sanitizeUrl(`https://platform.p.rainbow.me/v1/transactions/${TX_HASH}/status`)).toBe(
-      'https://platform.p.rainbow.me/v1/transactions/:id/status'
+    expect(sanitizeUrl(`https://api.example.com/v1/transactions/${TX_HASH}/status`)).toBe(
+      'https://api.example.com/v1/transactions/:id/status'
     );
   });
 
   test('templates numeric segments, since a chain id and a resource id are the same shape', () => {
-    expect(sanitizeUrl('https://rpc.rainbow.me/v1/137/balances')).toBe('https://rpc.rainbow.me/v1/:id/balances');
-    expect(sanitizeUrl('https://gamma-api.polymarket.com/events/512340')).toBe('https://gamma-api.polymarket.com/events/:id');
-    expect(sanitizeUrl('https://token-search.p.rainbow.me/v3/discovery/1,10,8453')).toBe(
-      'https://token-search.p.rainbow.me/v3/discovery/:id'
-    );
+    expect(sanitizeUrl('https://rpc.example.com/v1/137/balances')).toBe('https://rpc.example.com/v1/:id/balances');
+    expect(sanitizeUrl('https://events.example.com/events/512340')).toBe('https://events.example.com/events/:id');
+    expect(sanitizeUrl('https://search.example.com/v3/discovery/1,10,8453')).toBe('https://search.example.com/v3/discovery/:id');
   });
 
   test('templates a random-looking path segment', () => {
@@ -49,11 +45,11 @@ describe('sanitizeUrl', () => {
     expect(sanitizeUrl('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjg2Ij48L3N2Zz4=')).toBeUndefined();
     expect(sanitizeUrl('ipfs://QmYx6GsYAKnNzZ9A6NvEKV9nf1VaDzJrqDR23Y8YSkebLU/1.png')).toBeUndefined();
     expect(sanitizeUrl('file:///var/mobile/Containers/Data/Application/tmp/x.png')).toBeUndefined();
-    expect(sanitizeUrl('rainbow://wc?uri=wc%3Aab12%402%3FsymKey%3Dcd34')).toBeUndefined();
+    expect(sanitizeUrl('myapp://wc?uri=wc%3Aab12%402%3FsymKey%3Dcd34')).toBeUndefined();
   });
 
   test('keeps websocket origins, which say which relay failed', () => {
-    expect(sanitizeUrl('wss://relay.walletconnect.org')).toBe('wss://relay.walletconnect.org');
+    expect(sanitizeUrl('wss://relay.example.com')).toBe('wss://relay.example.com');
   });
 
   test('returns undefined for anything it cannot parse, so callers drop the field', () => {

--- a/src/logger/sanitizeUrl.test.ts
+++ b/src/logger/sanitizeUrl.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from '@jest/globals';
+
+import { sanitizeUrl } from '@/logger/sanitizeUrl';
+
+const WALLET_ADDRESS = `0x${'a'.repeat(40)}`;
+const TX_HASH = `0x${'b'.repeat(64)}`;
+/** A random-looking segment, carrying no routing information. */
+const RANDOM_SEGMENT = 'aB3dE5gH7jK9mN1pQ3sT5vW7yZ9bD2fH4jL6nP8rT0vX2zA4cE6gI8kM0oQ2sU4w';
+
+describe('sanitizeUrl', () => {
+  test('keeps the origin and static route words', () => {
+    expect(sanitizeUrl('https://platform.p.rainbow.me/v1/rewards/GetAirdropBalance')).toBe(
+      'https://platform.p.rainbow.me/v1/rewards/GetAirdropBalance'
+    );
+  });
+
+  test('drops the query string, which is where addresses and GraphQL documents travel', () => {
+    expect(sanitizeUrl(`https://aha.rainbow.me/?address=${WALLET_ADDRESS}`)).toBe('https://aha.rainbow.me');
+    expect(sanitizeUrl('https://arc-graphql.rainbow.me/graphql?query=%7Bfoo%7D&operationName=getNftCollections')).toBe(
+      'https://arc-graphql.rainbow.me/graphql'
+    );
+  });
+
+  test('templates the user data that paths legitimately carry', () => {
+    expect(sanitizeUrl(`https://api.rainbow.me/v1/wallets/${WALLET_ADDRESS}/positions`)).toBe(
+      'https://api.rainbow.me/v1/wallets/:id/positions'
+    );
+    expect(sanitizeUrl(`https://platform.p.rainbow.me/v1/transactions/${TX_HASH}/status`)).toBe(
+      'https://platform.p.rainbow.me/v1/transactions/:id/status'
+    );
+  });
+
+  test('templates numeric segments, since a chain id and a resource id are the same shape', () => {
+    expect(sanitizeUrl('https://rpc.rainbow.me/v1/137/balances')).toBe('https://rpc.rainbow.me/v1/:id/balances');
+    expect(sanitizeUrl('https://gamma-api.polymarket.com/events/512340')).toBe('https://gamma-api.polymarket.com/events/:id');
+    expect(sanitizeUrl('https://token-search.p.rainbow.me/v3/discovery/1,10,8453')).toBe(
+      'https://token-search.p.rainbow.me/v3/discovery/:id'
+    );
+  });
+
+  test('templates a random-looking path segment', () => {
+    const sanitized = sanitizeUrl(`https://api.example.com/v1/sessions/${RANDOM_SEGMENT}?verbose=1`);
+
+    expect(sanitized).not.toContain(RANDOM_SEGMENT);
+    expect(sanitized).toBe('https://api.example.com/v1/sessions/:id');
+  });
+
+  test('drops schemes with no origin, whose whole value is one unreadable payload', () => {
+    expect(sanitizeUrl('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjg2Ij48L3N2Zz4=')).toBeUndefined();
+    expect(sanitizeUrl('ipfs://QmYx6GsYAKnNzZ9A6NvEKV9nf1VaDzJrqDR23Y8YSkebLU/1.png')).toBeUndefined();
+    expect(sanitizeUrl('file:///var/mobile/Containers/Data/Application/tmp/x.png')).toBeUndefined();
+    expect(sanitizeUrl('rainbow://wc?uri=wc%3Aab12%402%3FsymKey%3Dcd34')).toBeUndefined();
+  });
+
+  test('keeps websocket origins, which say which relay failed', () => {
+    expect(sanitizeUrl('wss://relay.walletconnect.org')).toBe('wss://relay.walletconnect.org');
+  });
+
+  test('returns undefined for anything it cannot parse, so callers drop the field', () => {
+    expect(sanitizeUrl('')).toBeUndefined();
+    expect(sanitizeUrl(`api.example.com/v1/sessions/${RANDOM_SEGMENT}`)).toBeUndefined();
+  });
+});

--- a/src/logger/sanitizeUrl.ts
+++ b/src/logger/sanitizeUrl.ts
@@ -3,19 +3,19 @@
  * REST design, and a URL is the one part of a request that gets logged by default, everywhere: the
  * SDK attaches a breadcrumb per request to every event it sends.
  *
- *   platform.p.rainbow.me/v1/rewards/GetAirdropBalance   ->  unchanged; route words carry no values
- *   api.example.com/v1/sessions/aB3dE5gH...oQ2sU4w       ->  api.example.com/v1/sessions/:id
- *   platform.p.rainbow.me/v1/transactions/0x88df...944b  ->  platform.p.rainbow.me/v1/transactions/:id
- *   token-search.p.rainbow.me/v3/discovery/1,10,8453     ->  token-search.p.rainbow.me/v3/discovery/:id
- *   api.rainbow.me/v1/ens/vitalik.eth                    ->  api.rainbow.me/v1/ens/:id
- *   aha.rainbow.me/?address=0x7a25...488d                ->  aha.rainbow.me
- *   arc-graphql.rainbow.me/graphql?query=%7B...%7D       ->  arc-graphql.rainbow.me/graphql
- *   anything unparseable, including a bare host          ->  undefined, and the caller drops the field
+ *   api.example.com/v1/rewards/GetBalance          ->  unchanged; route words carry no values
+ *   api.example.com/v1/transactions/0x88df...944b  ->  api.example.com/v1/transactions/:id
+ *   api.example.com/v1/sessions/aB3dE5gH...oQ2sU4w ->  api.example.com/v1/sessions/:id
+ *   api.example.com/v3/discovery/1,10,8453         ->  api.example.com/v3/discovery/:id
+ *   api.example.com/v1/names/alice.eth             ->  api.example.com/v1/names/:id
+ *   api.example.com/?address=0x7a25...488d         ->  api.example.com
+ *   api.example.com/graphql?query=%7B...%7D        ->  api.example.com/graphql
+ *   anything unparseable, including a bare host    ->  undefined, and the caller drops the field
  */
 
 const KEEPABLE_SEGMENT = [
   /^v\d{1,3}$/i, // api version: v1, v3
-  /^[A-Za-z][A-Za-z_-]{0,39}$/, // route word, no digits and no dot: rewards, GetAirdropBalance, token-price
+  /^[A-Za-z][A-Za-z_-]{0,39}$/, // route word, no digits and no dot: rewards, GetBalance, token-price
 ];
 
 /** Returns the sanitized URL or `undefined` if the URL could not be sanitized */

--- a/src/logger/sanitizeUrl.ts
+++ b/src/logger/sanitizeUrl.ts
@@ -1,0 +1,42 @@
+/**
+ * Reduces a URL to what is safe to log. Our request URLs carry user data as a matter of ordinary
+ * REST design, and a URL is the one part of a request that gets logged by default, everywhere: the
+ * SDK attaches a breadcrumb per request to every event it sends.
+ *
+ *   platform.p.rainbow.me/v1/rewards/GetAirdropBalance   ->  unchanged; route words carry no values
+ *   api.example.com/v1/sessions/aB3dE5gH...oQ2sU4w       ->  api.example.com/v1/sessions/:id
+ *   platform.p.rainbow.me/v1/transactions/0x88df...944b  ->  platform.p.rainbow.me/v1/transactions/:id
+ *   token-search.p.rainbow.me/v3/discovery/1,10,8453     ->  token-search.p.rainbow.me/v3/discovery/:id
+ *   api.rainbow.me/v1/ens/vitalik.eth                    ->  api.rainbow.me/v1/ens/:id
+ *   aha.rainbow.me/?address=0x7a25...488d                ->  aha.rainbow.me
+ *   arc-graphql.rainbow.me/graphql?query=%7B...%7D       ->  arc-graphql.rainbow.me/graphql
+ *   anything unparseable, including a bare host          ->  undefined, and the caller drops the field
+ */
+
+const KEEPABLE_SEGMENT = [
+  /^v\d{1,3}$/i, // api version: v1, v3
+  /^[A-Za-z][A-Za-z_-]{0,39}$/, // route word, no digits and no dot: rewards, GetAirdropBalance, token-price
+];
+
+/** Returns the sanitized URL or `undefined` if the URL could not be sanitized */
+export function sanitizeUrl(url: string): string | undefined {
+  try {
+    const parsed = new URL(url);
+    // Fail closed, as everywhere else here: `data:`, `ipfs:`, `file:` and app schemes report their
+    // origin as the string `"null"` and their whole payload as the path, so nothing here is safe to
+    // keep. Only request URLs reach this function, so anything without an origin is anomalous input.
+    if (!parsed.origin || parsed.origin === 'null') return undefined;
+
+    return `${parsed.origin}${templatePath(parsed.pathname)}`;
+  } catch {
+    return undefined;
+  }
+}
+
+function templatePath(pathname: string): string {
+  const segments = pathname.split('/').filter(Boolean);
+  if (segments.length === 0) return '';
+
+  // An allowlist rather than a denylist, so a segment we do not recognise fails closed to `:id`.
+  return `/${segments.map(segment => (KEEPABLE_SEGMENT.some(pattern => pattern.test(segment)) ? segment : ':id')).join('/')}`;
+}

--- a/src/logger/sentry.ts
+++ b/src/logger/sentry.ts
@@ -5,6 +5,8 @@ import VersionNumber from 'react-native-version-number';
 import { IS_DEV, IS_STORE_INSTALL, IS_TEST } from '@/env';
 import { RainbowFetchError } from '@/framework/data/http/rainbowFetch';
 import { logger, RainbowError } from '@/logger';
+import { redactIdentifiers } from '@/logger/redactIdentifiers';
+import { sanitizeUrl } from '@/logger/sanitizeUrl';
 
 type Environment = 'production' | 'internal' | 'development';
 const ENVIRONMENT: Environment = IS_DEV ? 'development' : IS_STORE_INSTALL ? 'production' : 'internal';
@@ -28,10 +30,73 @@ const IGNORED_ERRORS: Array<string | RegExp> = [
   /^Network request failed$/,
 ];
 
+/**
+ * Every fetch and XHR produces a breadcrumb carrying the full request URL, and the SDK attaches
+ * breadcrumbs to every event it sends.
+ *
+ * Both beforeBreadcrumb and beforeSend hooks need this, and neither is redundant. `beforeBreadcrumb`
+ * is the only pass over breadcrumbs that JS forwards to the native scope, where they ride native crash events that
+ * `beforeSend` never sees. `beforeSend` is the only pass over the breadcrumbs iOS merges onto an
+ * event of its own accord, which never reach `beforeBreadcrumb`. Running twice is harmless: a
+ * templated path and a placeholder both survive a second pass unchanged.
+ */
+function sanitizeBreadcrumb(breadcrumb: Sentry.Breadcrumb): Sentry.Breadcrumb {
+  const { data } = breadcrumb;
+  if (data) {
+    if (typeof data.url === 'string') {
+      const safe = sanitizeUrl(data.url);
+      if (safe) data.url = safe;
+      else delete data.url;
+    }
+    // The native tracker keeps these beside the url, so sanitising the url alone leaves them behind.
+    delete data['http.query'];
+    delete data['http.fragment'];
+  }
+
+  if (breadcrumb.message) breadcrumb.message = redactIdentifiers(breadcrumb.message);
+
+  return breadcrumb;
+}
+
+const MAX_METADATA_DEPTH = 3;
+
+/**
+ * Metadata is an open map of whatever a caller passed, so it has to be walked rather than assumed.
+ *
+ * **Only safe from `beforeSend`.** By then the event is Sentry's own normalised deep copy, so rewriting
+ * it affects nothing else, and Errors have already been flattened to plain objects. `beforeBreadcrumb`
+ * runs synchronously inside `addBreadcrumb`, and `sentryTransport` hands it a shallow copy of the
+ * caller's metadata: walking there would rewrite strings inside objects the app is still using.
+ */
+function redactValues(container: Record<string, unknown> | unknown[], depth = 0): void {
+  for (const [key, value] of Object.entries(container)) {
+    if (typeof value === 'string') (container as Record<string, unknown>)[key] = redactIdentifiers(value);
+    else if (value && typeof value === 'object' && depth < MAX_METADATA_DEPTH) {
+      redactValues(value as Record<string, unknown>, depth + 1);
+    }
+  }
+}
+
 export const defaultOptions: Sentry.ReactNativeOptions = {
   attachStacktrace: true,
 
+  beforeBreadcrumb: sanitizeBreadcrumb,
   beforeSend(event, hint) {
+    // iOS merges its own network breadcrumbs onto the event after `beforeBreadcrumb` has run, so this
+    // is the only hook that sees them, and they arrive with the path and query intact.
+    for (const breadcrumb of event.breadcrumbs ?? []) {
+      sanitizeBreadcrumb(breadcrumb);
+      if (breadcrumb.data) redactValues(breadcrumb.data);
+    }
+
+    // Logger metadata lands here, and our own call sites pass addresses through it.
+    if (event.extra) redactValues(event.extra);
+
+    if (event.message) event.message = redactIdentifiers(event.message);
+    for (const exception of event.exception?.values ?? []) {
+      if (exception.value) exception.value = redactIdentifiers(exception.value);
+    }
+
     // Drop non-actionable fetch errors (5xx, network failures).
     const error = hint?.originalException;
     if (error instanceof RainbowError && error.cause instanceof RainbowFetchError) {


### PR DESCRIPTION
Sentry logs a URL for every request as a breadcrumb, and SDKs interpolate their own values into their own error messages, so both fill up with identifiers nobody decided to collect. It also makes issues hard to read: e.g an ethers `CALL_EXCEPTION` carries the JSON-RPC request id, so one recurring failure gets a different title every time.

This change redacts URLs, message text and logger metadata before anything leaves the device, e.g

```
api.example.com/v1/transactions/0x88df…944b?currency=USD
  ->  api.example.com/v1/transactions/:id

missing revert data … (requestBody={"id":42,…}, code=CALL_EXCEPTION)
  ->  missing revert data … (requestBody={"id":[id],…}, code=CALL_EXCEPTION)
```

Breadcrumb URLs keep their origin and a templated path, and lose the query. Templating fails closed: a segment survives only if it's an api version or a route word, so anything unrecognised becomes `:id` and a URL we can't parse is dropped rather than half-rendered. Chain ids go with it, since a chain id and a resource id are the same shape. Message text, exception values and metadata values get typed placeholders (`[address]`, `[hash]`, `[id]`). Grouping keys on stacks rather than message text, so this shouldn't merge or split issues.

One thing worth flagging, since it explains why `beforeSend` repeats work `beforeBreadcrumb` has already done: iOS records its own network breadcrumbs and merges them onto JS events in an event processor, so they never pass `beforeBreadcrumb`, and they arrive with the path intact and the query in a separate field. I only found that by reading the SDK source, and it doesn't seem to be documented. Metadata is walked in `beforeSend` and deliberately not in `beforeBreadcrumb`: that hook runs synchronously inside `addBreadcrumb` on a shallow copy of the caller's object, so redacting there would rewrite strings the app is still using.

Not covered, and asserted as such in the tests: tags, which are low-cardinality by design, contexts, which are SDK-owned diagnostics, and breadcrumbs on native crash events, which never pass through JS. A contract address is also indistinguishable from a wallet address, so both get templated. In general, the goal is not to cover EVERY surface and redact EVERYTHING that could POSSIBLY leak, but first and foremost to do a good enough job and improve on it later.

Ref APP-3950.