### PR TITLE
fix: window.addEventListener is undefined

### DIFF
--- a/src/features/dapp-browser/services/AppMessenger.test.ts
+++ b/src/features/dapp-browser/services/AppMessenger.test.ts
@@ -1,0 +1,33 @@
+import { type RefObject } from 'react';
+
+import type WebView from 'react-native-webview';
+
+import { appMessenger } from './AppMessenger';
+
+test('routes a WebView reply to the matching app message', async () => {
+  const injectJavaScript = jest.fn();
+  const messenger = appMessenger({ current: { injectJavaScript } } as unknown as RefObject<WebView>, 'tab-id', 'https://example.com');
+
+  const response = messenger.send<number, string>('chainChanged:example.com', 137, { id: 7 });
+
+  expect(injectJavaScript).toHaveBeenCalledWith('window.postMessage({"topic":"> chainChanged:example.com","payload":137,"id":7})');
+
+  messenger.dispatch({
+    data: {
+      topic: '< chainChanged:example.com',
+      payload: { response: 'wrong response' },
+      id: 8,
+    },
+    meta: { sender: {} },
+  });
+  messenger.dispatch({
+    data: {
+      topic: '< chainChanged:example.com',
+      payload: { response: 'handled' },
+      id: 7,
+    },
+    meta: { sender: {} },
+  });
+
+  await expect(response).resolves.toBe('handled');
+});

--- a/src/features/dapp-browser/services/AppMessenger.ts
+++ b/src/features/dapp-browser/services/AppMessenger.ts
@@ -39,6 +39,7 @@ export type Messenger = {
     topic: string,
     callback: CallbackFunction<TPayload, TResponse>
   ) => () => void;
+  dispatch: (event: MessengerEvent) => void;
 };
 
 export type SendMessage<TPayload> = {
@@ -51,6 +52,11 @@ export type ReplyMessage<TResponse> = {
   topic: string;
   id: number | string;
   payload: { response: TResponse; error: Error };
+};
+
+export type MessengerEvent<TPayload = unknown> = {
+  data: SendMessage<TPayload>;
+  meta: { sender: IMessageSender };
 };
 
 /**
@@ -68,41 +74,41 @@ export function isValidSend({ topic, message }: { topic: string; message: SendMe
   return true;
 }
 
-export function isValidReply<TResponse>({ id, topic, message }: { id?: number | string; topic: string; message: ReplyMessage<TResponse> }) {
-  if (message.topic !== `< ${topic}`) return;
-  if (typeof id !== 'undefined' && message.id !== id) return;
-  if (!message.payload) return;
+export function isValidReply<TResponse>(
+  message: SendMessage<unknown>,
+  { id, topic }: { id?: number | string; topic: string }
+): message is ReplyMessage<TResponse> {
+  if (message.topic !== `< ${topic}`) return false;
+  if (typeof id !== 'undefined' && message.id !== id) return false;
+  if (!message.payload) return false;
   return true;
 }
 
 export const appMessenger = (webViewRef: RefObject<WebView | null>, tabId: string, url: string) => {
-  const listeners: { [topic: string]: (event: MessageEvent) => void } = {};
+  const listeners: { [topic: string]: (event: MessengerEvent) => void } = {};
 
   return {
     ...createMessenger({
       available: true,
       name: 'appMessenger',
-      async send(topic, payload, { id } = {}) {
+      async send<TPayload, TResponse>(topic: string, payload: TPayload, { id }: { id?: number | string } = {}) {
         const data = { topic: `> ${topic}`, payload, id };
-        webViewRef.current?.injectJavaScript(`window.postMessage(${JSON.stringify(data)})`);
-        // ... and also set up an event listener to listen for the response ('< {topic}').
-        return new Promise((resolve, reject) => {
-          const listener = (event: MessageEvent) => {
-            if (!isValidReply({ id, message: event.data, topic })) return;
-            const { response, error } = event.data.payload;
+        const response = new Promise<TResponse>((resolve, reject) => {
+          const listener = (event: MessengerEvent) => {
+            const message = event.data;
+            if (!isValidReply<TResponse>(message, { id, topic })) return;
             delete listeners[topic];
-            if (error) reject(new Error(error.message));
-            resolve(response);
+            if (message.payload.error) reject(new Error(message.payload.error.message));
+            resolve(message.payload.response);
           };
-          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-          // @ts-ignore
-          listeners[topic] = listener as (event: MessageEvent) => void;
-
-          window.addEventListener('message', listener);
+          listeners[topic] = listener;
         });
+
+        webViewRef.current?.injectJavaScript(`window.postMessage(${JSON.stringify(data)})`);
+        return response;
       },
       reply<TPayload, TResponse>(topic: string, callback: CallbackFunction<TPayload, TResponse>) {
-        const listener = async (event: MessageEvent<SendMessage<TPayload>>) => {
+        const listener = async (event: MessengerEvent<TPayload>) => {
           if (!isValidSend({ message: event.data, topic })) {
             return;
           }
@@ -111,8 +117,7 @@ export const appMessenger = (webViewRef: RefObject<WebView | null>, tabId: strin
           try {
             response = await callback(event.data.payload, {
               topic: event.data.topic,
-              // @ts-ignore
-              sender: event.meta.sender as IMessageSender,
+              sender: event.meta.sender,
               id: event.data.id,
             });
           } catch (error_) {
@@ -130,15 +135,19 @@ export const appMessenger = (webViewRef: RefObject<WebView | null>, tabId: strin
           };
           webViewRef.current?.injectJavaScript(`window.postMessage(${JSON.stringify(data)})`);
         };
-        listeners[topic] = listener as (event: MessageEvent) => void;
+        listeners[topic] = listener as (event: MessengerEvent) => void;
 
         return () => {
           delete listeners[topic];
         };
       },
+      dispatch(event) {
+        if (typeof event.data.topic !== 'string') return;
+        const topic = event.data.topic.slice(2);
+        listeners[topic]?.(event);
+      },
     }),
     url,
     tabId,
-    listeners,
   };
 };

--- a/src/features/dapp-browser/services/handleProviderRequest.ts
+++ b/src/features/dapp-browser/services/handleProviderRequest.ts
@@ -361,6 +361,5 @@ export const handleProviderRequestApp = ({ messenger, data, meta }: { messenger:
     getChainNativeCurrency: chainId => useBackendNetworksStore.getState().getChainsNativeAsset()[chainId],
   });
 
-  // @ts-ignore
-  messenger.listeners['providerRequest']?.({ data, meta });
+  messenger.dispatch({ data, meta });
 };


### PR DESCRIPTION
## Why?

Every message the app sends to a dapp in the in-app browser rejects with `TypeError: undefined is not a function`: the messenger was ported from the extension codebase and still registers reply listeners via `window.addEventListener`, which doesn't exist in React Native. Outgoing messages still reach the dapp, but replies can never be received, and each send surfaces as an unhandled rejection — [RAINBOW-WALLET-3XB0](https://rainbow-me.sentry.io/issues/RAINBOW-WALLET-3XB0), ~350k events across ~8k users.

## Approach

Reply listeners now live only in the messenger's own topic map, and incoming WebView events are routed to them through an explicit dispatch entry point — replacing both the dead DOM registration and the previous direct poke into the internal listeners map.

## What to test

- In the dapp browser, connect a wallet to a dapp and switch networks (from the dapp or the app) — the dapp should pick up the chain change and keep working.
- After release, the Sentry issue above should stop receiving new events.
