### PR TITLE
feat(CASH): Handle resume when user KYC been approved already

### DIFF
--- a/e2e/flows/cash/SetupResume.yaml
+++ b/e2e/flows/cash/SetupResume.yaml
@@ -93,7 +93,8 @@ tags:
     timeout: 10000
 - assertVisible:
     text: 'This number is already connected to an account.'
-# The kept digits resume again; the mock OTP finishes the resume and lands on Identity.
+# The kept digits resume again; the mock OTP finishes the resume, and the mock
+# account's approved KYC (mock GetUserStatus) skips straight to Add Passkey.
 - tapOn:
     id: cash-setup-next
 - extendedWaitUntil:
@@ -109,5 +110,5 @@ tags:
 - inputText: '0'
 - extendedWaitUntil:
     visible:
-      text: 'Enter some information about yourself'
+      text: 'Add a Passkey'
     timeout: 10000

--- a/src/features/cash/screens/cash-deposit-setup/CashDepositSetupScreen.tsx
+++ b/src/features/cash/screens/cash-deposit-setup/CashDepositSetupScreen.tsx
@@ -14,6 +14,7 @@ import Routes from '@/navigation/routesNames';
 import { type CashDepositSetupRoute, type RootStackParamList } from '@/navigation/types';
 
 import { useCashDepositSetupStatusStore } from '../../stores/cashDepositSetupStore';
+import { useVerifyPhoneFlowStore } from '../../stores/verifyPhoneFlowStore';
 import { CashDepositSetupNavigation, CashDepositSetupNavigator, useCashDepositSetupNavigationStore } from './cashDepositSetupNavigator';
 import { getFirstSetupStep, SETUP_STEP_ORDER } from './steps';
 import { AllDoneStep } from './steps/AllDoneStep';
@@ -64,6 +65,7 @@ export const CashDepositSetupScreen = memo(function CashDepositSetupScreen() {
   useCleanup(() => {
     CashDepositSetupNavigation.resetNavigationState();
     useSubmitPhoneFlowStore.getState().reset();
+    useVerifyPhoneFlowStore.getState().reset();
     useSubmitKycFlowStore.getState().reset();
     useAddPasskeyFlowStore.getState().reset();
   });

--- a/src/features/cash/screens/cash-deposit-setup/steps/PasskeyStep.tsx
+++ b/src/features/cash/screens/cash-deposit-setup/steps/PasskeyStep.tsx
@@ -1,10 +1,12 @@
-import React, { memo } from 'react';
-import { StyleSheet } from 'react-native';
+import React, { memo, useEffect } from 'react';
+import { Keyboard, StyleSheet } from 'react-native';
 
 import { Box, Text } from '@/design-system';
 import { CashStatusHalfSheet } from '@/features/cash/components/CashStatusHalfSheet';
 import * as i18n from '@/languages';
+import Routes from '@/navigation/routesNames';
 
+import { useCashDepositSetupNavigationStore } from '../cashDepositSetupNavigator';
 import { SetupStepLayout } from '../components/SetupStepLayout';
 import { useAddPasskeyFlow } from './useAddPasskeyFlow';
 
@@ -14,7 +16,12 @@ const KEY_ICON = '􀟖';
 
 export const PasskeyStep = memo(function PasskeyStep() {
   const { reset, state, submit } = useAddPasskeyFlow();
+  const isActiveStep = useCashDepositSetupNavigationStore(s => s.activeRoute === Routes.CASH_SETUP_PASSKEY);
   const submitting = state === 'submitting';
+
+  useEffect(() => {
+    if (isActiveStep) Keyboard.dismiss();
+  }, [isActiveStep]);
 
   return (
     <>

--- a/src/features/cash/screens/cash-deposit-setup/steps/useVerifyPhoneFlow.ts
+++ b/src/features/cash/screens/cash-deposit-setup/steps/useVerifyPhoneFlow.ts
@@ -3,9 +3,11 @@ import { useCallback, useEffect, useState } from 'react';
 import { createStoreActions } from '@storesjs/stores';
 
 import { time } from '@/framework/core/utils/time';
+import Routes from '@/navigation/routesNames';
 
 import { selectResendAfter, useCashSetupSessionStore } from '../../../stores/cashSetupSessionStore';
 import { useVerifyPhoneFlowStore, type VerifyPhoneState } from '../../../stores/verifyPhoneFlowStore';
+import { CashDepositSetupNavigation } from '../cashDepositSetupNavigator';
 import { useCashDepositSetupNavigation } from '../useCashDepositSetupNavigation';
 
 const verifyPhoneFlowActions = createStoreActions(useVerifyPhoneFlowStore);
@@ -29,6 +31,7 @@ export function useVerifyPhoneFlow(): {
   const submit = useCallback(async () => {
     const result = await verifyPhoneFlowActions.submit();
     if (result === 'verified') next();
+    if (result === 'verifiedKycApproved') CashDepositSetupNavigation.navigate(Routes.CASH_SETUP_PASSKEY);
     if (result === 'signupAlreadyComplete') back();
   }, [back, next]);
 

--- a/src/features/cash/stores/verifyPhoneFlowStore.test.ts
+++ b/src/features/cash/stores/verifyPhoneFlowStore.test.ts
@@ -1,7 +1,8 @@
 import { analytics } from '@/analytics';
 import { logger } from '@/logger';
+import { delay } from '@/utils/delay';
 
-import { finishSignupResume, resendPhoneCode, startSignupResume, verifyPhone } from '../services/userClient';
+import { finishSignupResume, getUserStatus, KycStatus, resendPhoneCode, startSignupResume, verifyPhone } from '../services/userClient';
 import { useCashSetupSessionStore, type PhoneChallenge } from './cashSetupSessionStore';
 import { useVerifyPhoneFlowStore } from './verifyPhoneFlowStore';
 
@@ -21,8 +22,20 @@ jest.mock('@/logger', () => ({
   RainbowError: class RainbowError extends Error {},
 }));
 
+jest.mock('@/utils/delay', () => ({
+  delay: jest.fn(() => Promise.resolve()),
+}));
+
 jest.mock('../services/userClient', () => ({
+  KycStatus: {
+    Unspecified: 'KYC_STATUS_UNSPECIFIED',
+    Pending: 'KYC_STATUS_PENDING',
+    Approved: 'KYC_STATUS_APPROVED',
+    Rejected: 'KYC_STATUS_REJECTED',
+    Review: 'KYC_STATUS_REVIEW',
+  },
   finishSignupResume: jest.fn(),
+  getUserStatus: jest.fn(),
   resendPhoneCode: jest.fn(),
   startSignupResume: jest.fn(),
   verifyPhone: jest.fn(),
@@ -30,6 +43,8 @@ jest.mock('../services/userClient', () => ({
 
 const mockVerifyPhone = verifyPhone as jest.Mock;
 const mockFinishSignupResume = finishSignupResume as jest.Mock;
+const mockGetUserStatus = getUserStatus as jest.Mock;
+const mockDelay = delay as jest.Mock;
 const mockResendPhoneCode = resendPhoneCode as jest.Mock;
 const mockStartSignupResume = startSignupResume as jest.Mock;
 const track = analytics.track as jest.Mock;
@@ -56,6 +71,7 @@ beforeEach(() => {
   useVerifyPhoneFlowStore.getState().reset();
   mockVerifyPhone.mockResolvedValue(TOKEN);
   mockFinishSignupResume.mockResolvedValue({ outcome: 'verified', ...TOKEN });
+  mockGetUserStatus.mockResolvedValue({ kycStatus: KycStatus.Pending });
   mockResendPhoneCode.mockResolvedValue({ resendAfter: RESEND_AFTER });
   mockStartSignupResume.mockResolvedValue({ resumeId: 'rcv_2', resendAfter: RESEND_AFTER });
 });
@@ -65,7 +81,7 @@ afterEach(() => {
 });
 
 describe('useVerifyPhoneFlowStore.submit', () => {
-  it('verifies the code, stores the token, tracks, then resets to a clean entry state', async () => {
+  it('verifies the code, stores the token, tracks, and keeps the OTP input disabled', async () => {
     flow().setCode(CODE);
 
     await expect(flow().submit()).resolves.toBe('verified');
@@ -77,8 +93,7 @@ describe('useVerifyPhoneFlowStore.submit', () => {
       bootstrapTokenExpiresAt: TOKEN.expiresAt,
     });
     expect(track).toHaveBeenCalledWith('cash.phone_verified', { mode: 'signup' });
-    expect(flow().state).toBe('entry');
-    expect(flow().code).toBe('');
+    expect(flow().state).toBe('verifying');
   });
 
   it('verifies a resume challenge through FinishSignupResume', async () => {
@@ -91,6 +106,53 @@ describe('useVerifyPhoneFlowStore.submit', () => {
     expect(mockVerifyPhone).not.toHaveBeenCalled();
     expect(session()).toMatchObject({ status: 'phoneVerified', bootstrapToken: TOKEN.bootstrapToken });
     expect(track).toHaveBeenCalledWith('cash.phone_verified', { mode: 'resume' });
+  });
+
+  it('reports approved KYC when the resumed account already passed it', async () => {
+    submitPhone({ kind: 'resume', resumeId: 'rcv_1' });
+    mockGetUserStatus.mockResolvedValue({ kycStatus: KycStatus.Approved });
+    flow().setCode(CODE);
+
+    await expect(flow().submit()).resolves.toBe('verifiedKycApproved');
+
+    expect(mockGetUserStatus).toHaveBeenCalledWith({ bootstrapToken: TOKEN.bootstrapToken });
+    expect(session()).toMatchObject({ status: 'phoneVerified', bootstrapToken: TOKEN.bootstrapToken });
+    expect(track).toHaveBeenCalledWith('cash.phone_verified', { mode: 'resume' });
+    expect(flow().state).toBe('verifying');
+  });
+
+  it('retries a failed resume status check once after a delay', async () => {
+    submitPhone({ kind: 'resume', resumeId: 'rcv_1' });
+    mockGetUserStatus.mockRejectedValueOnce(new Error('network down')).mockResolvedValueOnce({ kycStatus: KycStatus.Approved });
+    flow().setCode(CODE);
+
+    await expect(flow().submit()).resolves.toBe('verifiedKycApproved');
+
+    expect(mockGetUserStatus).toHaveBeenCalledTimes(2);
+    expect(mockDelay).toHaveBeenCalledWith(2000);
+    expect(session()).toMatchObject({ status: 'phoneVerified', bootstrapToken: TOKEN.bootstrapToken });
+  });
+
+  it('keeps the verification and falls back to the KYC entry flow when the resume status check keeps failing', async () => {
+    submitPhone({ kind: 'resume', resumeId: 'rcv_1' });
+    mockGetUserStatus.mockRejectedValue(new Error('network down'));
+    flow().setCode(CODE);
+
+    await expect(flow().submit()).resolves.toBe('verified');
+
+    expect(mockGetUserStatus).toHaveBeenCalledTimes(2);
+    expect(session()).toMatchObject({ status: 'phoneVerified', bootstrapToken: TOKEN.bootstrapToken });
+    expect(track).toHaveBeenCalledWith('cash.phone_verified', { mode: 'resume' });
+    expect(track).not.toHaveBeenCalledWith('cash.phone_verify_failed', expect.anything());
+  });
+
+  it('does not check KYC status for a fresh signup', async () => {
+    mockGetUserStatus.mockResolvedValue({ kycStatus: KycStatus.Approved });
+    flow().setCode(CODE);
+
+    await expect(flow().submit()).resolves.toBe('verified');
+
+    expect(mockGetUserStatus).not.toHaveBeenCalled();
   });
 
   it('marks the phone as already registered when the resumed account turns out to have a passkey', async () => {
@@ -158,6 +220,8 @@ describe('useVerifyPhoneFlowStore.submit', () => {
     await expect(pending).resolves.toBe('failed');
     expect(session()).toMatchObject({ status: 'phoneSubmitted', challenge: { kind: 'signup', userId: 'user-2' } });
     expect(track).not.toHaveBeenCalledWith('cash.phone_verified', expect.anything());
+    expect(flow().state).toBe('entry');
+    expect(flow().code).toBe('');
   });
 
   it('discards a verification that resolves after a replacement submission for the same user', async () => {

--- a/src/features/cash/stores/verifyPhoneFlowStore.ts
+++ b/src/features/cash/stores/verifyPhoneFlowStore.ts
@@ -1,16 +1,27 @@
 import { createBaseStore } from '@storesjs/stores';
 
 import { analytics } from '@/analytics';
+import { time } from '@/framework/core/utils/time';
 import { logger, RainbowError } from '@/logger';
+import { delay } from '@/utils/delay';
 
-import { finishSignupResume, resendPhoneCode, startSignupResume, verifyPhone } from '../services/userClient';
+import { finishSignupResume, getUserStatus, KycStatus, resendPhoneCode, startSignupResume, verifyPhone } from '../services/userClient';
 import { useCashSetupSessionStore, type PhoneChallenge } from './cashSetupSessionStore';
 
 export const OTP_LENGTH = 6;
 
 export type VerifyPhoneState = 'entry' | 'verifying' | 'error';
 
-export type VerifyPhoneResult = 'verified' | 'failed' | 'signupAlreadyComplete';
+export type VerifyPhoneResult = 'verified' | 'verifiedKycApproved' | 'failed' | 'signupAlreadyComplete';
+
+// Best-effort: failing only costs an approved user a redundant pass through
+// KYC entry, so a transient status failure gets one delayed retry.
+async function getIsKycApproved(bootstrapToken: string): Promise<boolean> {
+  const check = async () => (await getUserStatus({ bootstrapToken })).kycStatus === KycStatus.Approved;
+  return check()
+    .catch(() => delay(time.seconds(2)).then(check))
+    .catch(() => false);
+}
 
 type VerifyPhoneFlowStore = {
   state: VerifyPhoneState;
@@ -43,7 +54,10 @@ export const useVerifyPhoneFlowStore = createBaseStore<VerifyPhoneFlowStore>((se
         challenge.kind === 'signup'
           ? { outcome: 'verified' as const, ...(await verifyPhone({ userId: challenge.userId, code })) }
           : await finishSignupResume({ resumeId: challenge.resumeId, code });
-      if (!sessionStore.getIsCurrentChallenge(challenge)) return 'failed';
+      if (!sessionStore.getIsCurrentChallenge(challenge)) {
+        set(state => (state.state === 'verifying' ? { code: '', state: 'entry' } : state));
+        return 'failed';
+      }
 
       if (result.outcome === 'signupAlreadyComplete') {
         analytics.track(analytics.event.cashPhoneAlreadyRegistered, { outcome: 'signupAlreadyComplete' });
@@ -54,10 +68,17 @@ export const useVerifyPhoneFlowStore = createBaseStore<VerifyPhoneFlowStore>((se
 
       sessionStore.setPhoneVerified(challenge, { bootstrapToken: result.bootstrapToken, expiresAt: result.expiresAt });
       analytics.track(analytics.event.cashPhoneVerified, { mode: challenge.kind });
-      set({ code: '', state: 'entry' });
-      return 'verified';
+      // A resumed account may have completed KYC in an earlier signup attempt.
+      const skipKyc = challenge.kind === 'resume' && (await getIsKycApproved(result.bootstrapToken));
+      // State stays 'verifying' for good — this step is never revisited, and
+      // re-enabling the kept-mounted OTP input would refocus it and flash the
+      // keyboard. Screen cleanup or a fresh phone submission resets the store.
+      return skipKyc ? 'verifiedKycApproved' : 'verified';
     } catch (e) {
-      if (!sessionStore.getIsCurrentChallenge(challenge)) return 'failed';
+      if (!sessionStore.getIsCurrentChallenge(challenge)) {
+        set(state => (state.state === 'verifying' ? { code: '', state: 'entry' } : state));
+        return 'failed';
+      }
       logger.error(new RainbowError('[useVerifyPhoneFlow]: Failed to verify phone', e));
       analytics.track(analytics.event.cashPhoneVerifyFailed, {
         reason: e instanceof Error ? e.message : String(e),


### PR DESCRIPTION
Fixed: APP-3917

## Description

A user who verified their phone and passed KYC in an earlier signup attempt, but dropped off before adding a passkey, resumes signup through the silent resume flow. Until now they were pushed through the identity, SSN, and review steps again even though their KYC was already approved — and could not complete them meaningfully.

After the resume OTP is confirmed we now check the account's KYC status: approved users land directly on the Add Passkey step, everyone else continues through the KYC steps unchanged. If the status check itself fails, there is a second attempt, if the latter fails - it fails as the code incorrect.

## Caveat
Right now there is no good way to skip over some screen using `SmoothPager`, so under the hood we skip all KYC screen between code verification and Add Passkey screen, which is not critical, but not ideal either - we can address it later though.

## Video

https://github.com/user-attachments/assets/76584be2-498d-4abd-8fc8-7ea079f828bb


## Testing

1. Start deposit setup with a phone number registered without a passkey whose KYC was already approved, and confirm the OTP → you land straight on Add Passkey, with no identity/SSN/review screens.
2. Repeat with a resumed account whose KYC is not approved → the identity, SSN, and review steps appear as before.
