### PR TITLE
chore(CASH): Ensure user can not go back after certain milestones

### DIFF
--- a/src/features/cash/components/CashActionButton.tsx
+++ b/src/features/cash/components/CashActionButton.tsx
@@ -7,6 +7,7 @@ import { Box, Text, useForegroundColor, type TextProps } from '@/design-system';
 import { opacity } from '@/framework/ui/utils/opacity';
 
 type CashActionButtonProps = {
+  color?: 'blue' | 'red';
   disabled?: boolean;
   label: string;
   loading?: boolean;
@@ -18,6 +19,7 @@ type CashActionButtonProps = {
 };
 
 export const CashActionButton = memo(function CashActionButton({
+  color = 'blue',
   disabled = false,
   label,
   loading = false,
@@ -29,7 +31,7 @@ export const CashActionButton = memo(function CashActionButton({
 }: CashActionButtonProps) {
   const blue = useForegroundColor('blue');
   const isDisabled = disabled || loading;
-  const textColor = variant === 'solid' ? 'white' : 'blue';
+  const textColor = variant === 'solid' ? 'white' : color;
 
   return (
     <ButtonPressAnimation

--- a/src/features/cash/components/CashStatusHalfSheet.tsx
+++ b/src/features/cash/components/CashStatusHalfSheet.tsx
@@ -1,5 +1,5 @@
-import React, { memo } from 'react';
-import { StyleSheet, View } from 'react-native';
+import React, { memo, useEffect } from 'react';
+import { Keyboard, StyleSheet, View } from 'react-native';
 
 import Animated, { Easing, FadeIn, FadeOut, LinearTransition, SlideInDown, SlideOutDown } from 'react-native-reanimated';
 
@@ -7,6 +7,7 @@ import { AbsolutePortal } from '@/components/AbsolutePortal';
 import { PanelSheet } from '@/components/PanelSheet/PanelSheet';
 import { Box, Text } from '@/design-system';
 
+import { useCashHalfSheetVisibilityStore } from '../stores/cashHalfSheetVisibilityStore';
 import { CashActionButton } from './CashActionButton';
 
 type HalfSheetAction = {
@@ -26,17 +27,20 @@ type CashStatusHalfSheetProps = CommonProps &
     | { status: 'inProgress' }
     | { status: 'success'; action: HalfSheetAction; successIcon: string }
     | { status: 'error'; primaryAction: HalfSheetAction; secondaryAction?: HalfSheetAction }
+    | { status: 'warning'; primaryAction: HalfSheetAction; secondaryAction: HalfSheetAction }
   );
 
 const STATUS_ICONS = {
   error: '􀁠',
   inProgress: '􀖇',
+  warning: '􀇾',
 } as const;
 
 const STATUS_ICON_COLORS = {
   error: 'red',
   inProgress: 'blue',
   success: 'green',
+  warning: 'red',
 } as const;
 
 const PANEL_ENTERING_ANIMATION = SlideInDown.springify().damping(70).mass(0.8).stiffness(500);
@@ -46,6 +50,15 @@ const PANEL_RESIZE_ANIMATION = LinearTransition.duration(200).easing(Easing.inOu
 export const CashStatusHalfSheet = memo(function CashStatusHalfSheet(props: CashStatusHalfSheetProps) {
   const icon = props.status === 'success' ? props.successIcon : STATUS_ICONS[props.status];
   const iconColor = STATUS_ICON_COLORS[props.status];
+  const isAlert = props.status === 'error' || props.status === 'warning';
+
+  useEffect(() => {
+    // A keyboard would cover the sheet, whose backdrop blocks any way to close it.
+    Keyboard.dismiss();
+    const { register, unregister } = useCashHalfSheetVisibilityStore.getState();
+    register();
+    return unregister;
+  }, []);
 
   return (
     <AbsolutePortal>
@@ -56,7 +69,7 @@ export const CashStatusHalfSheet = memo(function CashStatusHalfSheet(props: Cash
             <Animated.View entering={FadeIn.duration(160)} exiting={FadeOut.duration(160)} key={props.status}>
               <Box paddingBottom={props.status === 'inProgress' ? '32px' : '20px'} paddingHorizontal="32px" paddingTop="52px">
                 <Box height={{ custom: 64 }} justifyContent="center">
-                  <Text color={iconColor} size="44pt" style={[styles.icon, props.status === 'error' && styles.errorIcon]} weight="heavy">
+                  <Text color={iconColor} size="44pt" style={[styles.icon, isAlert && styles.alertIcon]} weight="heavy">
                     {icon}
                   </Text>
                 </Box>
@@ -76,7 +89,7 @@ export const CashStatusHalfSheet = memo(function CashStatusHalfSheet(props: Cash
                   </Box>
                 )}
 
-                {props.status === 'error' && (
+                {isAlert && (
                   <Box gap={16} paddingTop="32px">
                     <CashActionButton
                       label={props.primaryAction.label}
@@ -86,6 +99,7 @@ export const CashStatusHalfSheet = memo(function CashStatusHalfSheet(props: Cash
                     />
                     {props.secondaryAction && (
                       <CashActionButton
+                        color={props.status === 'warning' ? 'red' : 'blue'}
                         label={props.secondaryAction.label}
                         onPress={props.secondaryAction.onPress}
                         testID={props.secondaryAction.testID}
@@ -108,7 +122,7 @@ const styles = StyleSheet.create({
     ...StyleSheet.absoluteFillObject,
     backgroundColor: 'rgba(0, 0, 0, 0.44)',
   },
-  errorIcon: {
+  alertIcon: {
     fontSize: 46,
   },
   icon: {

--- a/src/features/cash/components/CashStepLayout.tsx
+++ b/src/features/cash/components/CashStepLayout.tsx
@@ -17,7 +17,9 @@ export type CashStepLayoutProps = {
   actionTestID: string;
   backTestID: string;
   onAction: () => void;
-  onBack: () => void;
+  /** Omit to hide the back button. */
+  onBack?: () => void;
+  headerRight?: ReactNode;
   actionDisabled?: boolean;
   actionLoading?: boolean;
   backDisabled?: boolean;
@@ -32,6 +34,7 @@ export const CashStepLayout = memo(function CashStepLayout({
   backTestID,
   onAction,
   onBack,
+  headerRight,
   actionDisabled = false,
   actionLoading = false,
   backDisabled = false,
@@ -53,20 +56,27 @@ export const CashStepLayout = memo(function CashStepLayout({
         width="full"
         style={{ paddingBottom: insets.bottom, paddingTop: insets.top + 24 }}
       >
-        <ButtonPressAnimation disabled={backDisabled} onPress={onBack} scaleTo={0.8} testID={backTestID}>
-          <Box
-            alignItems="center"
-            background="fillTertiary"
-            borderRadius={18}
-            height={{ custom: 36 }}
-            justifyContent="center"
-            width={{ custom: 36 }}
-          >
-            <Text align="center" color="label" size="17pt" weight="heavy">
-              {'􀆉'}
-            </Text>
-          </Box>
-        </ButtonPressAnimation>
+        <Box alignItems="center" flexDirection="row" height={{ custom: 36 }} justifyContent="space-between">
+          {onBack ? (
+            <ButtonPressAnimation disabled={backDisabled} onPress={onBack} scaleTo={0.8} testID={backTestID}>
+              <Box
+                alignItems="center"
+                background="fillTertiary"
+                borderRadius={18}
+                height={{ custom: 36 }}
+                justifyContent="center"
+                width={{ custom: 36 }}
+              >
+                <Text align="center" color="label" size="17pt" weight="heavy">
+                  {'􀆉'}
+                </Text>
+              </Box>
+            </ButtonPressAnimation>
+          ) : (
+            <Box />
+          )}
+          {headerRight}
+        </Box>
 
         <Box gap={24} paddingTop="24px">
           <Text color="label" size="26pt" weight="heavy">

--- a/src/features/cash/screens/cash-deposit-setup/CashDepositSetupScreen.tsx
+++ b/src/features/cash/screens/cash-deposit-setup/CashDepositSetupScreen.tsx
@@ -8,14 +8,21 @@ import { AbsolutePortalRoot } from '@/components/AbsolutePortal';
 import { SPRING_CONFIGS } from '@/components/animations/animationConfigs';
 import { SmoothPager, usePagerNavigation } from '@/components/SmoothPager/SmoothPager';
 import { Box } from '@/design-system';
+import { useHardwareBackOnFocus } from '@/framework/ui/hooks/useHardwareBack';
 import { useCleanup } from '@/hooks/useCleanup';
 import { useStableValue } from '@/hooks/useStableValue';
 import Routes from '@/navigation/routesNames';
 import { type CashDepositSetupRoute, type RootStackParamList } from '@/navigation/types';
 
+import { useCardLinkFlowStore } from '../../stores/cardLinkFlowStore';
 import { useCashDepositSetupStatusStore } from '../../stores/cashDepositSetupStore';
+import { getIsCashHalfSheetOpen } from '../../stores/cashHalfSheetVisibilityStore';
+import { useCashSetupSessionStore } from '../../stores/cashSetupSessionStore';
 import { useVerifyPhoneFlowStore } from '../../stores/verifyPhoneFlowStore';
 import { CashDepositSetupNavigation, CashDepositSetupNavigator, useCashDepositSetupNavigationStore } from './cashDepositSetupNavigator';
+import { SetupCancelSheet } from './components/SetupCancelSheet';
+import { useSetupCancelSheetStore } from './setupCancelSheetStore';
+import { useIsSetupSubmittingStore } from './setupSubmittingStore';
 import { getFirstSetupStep, SETUP_STEP_ORDER } from './steps';
 import { AllDoneStep } from './steps/AllDoneStep';
 import { CardAddedStep } from './steps/CardAddedStep';
@@ -30,6 +37,7 @@ import { SsnStep } from './steps/SsnStep';
 import { useAddPasskeyFlowStore } from './steps/useAddPasskeyFlow';
 import { useSubmitKycFlowStore } from './steps/useSubmitKycFlow';
 import { useSubmitPhoneFlowStore } from './steps/useSubmitPhoneFlow';
+import { useCashDepositSetupNavigation } from './useCashDepositSetupNavigation';
 
 const STEP_COMPONENTS: Record<CashDepositSetupRoute, React.ReactElement> = {
   [Routes.CASH_SETUP_PHONE]: <PhoneStep />,
@@ -47,6 +55,7 @@ const STEP_COMPONENTS: Record<CashDepositSetupRoute, React.ReactElement> = {
 export const CashDepositSetupScreen = memo(function CashDepositSetupScreen() {
   const { params } = useRoute<RouteProp<RootStackParamList, typeof Routes.CASH_DEPOSIT_SETUP_SCREEN>>();
   const { ref, goToPage } = usePagerNavigation();
+  const { next, cancel } = useCashDepositSetupNavigation();
   const initialPage = useStableValue(
     () => params?.initialStep ?? getFirstSetupStep(useCashDepositSetupStatusStore.getState()) ?? SETUP_STEP_ORDER[0]
   );
@@ -62,19 +71,40 @@ export const CashDepositSetupScreen = memo(function CashDepositSetupScreen() {
     route => goToPage(route)
   );
 
+  useHardwareBackOnFocus(
+    () => {
+      if (useIsSetupSubmittingStore.getState() || getIsCashHalfSheetOpen()) return true;
+      const { activeRoute, history } = useCashDepositSetupNavigationStore.getState();
+      if (history.length) {
+        CashDepositSetupNavigation.goBack();
+      } else if (activeRoute === Routes.CASH_SETUP_CARD_ADDED) {
+        next();
+      } else {
+        cancel();
+      }
+      return true;
+    },
+    false,
+    [next, cancel]
+  );
+
   useCleanup(() => {
     CashDepositSetupNavigation.resetNavigationState();
+    useCashSetupSessionStore.getState().reset();
     useSubmitPhoneFlowStore.getState().reset();
     useVerifyPhoneFlowStore.getState().reset();
     useSubmitKycFlowStore.getState().reset();
     useAddPasskeyFlowStore.getState().reset();
+    useCardLinkFlowStore.getState().reset();
+    useSetupCancelSheetStore.getState().close();
   });
 
   return (
     <Box style={styles.container}>
       {useStableValue(() => (
         <SmoothPager
-          enableSwipeToGoBack
+          enableSwipeToGoBack={false}
+          enableSwipeToGoForward={false}
           initialPage={initialPage}
           lazy
           onNewIndex={CashDepositSetupNavigator.handlePagerIndexChange}
@@ -91,6 +121,7 @@ export const CashDepositSetupScreen = memo(function CashDepositSetupScreen() {
           ))}
         </SmoothPager>
       ))}
+      <SetupCancelSheet />
       <AbsolutePortalRoot />
     </Box>
   );

--- a/src/features/cash/screens/cash-deposit-setup/cashDepositSetupNavigator.ts
+++ b/src/features/cash/screens/cash-deposit-setup/cashDepositSetupNavigator.ts
@@ -1,11 +1,14 @@
 import { createVirtualNavigator } from '@/navigation/createVirtualNavigator';
 import { type CashDepositSetupRoute } from '@/navigation/types';
 
-import { SETUP_STEP_ORDER } from './steps';
+import { SETUP_STEP_GROUP, SETUP_STEP_ORDER } from './steps';
 
 const Navigator = createVirtualNavigator<CashDepositSetupRoute>({
   initialRoute: SETUP_STEP_ORDER[0],
   routes: [...SETUP_STEP_ORDER],
+  options: {
+    getRouteGroup: route => SETUP_STEP_GROUP[route],
+  },
 });
 
 export const CashDepositSetupNavigator = Navigator;

--- a/src/features/cash/screens/cash-deposit-setup/components/SetupCancelButton.tsx
+++ b/src/features/cash/screens/cash-deposit-setup/components/SetupCancelButton.tsx
@@ -5,13 +5,18 @@ import { Box, Text } from '@/design-system';
 import * as i18n from '@/languages';
 
 type SetupCancelButtonProps = {
+  disabled?: boolean;
   onPress: () => void;
   testID?: string;
 };
 
-export const SetupCancelButton = memo(function SetupCancelButton({ onPress, testID = 'cash-setup-cancel' }: SetupCancelButtonProps) {
+export const SetupCancelButton = memo(function SetupCancelButton({
+  disabled = false,
+  onPress,
+  testID = 'cash-setup-cancel',
+}: SetupCancelButtonProps) {
   return (
-    <ButtonPressAnimation onPress={onPress} scaleTo={0.92} testID={testID}>
+    <ButtonPressAnimation disabled={disabled} onPress={onPress} scaleTo={0.92} testID={testID}>
       <Box
         alignItems="center"
         background="fillTertiary"

--- a/src/features/cash/screens/cash-deposit-setup/components/SetupCancelSheet.tsx
+++ b/src/features/cash/screens/cash-deposit-setup/components/SetupCancelSheet.tsx
@@ -1,0 +1,33 @@
+import React, { memo, useCallback } from 'react';
+
+import { CashStatusHalfSheet } from '@/features/cash/components/CashStatusHalfSheet';
+import * as i18n from '@/languages';
+
+import { useSetupCancelSheetStore } from '../setupCancelSheetStore';
+import { useCashDepositSetupNavigation } from '../useCashDepositSetupNavigation';
+
+const l = i18n.l.cash.deposit_setup.cancel_sheet;
+
+export const SetupCancelSheet = memo(function SetupCancelSheet() {
+  const visible = useSetupCancelSheetStore(state => state.visible);
+  const close = useSetupCancelSheetStore(state => state.close);
+  const { dismiss } = useCashDepositSetupNavigation();
+
+  const confirm = useCallback(() => {
+    close();
+    dismiss();
+  }, [close, dismiss]);
+
+  if (!visible) return null;
+
+  return (
+    <CashStatusHalfSheet
+      description={i18n.t(l.description)}
+      primaryAction={{ label: i18n.t(l.continue), onPress: close, testID: 'cash-setup-cancel-continue' }}
+      secondaryAction={{ label: i18n.t(l.confirm), onPress: confirm, testID: 'cash-setup-cancel-confirm' }}
+      status="warning"
+      testID="cash-setup-cancel-sheet"
+      title={i18n.t(l.title)}
+    />
+  );
+});

--- a/src/features/cash/screens/cash-deposit-setup/components/SetupStepLayout.tsx
+++ b/src/features/cash/screens/cash-deposit-setup/components/SetupStepLayout.tsx
@@ -3,9 +3,15 @@ import React, { memo } from 'react';
 import { CashStepLayout, type CashStepLayoutProps } from '@/features/cash/components/CashStepLayout';
 import * as i18n from '@/languages';
 
+import { useCashDepositSetupNavigationStore } from '../cashDepositSetupNavigator';
+import { useIsSetupSubmittingStore } from '../setupSubmittingStore';
 import { useCashDepositSetupNavigation } from '../useCashDepositSetupNavigation';
+import { SetupCancelButton } from './SetupCancelButton';
 
-type SetupStepLayoutProps = Omit<CashStepLayoutProps, 'actionLabel' | 'actionTestID' | 'backTestID' | 'onAction' | 'onBack'> & {
+type SetupStepLayoutProps = Omit<
+  CashStepLayoutProps,
+  'actionLabel' | 'actionTestID' | 'backDisabled' | 'backTestID' | 'headerRight' | 'onAction' | 'onBack'
+> & {
   /** Overrides the default "Next" CTA label. */
   actionLabel?: string;
   /** Overrides the default `next()` press handler. */
@@ -13,16 +19,20 @@ type SetupStepLayoutProps = Omit<CashStepLayoutProps, 'actionLabel' | 'actionTes
 };
 
 export const SetupStepLayout = memo(function SetupStepLayout({ actionLabel, onAction, ...props }: SetupStepLayoutProps) {
-  const { next, back } = useCashDepositSetupNavigation();
+  const { next, back, cancel } = useCashDepositSetupNavigation();
+  const submitting = useIsSetupSubmittingStore();
+  const hasHistory = useCashDepositSetupNavigationStore(state => state.history.length > 0);
 
   return (
     <CashStepLayout
       {...props}
       actionLabel={actionLabel ?? i18n.t(i18n.l.cash.deposit_setup.next)}
       actionTestID="cash-setup-next"
+      backDisabled={submitting}
       backTestID="cash-setup-back"
+      headerRight={<SetupCancelButton disabled={submitting} onPress={cancel} />}
       onAction={onAction ?? next}
-      onBack={back}
+      onBack={hasHistory ? back : undefined}
     />
   );
 });

--- a/src/features/cash/screens/cash-deposit-setup/setupCancelSheetStore.ts
+++ b/src/features/cash/screens/cash-deposit-setup/setupCancelSheetStore.ts
@@ -1,0 +1,13 @@
+import { createBaseStore } from '@storesjs/stores';
+
+type SetupCancelSheetStore = {
+  visible: boolean;
+  open: () => void;
+  close: () => void;
+};
+
+export const useSetupCancelSheetStore = createBaseStore<SetupCancelSheetStore>(set => ({
+  visible: false,
+  open: () => set({ visible: true }),
+  close: () => set({ visible: false }),
+}));

--- a/src/features/cash/screens/cash-deposit-setup/setupSubmittingStore.ts
+++ b/src/features/cash/screens/cash-deposit-setup/setupSubmittingStore.ts
@@ -1,0 +1,20 @@
+import { createDerivedStore } from '@storesjs/stores';
+
+import { useCardLinkFlowStore } from '../../stores/cardLinkFlowStore';
+import { useVerifyPhoneFlowStore } from '../../stores/verifyPhoneFlowStore';
+import { useAddPasskeyFlowStore } from './steps/useAddPasskeyFlow';
+import { useSubmitKycFlowStore } from './steps/useSubmitKycFlow';
+import { useSubmitPhoneFlowStore } from './steps/useSubmitPhoneFlow';
+
+/** True while any Setup submission is in flight; disables every back/cancel affordance. */
+export const useIsSetupSubmittingStore = createDerivedStore<boolean>(
+  $ => {
+    const submittingPhone = $(useSubmitPhoneFlowStore, state => state.state === 'submitting');
+    const verifyingPhone = $(useVerifyPhoneFlowStore, state => state.state === 'verifying');
+    const submittingKyc = $(useSubmitKycFlowStore, state => state.state === 'submitting');
+    const addingPasskey = $(useAddPasskeyFlowStore, state => state.state === 'submitting');
+    const linkingCard = $(useCardLinkFlowStore, state => state.state === 'submitting');
+    return submittingPhone || verifyingPhone || submittingKyc || addingPasskey || linkingCard;
+  },
+  { lockDependencies: true }
+);

--- a/src/features/cash/screens/cash-deposit-setup/steps.ts
+++ b/src/features/cash/screens/cash-deposit-setup/steps.ts
@@ -17,6 +17,26 @@ export const SETUP_STEP_ORDER: readonly CashDepositSetupRoute[] = [
   Routes.CASH_SETUP_CARD_ADDED,
 ];
 
+type SetupBackGroup = 'signup' | 'kyc' | 'passkey' | 'email' | 'card' | 'cardAdded';
+
+/**
+ * Back navigation only works within a group; navigating across a boundary clears history, so
+ * steps behind an irreversible milestone (phone verified, KYC submitted, passkey enrolled,
+ * card linked) are unreachable.
+ */
+export const SETUP_STEP_GROUP: Record<CashDepositSetupRoute, SetupBackGroup> = {
+  [Routes.CASH_SETUP_PHONE]: 'signup',
+  [Routes.CASH_SETUP_CONFIRM_PHONE]: 'signup',
+  [Routes.CASH_SETUP_IDENTITY]: 'kyc',
+  [Routes.CASH_SETUP_SSN]: 'kyc',
+  [Routes.CASH_SETUP_REVIEW]: 'kyc',
+  [Routes.CASH_SETUP_PASSKEY]: 'passkey',
+  [Routes.CASH_SETUP_EMAIL]: 'email',
+  [Routes.CASH_SETUP_ALL_DONE]: 'card',
+  [Routes.CASH_SETUP_CARD_DETAILS]: 'card',
+  [Routes.CASH_SETUP_CARD_ADDED]: 'cardAdded',
+};
+
 export function getNextSetupStep(current: CashDepositSetupRoute): CashDepositSetupRoute | null {
   const index = SETUP_STEP_ORDER.indexOf(current);
   return SETUP_STEP_ORDER[index + 1] ?? null;

--- a/src/features/cash/screens/cash-deposit-setup/steps/AllDoneStep.tsx
+++ b/src/features/cash/screens/cash-deposit-setup/steps/AllDoneStep.tsx
@@ -8,11 +8,11 @@ import { useCashDepositSetupNavigation } from '../useCashDepositSetupNavigation'
 const l = i18n.l.cash.deposit_setup.all_done;
 
 export const AllDoneStep = memo(function AllDoneStep() {
-  const { dismiss } = useCashDepositSetupNavigation();
+  const { cancel } = useCashDepositSetupNavigation();
 
   return (
     <SetupSuccessStepLayout
-      accessory={{ type: 'cancel', onPress: dismiss }}
+      accessory={{ type: 'cancel', onPress: cancel }}
       actionLabel={i18n.t(l.add_bank_card)}
       description={i18n.t(l.description)}
       title={i18n.t(l.title)}

--- a/src/features/cash/screens/cash-deposit-setup/steps/CardDetailsStep.tsx
+++ b/src/features/cash/screens/cash-deposit-setup/steps/CardDetailsStep.tsx
@@ -1,5 +1,4 @@
 import React, { memo, useCallback, useEffect } from 'react';
-import { Keyboard } from 'react-native';
 
 import { BivoCardInput, BivoCVCInput, BivoTextInput } from '@bivoglobal/payment-react-native';
 
@@ -25,21 +24,14 @@ export const CardDetailsStep = memo(function CardLinkForm() {
     }
   }, [next, state]);
 
-  const submitting = state === 'submitting';
   const cancel = useCallback(() => {
     reset();
     back();
   }, [back, reset]);
 
-  // The number pads have no Done key, so an open keyboard would cover the status sheet with no way to close it.
-  const onSubmit = useCallback(() => {
-    Keyboard.dismiss();
-    submit();
-  }, [submit]);
-
   return (
     <>
-      <SetupStepLayout actionDisabled={!isReady} backDisabled={submitting} onAction={onSubmit} title={i18n.t(l.title)}>
+      <SetupStepLayout actionDisabled={!isReady} onAction={submit} title={i18n.t(l.title)}>
         <Box paddingTop="24px">
           <BivoCardInput
             bivoStore={bivoStore}

--- a/src/features/cash/screens/cash-deposit-setup/steps/ConfirmPhoneStep.tsx
+++ b/src/features/cash/screens/cash-deposit-setup/steps/ConfirmPhoneStep.tsx
@@ -17,21 +17,21 @@ export const ConfirmPhoneStep = memo(function ConfirmPhoneStep() {
   const { state, code, setCode, submit, resend, resending, resendCooldownSeconds } = useVerifyPhoneFlow();
   // The pager keeps visited steps mounted, so focus is tied to the step being active rather than to mount.
   const isActiveStep = useCashDepositSetupNavigationStore(s => s.activeRoute === Routes.CASH_SETUP_CONFIRM_PHONE);
-  const verifying = state === 'verifying';
+  // Stays true once the code is accepted: re-enabling the kept-mounted input would refocus it and flash the keyboard.
+  const submitted = state === 'verifying' || state === 'verified';
   const cooling = resendCooldownSeconds > 0;
 
   return (
     <SetupStepLayout
       actionDisabled={code.length !== OTP_LENGTH}
       actionLabel={i18n.t(l.confirm)}
-      actionLoading={verifying}
-      backDisabled={verifying}
+      actionLoading={submitted}
       onAction={submit}
       title={i18n.t(l.title)}
     >
       <Box gap={16} paddingTop="24px">
         <OtpInput
-          disabled={verifying}
+          disabled={submitted}
           error={state === 'error'}
           focused={isActiveStep}
           length={OTP_LENGTH}

--- a/src/features/cash/screens/cash-deposit-setup/steps/PasskeyStep.tsx
+++ b/src/features/cash/screens/cash-deposit-setup/steps/PasskeyStep.tsx
@@ -28,7 +28,6 @@ export const PasskeyStep = memo(function PasskeyStep() {
       <SetupStepLayout
         actionLabel={i18n.t(l.action)}
         actionLoading={submitting}
-        backDisabled={submitting}
         onAction={submit}
         subtitle={i18n.t(l.subtitle)}
         title={i18n.t(l.title)}

--- a/src/features/cash/screens/cash-deposit-setup/steps/PhoneStep.tsx
+++ b/src/features/cash/screens/cash-deposit-setup/steps/PhoneStep.tsx
@@ -24,7 +24,6 @@ export const PhoneStep = memo(function PhoneStep() {
     <SetupStepLayout
       actionDisabled={digits.length !== NATIONAL_NUMBER_LENGTH}
       actionLoading={submitting}
-      backDisabled={submitting}
       onAction={submit}
       subtitle={i18n.t(l.subtitle)}
       title={i18n.t(l.title)}

--- a/src/features/cash/screens/cash-deposit-setup/steps/ReviewStep.tsx
+++ b/src/features/cash/screens/cash-deposit-setup/steps/ReviewStep.tsx
@@ -73,7 +73,6 @@ export const ReviewStep = memo(function ReviewStep() {
       <SetupStepLayout
         actionDisabled={!identity || !governmentId}
         actionLabel={i18n.t(l.confirm)}
-        backDisabled={submitting}
         onAction={submit}
         subtitle={i18n.t(l.subtitle)}
         title={i18n.t(l.title)}

--- a/src/features/cash/screens/cash-deposit-setup/steps/useCardLinkFlow.ts
+++ b/src/features/cash/screens/cash-deposit-setup/steps/useCardLinkFlow.ts
@@ -1,16 +1,10 @@
-import { useCallback, useEffect, useReducer, useRef, useState } from 'react';
+import { useCallback, useEffect, useReducer, useState } from 'react';
 
 import { BivoSecureStore } from '@bivoglobal/payment-react-native';
+import { createStoreActions } from '@storesjs/stores';
 import { BIVO_ENV, BIVO_VAULT_ID } from 'react-native-dotenv';
 
-import { analytics } from '@/analytics';
-import { logger, RainbowError } from '@/logger';
-
-import { linkCardWithVault } from '../../../services/cardLinkService';
-import { isPasskeyCancellation } from '../../../services/cashPasskeyService';
-import { useCashPaymentMethodStore } from '../../../stores/cashPaymentMethodStore';
-
-export type CardLinkState = 'entry' | 'submitting' | 'submitError' | 'success';
+import { useCardLinkFlowStore, type CardLinkState } from '../../../stores/cardLinkFlowStore';
 
 export const CARD_FIELD = {
   number: 'card',
@@ -25,6 +19,8 @@ function createBivoStore(): BivoSecureStore {
   return new BivoSecureStore(BIVO_VAULT_ID, BIVO_ENV);
 }
 
+const cardLinkFlowActions = createStoreActions(useCardLinkFlowStore);
+
 export type UseCardLinkFlow = {
   state: CardLinkState;
   bivoStore: BivoSecureStore;
@@ -35,57 +31,24 @@ export type UseCardLinkFlow = {
 };
 
 export function useCardLinkFlow(): UseCardLinkFlow {
-  const [flowState, setFlowState] = useState<CardLinkState>('entry');
+  const state = useCardLinkFlowStore(state => state.state);
   const [bivoStore] = useState(createBivoStore);
   const [, onFieldStateChange] = useReducer(i => i + 1, 0);
-  const abortRef = useRef<AbortController | null>(null);
 
   const isReady = !bivoStore.isSubmitDisabled(SUBMIT_FIELDS);
 
-  const submit = useCallback(async () => {
-    if (abortRef.current) return;
-
-    const controller = new AbortController();
-    abortRef.current = controller;
-    setFlowState('submitting');
-
-    try {
-      const card = await linkCardWithVault(bivoStore, controller);
-      if (controller.signal.aborted) return;
-      useCashPaymentMethodStore.getState().setLinkedCard(card);
-      analytics.track(analytics.event.cashCardLinked, { brand: card.brand });
-      setFlowState('success');
-    } catch (e) {
-      if (controller.signal.aborted) return;
-      // Sign-in cancellation is a deliberate dismissal, not a failure: back to the form, silently.
-      if (isPasskeyCancellation(e)) {
-        setFlowState('entry');
-        return;
-      }
-      logger.error(new RainbowError('[useCardLinkFlow]: Failed to link card', e));
-      analytics.track(analytics.event.cashCardLinkFailed, { reason: e instanceof Error ? e.message : String(e) });
-      setFlowState('submitError');
-    } finally {
-      if (abortRef.current === controller) {
-        abortRef.current = null;
-      }
-    }
+  const submit = useCallback(() => {
+    cardLinkFlowActions.submit(bivoStore);
   }, [bivoStore]);
 
-  const reset = useCallback(() => setFlowState('entry'), []);
-
-  useEffect(() => {
-    return () => {
-      abortRef.current?.abort();
-    };
-  }, []);
+  useEffect(() => cardLinkFlowActions.reset, []);
 
   return {
-    state: flowState,
+    state,
     bivoStore,
     isReady,
     onFieldStateChange,
-    reset,
+    reset: cardLinkFlowActions.reset,
     submit,
   };
 }

--- a/src/features/cash/screens/cash-deposit-setup/useCashDepositSetupNavigation.ts
+++ b/src/features/cash/screens/cash-deposit-setup/useCashDepositSetupNavigation.ts
@@ -3,7 +3,10 @@ import { useCallback } from 'react';
 import { useNavigation } from '@/navigation/Navigation';
 import Routes from '@/navigation/routesNames';
 
+import { useCashAccountStore } from '../../stores/cashAccountStore';
+import { useCashSetupSessionStore } from '../../stores/cashSetupSessionStore';
 import { CashDepositSetupNavigation, useCashDepositSetupNavigationStore } from './cashDepositSetupNavigator';
+import { useSetupCancelSheetStore } from './setupCancelSheetStore';
 import { getNextSetupStep } from './steps';
 
 export function useCashDepositSetupNavigation() {
@@ -21,13 +24,24 @@ export function useCashDepositSetupNavigation() {
     navigate(Routes.ADD_CASH_SHEET);
   }, [dismissScreen, navigate]);
 
-  const back = useCallback(() => {
-    if (useCashDepositSetupNavigationStore.getState().history.length) {
-      CashDepositSetupNavigation.goBack();
+  const cancel = useCallback(() => {
+    const hasPasskey = useCashAccountStore.getState().userId != null;
+    const { status } = useCashSetupSessionStore.getState().session;
+    const hasProgressToLose = status === 'phoneSubmitted' || status === 'phoneVerified';
+    if (!hasPasskey && hasProgressToLose) {
+      useSetupCancelSheetStore.getState().open();
     } else {
       dismissScreen();
     }
   }, [dismissScreen]);
 
-  return { next, back, dismiss: dismissScreen };
+  const back = useCallback(() => {
+    if (useCashDepositSetupNavigationStore.getState().history.length) {
+      CashDepositSetupNavigation.goBack();
+    } else {
+      cancel();
+    }
+  }, [cancel]);
+
+  return { next, back, cancel, dismiss: dismissScreen };
 }

--- a/src/features/cash/stores/cardLinkFlowStore.test.ts
+++ b/src/features/cash/stores/cardLinkFlowStore.test.ts
@@ -1,0 +1,132 @@
+import type { BivoSecureStore } from '@bivoglobal/payment-react-native';
+
+import { analytics } from '@/analytics';
+
+import { linkCardWithVault } from '../services/cardLinkService';
+import { isPasskeyCancellation } from '../services/cashPasskeyService';
+import { useCardLinkFlowStore } from './cardLinkFlowStore';
+import { useCashPaymentMethodStore, type LinkedCard } from './cashPaymentMethodStore';
+
+jest.mock('@/analytics', () => ({
+  analytics: {
+    track: jest.fn(),
+    event: {
+      cashCardLinked: 'cash.card_linked',
+      cashCardLinkFailed: 'cash.card_link_failed',
+    },
+  },
+}));
+
+jest.mock('@/logger', () => ({
+  logger: { debug: jest.fn(), error: jest.fn(), warn: jest.fn() },
+  RainbowError: class RainbowError extends Error {},
+}));
+
+jest.mock('../services/cardLinkService', () => ({
+  linkCardWithVault: jest.fn(),
+}));
+
+jest.mock('../services/cashPasskeyService', () => ({
+  isPasskeyCancellation: jest.fn(),
+}));
+
+const mockLinkCardWithVault = linkCardWithVault as jest.Mock;
+const mockIsPasskeyCancellation = isPasskeyCancellation as jest.Mock;
+const track = analytics.track as jest.Mock;
+
+const CARD: LinkedCard = { id: 'card_1', brand: 'Visa Debit', last4: '8990' };
+const BIVO_STORE = {} as BivoSecureStore;
+
+const flow = () => useCardLinkFlowStore.getState();
+const linkedCard = () => useCashPaymentMethodStore.getState().linkedCard;
+
+function deferLink() {
+  let settle!: (result: { card?: LinkedCard; error?: unknown }) => void;
+  const pending = new Promise<{ card?: LinkedCard; error?: unknown }>(resolve => {
+    settle = resolve;
+  });
+  mockLinkCardWithVault.mockImplementation(async () => {
+    const { card, error } = await pending;
+    if (error) throw error;
+    return card;
+  });
+  return settle;
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  flow().reset();
+  useCashPaymentMethodStore.getState().clearLinkedCard();
+  mockLinkCardWithVault.mockResolvedValue(CARD);
+  mockIsPasskeyCancellation.mockReturnValue(false);
+});
+
+describe('cardLinkFlowStore', () => {
+  it('stores the card and reports success', async () => {
+    await flow().submit(BIVO_STORE);
+
+    expect(flow().state).toBe('success');
+    expect(linkedCard()).toEqual(CARD);
+    expect(track).toHaveBeenCalledWith('cash.card_linked', { brand: CARD.brand });
+  });
+
+  it('returns to the form silently when the passkey prompt is cancelled', async () => {
+    mockLinkCardWithVault.mockRejectedValue(new Error('user cancelled'));
+    mockIsPasskeyCancellation.mockReturnValue(true);
+
+    await flow().submit(BIVO_STORE);
+
+    expect(flow().state).toBe('entry');
+    expect(linkedCard()).toBeNull();
+    expect(track).not.toHaveBeenCalled();
+  });
+
+  it('reports a failure without storing a card', async () => {
+    mockLinkCardWithVault.mockRejectedValue(new Error('vault exploded'));
+
+    await flow().submit(BIVO_STORE);
+
+    expect(flow().state).toBe('submitError');
+    expect(linkedCard()).toBeNull();
+    expect(track).toHaveBeenCalledWith('cash.card_link_failed', { reason: 'vault exploded' });
+  });
+
+  it('ignores a second submit while one is in flight', async () => {
+    const settle = deferLink();
+
+    const first = flow().submit(BIVO_STORE);
+    await flow().submit(BIVO_STORE);
+    expect(mockLinkCardWithVault).toHaveBeenCalledTimes(1);
+
+    settle({ card: CARD });
+    await first;
+    expect(flow().state).toBe('success');
+  });
+
+  it('discards a response that resolves after a reset', async () => {
+    const settle = deferLink();
+
+    const submitted = flow().submit(BIVO_STORE);
+    expect(flow().state).toBe('submitting');
+
+    flow().reset();
+    settle({ card: CARD });
+    await submitted;
+
+    expect(flow().state).toBe('entry');
+    expect(linkedCard()).toBeNull();
+    expect(track).not.toHaveBeenCalled();
+  });
+
+  it('discards a rejection that arrives after a reset', async () => {
+    const settle = deferLink();
+
+    const submitted = flow().submit(BIVO_STORE);
+    flow().reset();
+    settle({ error: new Error('vault exploded') });
+    await submitted;
+
+    expect(flow().state).toBe('entry');
+    expect(track).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/cash/stores/cardLinkFlowStore.ts
+++ b/src/features/cash/stores/cardLinkFlowStore.ts
@@ -1,0 +1,57 @@
+import type { BivoSecureStore } from '@bivoglobal/payment-react-native';
+import { createBaseStore } from '@storesjs/stores';
+
+import { analytics } from '@/analytics';
+import { logger, RainbowError } from '@/logger';
+
+import { linkCardWithVault } from '../services/cardLinkService';
+import { isPasskeyCancellation } from '../services/cashPasskeyService';
+import { useCashPaymentMethodStore } from './cashPaymentMethodStore';
+
+export type CardLinkState = 'entry' | 'submitting' | 'submitError' | 'success';
+
+type CardLinkFlowStore = {
+  state: CardLinkState;
+  submit: (bivoStore: BivoSecureStore) => Promise<void>;
+  reset: () => void;
+};
+
+let inFlight: AbortController | null = null;
+
+export const useCardLinkFlowStore = createBaseStore<CardLinkFlowStore>((set, get) => ({
+  state: 'entry',
+
+  submit: async bivoStore => {
+    if (get().state === 'submitting') return;
+
+    const controller = new AbortController();
+    inFlight = controller;
+    set({ state: 'submitting' });
+
+    try {
+      const card = await linkCardWithVault(bivoStore, controller);
+      if (controller.signal.aborted) return;
+      useCashPaymentMethodStore.getState().setLinkedCard(card);
+      analytics.track(analytics.event.cashCardLinked, { brand: card.brand });
+      set({ state: 'success' });
+    } catch (e) {
+      if (controller.signal.aborted) return;
+      // Sign-in cancellation is a deliberate dismissal, not a failure: back to the form, silently.
+      if (isPasskeyCancellation(e)) {
+        set({ state: 'entry' });
+        return;
+      }
+      logger.error(new RainbowError('[cardLinkFlowStore]: Failed to link card', e));
+      analytics.track(analytics.event.cashCardLinkFailed, { reason: e instanceof Error ? e.message : String(e) });
+      set({ state: 'submitError' });
+    } finally {
+      if (inFlight === controller) inFlight = null;
+    }
+  },
+
+  reset: () => {
+    inFlight?.abort();
+    inFlight = null;
+    set({ state: 'entry' });
+  },
+}));

--- a/src/features/cash/stores/cashHalfSheetVisibilityStore.ts
+++ b/src/features/cash/stores/cashHalfSheetVisibilityStore.ts
@@ -1,0 +1,18 @@
+import { createBaseStore } from '@storesjs/stores';
+
+type CashHalfSheetVisibilityStore = {
+  count: number;
+  register: () => void;
+  unregister: () => void;
+};
+
+/** Mounted `CashStatusHalfSheet` instances; while any is open, back navigation is a no-op. */
+export const useCashHalfSheetVisibilityStore = createBaseStore<CashHalfSheetVisibilityStore>(set => ({
+  count: 0,
+  register: () => set(state => ({ count: state.count + 1 })),
+  unregister: () => set(state => ({ count: Math.max(0, state.count - 1) })),
+}));
+
+export function getIsCashHalfSheetOpen(): boolean {
+  return useCashHalfSheetVisibilityStore.getState().count > 0;
+}

--- a/src/features/cash/stores/verifyPhoneFlowStore.test.ts
+++ b/src/features/cash/stores/verifyPhoneFlowStore.test.ts
@@ -93,7 +93,7 @@ describe('useVerifyPhoneFlowStore.submit', () => {
       bootstrapTokenExpiresAt: TOKEN.expiresAt,
     });
     expect(track).toHaveBeenCalledWith('cash.phone_verified', { mode: 'signup' });
-    expect(flow().state).toBe('verifying');
+    expect(flow().state).toBe('verified');
   });
 
   it('verifies a resume challenge through FinishSignupResume', async () => {
@@ -118,7 +118,7 @@ describe('useVerifyPhoneFlowStore.submit', () => {
     expect(mockGetUserStatus).toHaveBeenCalledWith({ bootstrapToken: TOKEN.bootstrapToken });
     expect(session()).toMatchObject({ status: 'phoneVerified', bootstrapToken: TOKEN.bootstrapToken });
     expect(track).toHaveBeenCalledWith('cash.phone_verified', { mode: 'resume' });
-    expect(flow().state).toBe('verifying');
+    expect(flow().state).toBe('verified');
   });
 
   it('retries a failed resume status check once after a delay', async () => {
@@ -296,6 +296,17 @@ describe('useVerifyPhoneFlowStore.submit', () => {
     expect(mockVerifyPhone).toHaveBeenCalledTimes(1);
     resolveVerify(TOKEN);
     await expect(first).resolves.toBe('verified');
+  });
+
+  // The Confirm button is briefly tappable again between acceptance and the pager moving on.
+  it('ignores a submit after the code was already accepted', async () => {
+    flow().setCode(CODE);
+    await flow().submit();
+
+    await expect(flow().submit()).resolves.toBe('failed');
+
+    expect(mockVerifyPhone).toHaveBeenCalledTimes(1);
+    expect(flow().state).toBe('verified');
   });
 });
 

--- a/src/features/cash/stores/verifyPhoneFlowStore.ts
+++ b/src/features/cash/stores/verifyPhoneFlowStore.ts
@@ -10,7 +10,7 @@ import { useCashSetupSessionStore, type PhoneChallenge } from './cashSetupSessio
 
 export const OTP_LENGTH = 6;
 
-export type VerifyPhoneState = 'entry' | 'verifying' | 'error';
+export type VerifyPhoneState = 'entry' | 'verifying' | 'verified' | 'error';
 
 export type VerifyPhoneResult = 'verified' | 'verifiedKycApproved' | 'failed' | 'signupAlreadyComplete';
 
@@ -42,7 +42,7 @@ export const useVerifyPhoneFlowStore = createBaseStore<VerifyPhoneFlowStore>((se
 
   submit: async () => {
     const { code, state } = get();
-    if (code.length !== OTP_LENGTH || state === 'verifying') return 'failed';
+    if (code.length !== OTP_LENGTH || state === 'verifying' || state === 'verified') return 'failed';
     const sessionStore = useCashSetupSessionStore.getState();
     const { session } = sessionStore;
     if (session.status !== 'phoneSubmitted') return 'failed';
@@ -70,9 +70,7 @@ export const useVerifyPhoneFlowStore = createBaseStore<VerifyPhoneFlowStore>((se
       analytics.track(analytics.event.cashPhoneVerified, { mode: challenge.kind });
       // A resumed account may have completed KYC in an earlier signup attempt.
       const skipKyc = challenge.kind === 'resume' && (await getIsKycApproved(result.bootstrapToken));
-      // State stays 'verifying' for good — this step is never revisited, and
-      // re-enabling the kept-mounted OTP input would refocus it and flash the
-      // keyboard. Screen cleanup or a fresh phone submission resets the store.
+      set({ state: 'verified' });
       return skipKyc ? 'verifiedKycApproved' : 'verified';
     } catch (e) {
       if (!sessionStore.getIsCurrentChallenge(challenge)) {

--- a/src/languages/en_US.json
+++ b/src/languages/en_US.json
@@ -1650,6 +1650,12 @@
         "card_added": {
           "title": "Card added",
           "description": "You’re all set. You can now deposit with your card."
+        },
+        "cancel_sheet": {
+          "title": "Cancel Setup?",
+          "description": "You’ll lose all progress made so far.",
+          "continue": "Continue Setup",
+          "confirm": "Cancel Setup"
         }
       }
     },

--- a/src/navigation/config.tsx
+++ b/src/navigation/config.tsx
@@ -665,13 +665,16 @@ export const cashDepositSetupConfig: PartialNavigatorConfigOptions = {
       ...params,
       backgroundOpacity: 1,
       cornerRadius: 'device',
-      headerHeight: safeAreaInsetValues.top + 68,
       springDamping: 1,
       topOffset: 0,
       transitionDuration: 0.3,
     }),
+    allowsDragToDismiss: false,
     dismissable: false,
     gestureEnabled: false,
+    // with dismissable: false the pan gesture still responds to touches starting within headerHeight;
+    // 0 disables the drag entirely (must be set after buildCoolModalConfig, which maps 0 to 25).
+    headerHeight: 0,
   }),
 };
 

--- a/src/navigation/createVirtualNavigator.test.ts
+++ b/src/navigation/createVirtualNavigator.test.ts
@@ -1,0 +1,81 @@
+import Routes from '@/navigation/routesNames';
+import { type CashDepositSetupRoute } from '@/navigation/types';
+
+import { createVirtualNavigator } from './createVirtualNavigator';
+
+jest.mock('@/navigation/Navigation', () => ({
+  UseRouteProvider: ({ children }: { children: unknown }) => children,
+}));
+
+jest.mock('@/state/navigation/navigationStore', () => ({
+  setActiveRoute: jest.fn(),
+}));
+
+const ROUTES: readonly CashDepositSetupRoute[] = [
+  Routes.CASH_SETUP_PHONE,
+  Routes.CASH_SETUP_CONFIRM_PHONE,
+  Routes.CASH_SETUP_IDENTITY,
+  Routes.CASH_SETUP_SSN,
+];
+
+const GROUPS: Record<string, string> = {
+  [Routes.CASH_SETUP_PHONE]: 'a',
+  [Routes.CASH_SETUP_CONFIRM_PHONE]: 'a',
+  [Routes.CASH_SETUP_IDENTITY]: 'b',
+  [Routes.CASH_SETUP_SSN]: 'b',
+};
+
+function createNavigator(withGroups: boolean) {
+  return createVirtualNavigator<CashDepositSetupRoute>({
+    initialRoute: ROUTES[0],
+    routes: ROUTES,
+    options: withGroups ? { getRouteGroup: route => GROUPS[route] } : undefined,
+  });
+}
+
+describe('createVirtualNavigator getRouteGroup', () => {
+  it('appends history when navigating within a group', () => {
+    const { Navigation, useNavigationStore } = createNavigator(true);
+    Navigation.navigate(Routes.CASH_SETUP_CONFIRM_PHONE);
+    expect(useNavigationStore.getState().history).toEqual([Routes.CASH_SETUP_PHONE]);
+  });
+
+  it('clears history when navigating across a group boundary', () => {
+    const { Navigation, useNavigationStore } = createNavigator(true);
+    Navigation.navigate(Routes.CASH_SETUP_CONFIRM_PHONE);
+    Navigation.navigate(Routes.CASH_SETUP_IDENTITY);
+    expect(useNavigationStore.getState()).toMatchObject({
+      activeRoute: Routes.CASH_SETUP_IDENTITY,
+      history: [],
+    });
+  });
+
+  it('resumes within-group history tracking after a boundary', () => {
+    const { Navigation, useNavigationStore } = createNavigator(true);
+    Navigation.navigate(Routes.CASH_SETUP_CONFIRM_PHONE);
+    Navigation.navigate(Routes.CASH_SETUP_IDENTITY);
+    Navigation.navigate(Routes.CASH_SETUP_SSN);
+    expect(useNavigationStore.getState().history).toEqual([Routes.CASH_SETUP_IDENTITY]);
+
+    Navigation.goBack();
+    expect(useNavigationStore.getState()).toMatchObject({
+      activeRoute: Routes.CASH_SETUP_IDENTITY,
+      history: [],
+    });
+  });
+
+  it('goBack is a no-op once a boundary emptied the history', () => {
+    const { Navigation, useNavigationStore } = createNavigator(true);
+    Navigation.navigate(Routes.CASH_SETUP_CONFIRM_PHONE);
+    Navigation.navigate(Routes.CASH_SETUP_IDENTITY);
+    Navigation.goBack();
+    expect(useNavigationStore.getState().activeRoute).toBe(Routes.CASH_SETUP_IDENTITY);
+  });
+
+  it('keeps full history without getRouteGroup', () => {
+    const { Navigation, useNavigationStore } = createNavigator(false);
+    Navigation.navigate(Routes.CASH_SETUP_CONFIRM_PHONE);
+    Navigation.navigate(Routes.CASH_SETUP_IDENTITY);
+    expect(useNavigationStore.getState().history).toEqual([Routes.CASH_SETUP_PHONE, Routes.CASH_SETUP_CONFIRM_PHONE]);
+  });
+});

--- a/src/navigation/createVirtualNavigator.ts
+++ b/src/navigation/createVirtualNavigator.ts
@@ -40,6 +40,8 @@ export function createVirtualNavigator<VirtualRoute extends Route>({
   initialRoute: VirtualRoute;
   routes: readonly VirtualRoute[];
   options?: {
+    /** When the group changes between two routes, `navigate` clears history instead of appending to it. */
+    getRouteGroup?: (route: VirtualRoute) => string;
     keyPrefix?: string;
     onRouteChange?: (route: VirtualRoute) => void;
   };
@@ -94,9 +96,11 @@ export function createVirtualNavigator<VirtualRoute extends Route>({
           }
           return state;
         }
+        const getRouteGroup = options?.getRouteGroup;
+        const crossesGroupBoundary = getRouteGroup != null && getRouteGroup(route) !== getRouteGroup(state.activeRoute);
         return {
           activeRoute: route,
-          history: [...state.history, state.activeRoute],
+          history: crossesGroupBoundary ? [] : [...state.history, state.activeRoute],
           params: didParamsChange ? { ...state.params, [route]: params } : state.params,
         };
       });


### PR DESCRIPTION
Fixed: APP-3906

## Why?

Cash Setup contains irreversible server-side milestones: phone verification, KYC submission, passkey enrollment, and card linking. Returning across one of these milestones can expose stale steps, repeat an operation that cannot be undone, or corrupt the setup navigation history.

Back and cancel behavior also needs to remain predictable while requests and blocking status sheets are active, especially for Android hardware back and modal dismissal gestures.

## Approach

- Divide Setup into navigation zones separated by irreversible milestones, clearing back history whenever a boundary is crossed.
- Route software and hardware back through the same setup-aware behavior, and prevent the outer modal or pager from bypassing those boundaries.
- Disable back and cancel actions while a setup request is in flight or a blocking status sheet is open.
- Keep cancel available outside active requests, with a confirmation before discarding progress made prior to passkey enrollment.
- Refactor card linking from screen-local state into setup-level flow state so submission locking can observe it, duplicate requests are ignored, and late results are discarded after the flow resets.

## Visuals

https://github.com/user-attachments/assets/a12da18d-ebeb-4dad-b682-1f6cabd39870

## Testing

- Start Setup from the beginning and confirm Phone has Cancel but no Back action.
- Continue to OTP and confirm software back and Android hardware back return to Phone.
- Verify the phone, then confirm Identity cannot navigate back across the verification boundary.
- Move through Identity, SSN, and Review; confirm back navigation works only within that group.
- Continue through KYC, passkey enrollment, email, completion, and card linking; confirm completed milestones cannot be revisited.
- During phone submission, OTP verification, KYC submission, passkey enrollment, and card linking, confirm software back, Cancel, Android hardware back, and modal dismissal do nothing.
- Cancel after submitting a phone number but before enrolling a passkey; confirm the warning can either resume Setup or discard progress.
- Resume a card-only setup from Add Cash and confirm earlier identity and passkey steps are unreachable.
- Confirm card-link success, retryable failure, and passkey cancellation still resolve to the expected Setup state.
- Finish card linking and confirm Android hardware back behaves like Finish.
