### PR TITLE
feat(CASH): allow user to check KYC verification later

### DIFF
--- a/e2e/flows/cash/SetupResume.yaml
+++ b/e2e/flows/cash/SetupResume.yaml
@@ -94,7 +94,7 @@ tags:
 - assertVisible:
     text: 'This number is already connected to an account.'
 # The kept digits resume again; the mock OTP finishes the resume, and the mock
-# account's approved KYC (mock GetUserStatus) skips straight to Add Passkey.
+# account's approved KYC (mock GetUserStatus) is acknowledged before Add Passkey.
 - tapOn:
     id: cash-setup-next
 - extendedWaitUntil:
@@ -110,5 +110,14 @@ tags:
 - inputText: '0'
 - extendedWaitUntil:
     visible:
+      text: 'Identity verified'
+    timeout: 10000
+- tapOn:
+    id: cash-setup-kyc-success-continue
+- extendedWaitUntil:
+    visible:
       text: 'Add a Passkey'
     timeout: 10000
+# The step text stays in the hierarchy underneath a sheet, so assert the sheet itself is gone.
+- assertNotVisible:
+    id: cash-setup-kyc-success-overlay

--- a/e2e/flows/cash/SetupResumeKycPending.yaml
+++ b/e2e/flows/cash/SetupResumeKycPending.yaml
@@ -1,0 +1,52 @@
+appId: ${APP_ID}
+tags:
+  - cash
+  - parallel
+---
+- launchApp:
+    clearState: true
+    clearKeychain: true
+    arguments:
+      isE2ETest: true
+- runFlow: ../../utils/Prepare.yaml
+- runFlow: ../../utils/ImportWalletWithKey.yaml
+- runFlow:
+    file: ../../utils/SetExperimentalFlag.yaml
+    env:
+      FLAG: Cash
+      VALUE: 'true'
+- tapOn:
+    id: buy-button
+- assertVisible:
+    id: cash-deposit-intro-set-up-account
+- tapOn:
+    id: cash-deposit-intro-set-up-account
+- assertVisible:
+    text: 'Connect your phone number'
+# Mock 5550001305 resumes like 1304 does, but its KYC decision never arrives.
+- tapOn:
+    id: cash-setup-phone-input
+- inputText: '5550001305'
+- tapOn:
+    id: cash-setup-next
+- extendedWaitUntil:
+    visible:
+      text: 'Confirm your phone'
+    timeout: 10000
+- waitForAnimationToEnd
+- inputText: '000000'
+- extendedWaitUntil:
+    visible:
+      text: 'reviewing your information'
+    timeout: 10000
+- assertVisible:
+    text: 'check back later'
+# Got it leaves Setup entirely; the submission carries on server-side.
+- tapOn:
+    id: cash-setup-kyc-reviewing-got-it
+- extendedWaitUntil:
+    visible:
+      id: buy-button
+    timeout: 10000
+- assertNotVisible:
+    text: 'reviewing your information'

--- a/src/analytics/event.ts
+++ b/src/analytics/event.ts
@@ -132,6 +132,7 @@ export const event = {
   cashPhoneVerifyFailed: 'cash.phone_verify_failed',
   cashKycSubmitted: 'cash.kyc_submitted',
   cashKycApproved: 'cash.kyc_approved',
+  cashKycAwaitingDecision: 'cash.kyc_awaiting_decision',
   cashKycFailed: 'cash.kyc_failed',
   cashPasskeySubmitted: 'cash.passkey_submitted',
   cashPasskeyAdded: 'cash.passkey_added',
@@ -567,6 +568,9 @@ export type EventProperties = {
   };
   [event.cashKycSubmitted]: undefined;
   [event.cashKycApproved]: undefined;
+  [event.cashKycAwaitingDecision]: {
+    source: 'submit' | 'resume';
+  };
   [event.cashKycFailed]: {
     reason: string;
   };

--- a/src/features/cash/components/CashStatusHalfSheet.tsx
+++ b/src/features/cash/components/CashStatusHalfSheet.tsx
@@ -25,6 +25,7 @@ type CommonProps = {
 type CashStatusHalfSheetProps = CommonProps &
   (
     | { status: 'inProgress' }
+    | { status: 'reviewing'; action: HalfSheetAction }
     | { status: 'success'; action: HalfSheetAction; successIcon: string }
     | { status: 'error'; primaryAction: HalfSheetAction; secondaryAction?: HalfSheetAction }
     | { status: 'warning'; primaryAction: HalfSheetAction; secondaryAction: HalfSheetAction }
@@ -33,12 +34,14 @@ type CashStatusHalfSheetProps = CommonProps &
 const STATUS_ICONS = {
   error: '􀁠',
   inProgress: '􀖇',
+  reviewing: '􀐫',
   warning: '􀇾',
 } as const;
 
 const STATUS_ICON_COLORS = {
   error: 'red',
   inProgress: 'blue',
+  reviewing: 'blue',
   success: 'green',
   warning: 'red',
 } as const;
@@ -86,6 +89,17 @@ export const CashStatusHalfSheet = memo(function CashStatusHalfSheet(props: Cash
                 {props.status === 'success' && (
                   <Box paddingTop="32px">
                     <CashActionButton label={props.action.label} onPress={props.action.onPress} shadow testID={props.action.testID} />
+                  </Box>
+                )}
+
+                {props.status === 'reviewing' && (
+                  <Box paddingTop="32px">
+                    <CashActionButton
+                      label={props.action.label}
+                      onPress={props.action.onPress}
+                      testID={props.action.testID}
+                      variant="tinted"
+                    />
                   </Box>
                 )}
 

--- a/src/features/cash/screens/cash-deposit-setup/components/KycOutcomeSheet.tsx
+++ b/src/features/cash/screens/cash-deposit-setup/components/KycOutcomeSheet.tsx
@@ -1,0 +1,58 @@
+import React, { memo, useCallback } from 'react';
+
+import { CashStatusHalfSheet } from '@/features/cash/components/CashStatusHalfSheet';
+import * as i18n from '@/languages';
+import { RAINBOW_SUPPORT_URL } from '@/references/constants';
+import { openInBrowser } from '@/utils/openInBrowser';
+
+import { type KycOutcome } from '../../../services/userClient';
+import { useCashDepositSetupNavigation } from '../useCashDepositSetupNavigation';
+
+const l = i18n.l.cash.deposit_setup.kyc;
+const IDENTITY_VERIFIED_ICON = '􀯧';
+
+export const KycOutcomeSheet = memo(function KycOutcomeSheet({ onContinue, outcome }: { onContinue: () => void; outcome: KycOutcome }) {
+  // Never `cancel()`: its warning sheet claims the user loses all progress, which
+  // is untrue once the submission is with the provider.
+  const { dismiss } = useCashDepositSetupNavigation();
+
+  const contactSupport = useCallback(() => {
+    openInBrowser(RAINBOW_SUPPORT_URL);
+    dismiss();
+  }, [dismiss]);
+
+  switch (outcome) {
+    case 'approved':
+      return (
+        <CashStatusHalfSheet
+          action={{ label: i18n.t(i18n.l.button.continue), onPress: onContinue, testID: 'cash-setup-kyc-success-continue' }}
+          description={i18n.t(l.verified_description)}
+          status="success"
+          successIcon={IDENTITY_VERIFIED_ICON}
+          testID="cash-setup-kyc-success"
+          title={i18n.t(l.verified_title)}
+        />
+      );
+    case 'reviewing':
+      return (
+        <CashStatusHalfSheet
+          action={{ label: i18n.t(l.reviewing_action), onPress: dismiss, testID: 'cash-setup-kyc-reviewing-got-it' }}
+          description={i18n.t(l.reviewing_description)}
+          status="reviewing"
+          testID="cash-setup-kyc-reviewing"
+          title={i18n.t(l.reviewing_title)}
+        />
+      );
+    case 'rejected':
+      return (
+        <CashStatusHalfSheet
+          description={i18n.t(l.rejected_description)}
+          primaryAction={{ label: i18n.t(l.contact_support), onPress: contactSupport, testID: 'cash-setup-kyc-rejected-support' }}
+          secondaryAction={{ label: i18n.t(l.close), onPress: dismiss, testID: 'cash-setup-kyc-rejected-close' }}
+          status="error"
+          testID="cash-setup-kyc-rejected"
+          title={i18n.t(l.rejected_title)}
+        />
+      );
+  }
+});

--- a/src/features/cash/screens/cash-deposit-setup/steps/ConfirmPhoneStep.tsx
+++ b/src/features/cash/screens/cash-deposit-setup/steps/ConfirmPhoneStep.tsx
@@ -8,13 +8,14 @@ import Routes from '@/navigation/routesNames';
 import { OtpInput } from '../../../components/OtpInput';
 import { OTP_LENGTH } from '../../../stores/verifyPhoneFlowStore';
 import { useCashDepositSetupNavigationStore } from '../cashDepositSetupNavigator';
+import { KycOutcomeSheet } from '../components/KycOutcomeSheet';
 import { SetupStepLayout } from '../components/SetupStepLayout';
 import { useVerifyPhoneFlow } from './useVerifyPhoneFlow';
 
 const l = i18n.l.cash.deposit_setup.confirm_phone;
 
 export const ConfirmPhoneStep = memo(function ConfirmPhoneStep() {
-  const { state, code, setCode, submit, resend, resending, resendCooldownSeconds } = useVerifyPhoneFlow();
+  const { state, code, kycOutcome, continueAfterKyc, setCode, submit, resend, resending, resendCooldownSeconds } = useVerifyPhoneFlow();
   // The pager keeps visited steps mounted, so focus is tied to the step being active rather than to mount.
   const isActiveStep = useCashDepositSetupNavigationStore(s => s.activeRoute === Routes.CASH_SETUP_CONFIRM_PHONE);
   // Stays true once the code is accepted: re-enabling the kept-mounted input would refocus it and flash the keyboard.
@@ -22,36 +23,40 @@ export const ConfirmPhoneStep = memo(function ConfirmPhoneStep() {
   const cooling = resendCooldownSeconds > 0;
 
   return (
-    <SetupStepLayout
-      actionDisabled={code.length !== OTP_LENGTH}
-      actionLabel={i18n.t(l.confirm)}
-      actionLoading={submitted}
-      onAction={submit}
-      title={i18n.t(l.title)}
-    >
-      <Box gap={16} paddingTop="24px">
-        <OtpInput
-          disabled={submitted}
-          error={state === 'error'}
-          focused={isActiveStep}
-          length={OTP_LENGTH}
-          onChange={newCode => {
-            setCode(newCode);
-            if (newCode.length === OTP_LENGTH) submit();
-          }}
-          value={code}
-        />
-        <ButtonPressAnimation disabled={cooling || resending} onPress={resend} testID="cash-setup-resend-code">
-          <Text color={cooling ? 'labelQuaternary' : 'blue'} size="17pt" weight="bold">
-            {cooling ? `${i18n.t(l.resend_code)} (${resendCooldownSeconds})` : i18n.t(l.resend_code)}
-          </Text>
-        </ButtonPressAnimation>
-        {state === 'error' && (
-          <Text color="red" size="17pt" weight="semibold">
-            {i18n.t(l.error)}
-          </Text>
-        )}
-      </Box>
-    </SetupStepLayout>
+    <>
+      <SetupStepLayout
+        actionDisabled={code.length !== OTP_LENGTH}
+        actionLabel={i18n.t(l.confirm)}
+        actionLoading={submitted}
+        onAction={submit}
+        title={i18n.t(l.title)}
+      >
+        <Box gap={16} paddingTop="24px">
+          <OtpInput
+            disabled={submitted}
+            error={state === 'error'}
+            focused={isActiveStep}
+            length={OTP_LENGTH}
+            onChange={newCode => {
+              setCode(newCode);
+              if (newCode.length === OTP_LENGTH) submit();
+            }}
+            value={code}
+          />
+          <ButtonPressAnimation disabled={cooling || resending} onPress={resend} testID="cash-setup-resend-code">
+            <Text color={cooling ? 'labelQuaternary' : 'blue'} size="17pt" weight="bold">
+              {cooling ? `${i18n.t(l.resend_code)} (${resendCooldownSeconds})` : i18n.t(l.resend_code)}
+            </Text>
+          </ButtonPressAnimation>
+          {state === 'error' && (
+            <Text color="red" size="17pt" weight="semibold">
+              {i18n.t(l.error)}
+            </Text>
+          )}
+        </Box>
+      </SetupStepLayout>
+
+      {kycOutcome && <KycOutcomeSheet onContinue={continueAfterKyc} outcome={kycOutcome} />}
+    </>
   );
 });

--- a/src/features/cash/screens/cash-deposit-setup/steps/ReviewStep.tsx
+++ b/src/features/cash/screens/cash-deposit-setup/steps/ReviewStep.tsx
@@ -9,12 +9,13 @@ import Routes from '@/navigation/routesNames';
 import { formatDateOfBirth, formatUsSsnMasked } from '../../../services/cashSetupIdentityService';
 import { useCashSetupSessionStore } from '../../../stores/cashSetupSessionStore';
 import { CashDepositSetupNavigation } from '../cashDepositSetupNavigator';
+import { KycOutcomeSheet } from '../components/KycOutcomeSheet';
 import { SetupStepLayout } from '../components/SetupStepLayout';
 import { useCashDepositSetupNavigation } from '../useCashDepositSetupNavigation';
 import { useSubmitKycFlow } from './useSubmitKycFlow';
 
 const l = i18n.l.cash.deposit_setup.review;
-const IDENTITY_VERIFIED_ICON = '􀯧';
+const kycL = i18n.l.cash.deposit_setup.kyc;
 
 function ReviewRow({
   disabled,
@@ -110,23 +111,10 @@ export const ReviewStep = memo(function ReviewStep() {
 
       {state === 'submitting' ? (
         <CashStatusHalfSheet
-          description={i18n.t(l.verifying_description)}
+          description={i18n.t(kycL.verifying_description)}
           status="inProgress"
           testID="cash-setup-kyc-verifying"
-          title={i18n.t(l.verifying_title)}
-        />
-      ) : state === 'success' ? (
-        <CashStatusHalfSheet
-          action={{
-            label: i18n.t(i18n.l.button.continue),
-            onPress: continueAfterVerification,
-            testID: 'cash-setup-kyc-success-continue',
-          }}
-          description={i18n.t(l.verified_description)}
-          status="success"
-          successIcon={IDENTITY_VERIFIED_ICON}
-          testID="cash-setup-kyc-success"
-          title={i18n.t(l.verified_title)}
+          title={i18n.t(kycL.verifying_title)}
         />
       ) : state === 'error' ? (
         <CashStatusHalfSheet
@@ -140,7 +128,9 @@ export const ReviewStep = memo(function ReviewStep() {
           testID="cash-setup-kyc-error"
           title={i18n.t(l.error_title)}
         />
-      ) : null}
+      ) : state === 'entry' ? null : (
+        <KycOutcomeSheet onContinue={continueAfterVerification} outcome={state} />
+      )}
     </>
   );
 });

--- a/src/features/cash/screens/cash-deposit-setup/steps/useSubmitKycFlow.test.ts
+++ b/src/features/cash/screens/cash-deposit-setup/steps/useSubmitKycFlow.test.ts
@@ -5,13 +5,22 @@ import { delay } from '@/utils/delay';
 import { createUsSsnLast4GovernmentId, isValidUsSsnLast4 } from '../../../services/cashSetupIdentityService';
 import { getUserStatus, KycStatus, submitOnboarding } from '../../../services/userClient';
 import { useCashSetupSessionStore } from '../../../stores/cashSetupSessionStore';
-import { KYC_POLL_BUDGET_MS, KYC_POLL_INTERVAL_MS, useSubmitKycFlowStore } from './useSubmitKycFlow';
+import { KYC_POLL_INTERVAL_MS, useSubmitKycFlowStore, type SubmitKycState } from './useSubmitKycFlow';
 
 jest.mock('@/analytics', () => ({
   analytics: {
     track: jest.fn(),
-    event: { cashKycSubmitted: 'cash.kyc_submitted', cashKycApproved: 'cash.kyc_approved', cashKycFailed: 'cash.kyc_failed' },
+    event: {
+      cashKycSubmitted: 'cash.kyc_submitted',
+      cashKycApproved: 'cash.kyc_approved',
+      cashKycAwaitingDecision: 'cash.kyc_awaiting_decision',
+      cashKycFailed: 'cash.kyc_failed',
+    },
   },
+}));
+
+jest.mock('@/features/config/stores/remoteConfig', () => ({
+  getRemoteConfig: () => ({ cash_kyc_review_delay_ms: 60_000 }),
 }));
 
 jest.mock('@/logger', () => ({
@@ -45,7 +54,13 @@ const IDENTITY = { firstName: 'Ada', lastName: 'Lovelace', dateOfBirth: { year: 
 const SSN_LAST4 = '6789';
 if (!isValidUsSsnLast4(SSN_LAST4)) throw new Error('expected a valid SSN last four');
 const GOVERNMENT_ID = createUsSsnLast4GovernmentId(SSN_LAST4);
-const POLL_ATTEMPTS = KYC_POLL_BUDGET_MS / KYC_POLL_INTERVAL_MS;
+const REVIEW_DELAY_MS = 60_000;
+
+function fakeClock(start = 1_750_000_000_000) {
+  let clock = start;
+  jest.spyOn(Date, 'now').mockImplementation(() => clock);
+  return { advance: (ms: number) => (clock += ms) };
+}
 
 const flow = () => useSubmitKycFlowStore.getState();
 const session = () => useCashSetupSessionStore.getState();
@@ -67,6 +82,10 @@ beforeEach(() => {
   mockGetUserStatus.mockResolvedValue({ kycStatus: KycStatus.Approved });
 });
 
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
 describe('useSubmitKycFlowStore.submit', () => {
   it('submits, tracks, and resolves approved — in order', async () => {
     await expect(flow().submit()).resolves.toBe('approved');
@@ -86,7 +105,7 @@ describe('useSubmitKycFlowStore.submit', () => {
     expect(submitOrder).toBeLessThan(trackApprovedOrder);
 
     expect(mockGetUserStatus).not.toHaveBeenCalled();
-    expect(flow().state).toBe('success');
+    expect(flow().state).toBe('approved');
   });
 
   it('polls while pending, then approves', async () => {
@@ -100,29 +119,90 @@ describe('useSubmitKycFlowStore.submit', () => {
     expect(mockDelay).toHaveBeenCalledWith(KYC_POLL_INTERVAL_MS);
   });
 
-  it('fails with timeout when pending never resolves within the poll budget', async () => {
+  it('switches to reviewing once the delay elapses, and keeps polling until the verdict lands', async () => {
+    const clock = fakeClock();
     mockSubmitOnboarding.mockResolvedValue({ kycStatus: KycStatus.Pending });
-    mockGetUserStatus.mockResolvedValue({ kycStatus: KycStatus.Pending });
+    const statesWhilePolling: SubmitKycState[] = [];
+    mockGetUserStatus
+      .mockImplementationOnce(() => {
+        statesWhilePolling.push(flow().state);
+        clock.advance(REVIEW_DELAY_MS);
+        return Promise.resolve({ kycStatus: KycStatus.Pending });
+      })
+      .mockImplementationOnce(() => {
+        statesWhilePolling.push(flow().state);
+        return Promise.resolve({ kycStatus: KycStatus.Approved });
+      });
 
-    await expect(flow().submit()).resolves.toBe('failed');
+    await expect(flow().submit()).resolves.toBe('approved');
 
-    expect(mockGetUserStatus).toHaveBeenCalledTimes(POLL_ATTEMPTS);
-    expect(track).toHaveBeenCalledWith('cash.kyc_failed', { reason: 'timeout' });
-    expect(logger.error).toHaveBeenCalled();
-    expect(flow().state).toBe('error');
+    expect(statesWhilePolling).toEqual(['submitting', 'reviewing']);
+    expect(track).toHaveBeenCalledWith('cash.kyc_awaiting_decision', { source: 'submit' });
+    expect(track).not.toHaveBeenCalledWith('cash.kyc_failed', expect.anything());
+    expect(flow().state).toBe('approved');
   });
 
-  it.each([
-    { kycStatus: 'KYC_STATUS_UNSPECIFIED', reason: 'unspecified' },
-    { kycStatus: 'KYC_STATUS_REJECTED', reason: 'rejected' },
-    { kycStatus: 'KYC_STATUS_REVIEW', reason: 'review' },
-  ])('fails with $reason without polling', async ({ kycStatus, reason }) => {
-    mockSubmitOnboarding.mockResolvedValue({ kycStatus });
+  it('tracks the awaiting-decision event only once however long the wait runs', async () => {
+    const clock = fakeClock();
+    mockSubmitOnboarding.mockResolvedValue({ kycStatus: KycStatus.Pending });
+    mockDelay.mockImplementationOnce(() => {
+      clock.advance(REVIEW_DELAY_MS);
+      return Promise.resolve();
+    });
+    mockGetUserStatus
+      .mockResolvedValueOnce({ kycStatus: KycStatus.Pending })
+      .mockResolvedValueOnce({ kycStatus: KycStatus.Pending })
+      .mockResolvedValueOnce({ kycStatus: KycStatus.Approved });
 
-    await expect(flow().submit()).resolves.toBe('failed');
+    await flow().submit();
+
+    expect(track.mock.calls.filter(([name]) => name === 'cash.kyc_awaiting_decision')).toHaveLength(1);
+  });
+
+  it('reports a rejection without offering a retry', async () => {
+    mockSubmitOnboarding.mockResolvedValue({ kycStatus: KycStatus.Rejected });
+
+    await expect(flow().submit()).resolves.toBe('rejected');
 
     expect(mockGetUserStatus).not.toHaveBeenCalled();
-    expect(track).toHaveBeenCalledWith('cash.kyc_failed', { reason });
+    expect(track).toHaveBeenCalledWith('cash.kyc_failed', { reason: 'rejected' });
+    expect(flow().state).toBe('rejected');
+  });
+
+  it.each([KycStatus.Unspecified, KycStatus.Review])('keeps polling on %s instead of failing', async kycStatus => {
+    mockSubmitOnboarding.mockResolvedValue({ kycStatus });
+    mockGetUserStatus.mockResolvedValue({ kycStatus: KycStatus.Approved });
+
+    await expect(flow().submit()).resolves.toBe('approved');
+
+    expect(mockGetUserStatus).toHaveBeenCalledTimes(1);
+    expect(track).not.toHaveBeenCalledWith('cash.kyc_failed', expect.anything());
+  });
+
+  it('falls back to reviewing when a status poll fails, never to the retryable error', async () => {
+    mockSubmitOnboarding.mockResolvedValue({ kycStatus: KycStatus.Pending });
+    mockGetUserStatus.mockRejectedValue(new Error('token expired'));
+
+    await expect(flow().submit()).resolves.toBe('awaitingDecision');
+
+    expect(flow().state).toBe('reviewing');
+    expect(track).toHaveBeenCalledWith('cash.kyc_awaiting_decision', { source: 'submit' });
+    expect(track).not.toHaveBeenCalledWith('cash.kyc_failed', expect.anything());
+    expect(logger.warn).toHaveBeenCalled();
+  });
+
+  it('stops writing once the flow is reset, so an abandoned poll cannot resurface later', async () => {
+    mockSubmitOnboarding.mockResolvedValue({ kycStatus: KycStatus.Pending });
+    mockDelay.mockImplementationOnce(() => {
+      flow().reset();
+      return Promise.resolve();
+    });
+
+    await expect(flow().submit()).resolves.toBe('cancelled');
+
+    expect(mockGetUserStatus).not.toHaveBeenCalled();
+    expect(flow().state).toBe('entry');
+    expect(track).not.toHaveBeenCalledWith('cash.kyc_approved');
   });
 
   it('fails with the error message when the submission throws', async () => {

--- a/src/features/cash/screens/cash-deposit-setup/steps/useSubmitKycFlow.ts
+++ b/src/features/cash/screens/cash-deposit-setup/steps/useSubmitKycFlow.ts
@@ -1,74 +1,103 @@
 import { createBaseStore, createStoreActions } from '@storesjs/stores';
 
 import { analytics } from '@/analytics';
+import { getRemoteConfig } from '@/features/config/stores/remoteConfig';
 import { time } from '@/framework/core/utils/time';
 import { logger, RainbowError } from '@/logger';
 import { delay } from '@/utils/delay';
 
 import { US_COUNTRY_CODE } from '../../../services/cashSetupIdentityService';
-import { getUserStatus, KycStatus, submitOnboarding } from '../../../services/userClient';
+import { getUserStatus, KycStatus, submitOnboarding, type KycOutcome } from '../../../services/userClient';
 import { useCashSetupSessionStore } from '../../../stores/cashSetupSessionStore';
 
 export const KYC_POLL_INTERVAL_MS = time.seconds(3);
-export const KYC_POLL_BUDGET_MS = time.seconds(30);
 
-const KYC_POLL_ATTEMPTS = Math.floor(KYC_POLL_BUDGET_MS / KYC_POLL_INTERVAL_MS);
+export type SubmitKycState = 'entry' | 'submitting' | 'error' | KycOutcome;
 
-const KYC_FAILURE_REASONS: Record<Exclude<KycStatus, KycStatus.Approved>, string> = {
-  [KycStatus.Unspecified]: 'unspecified',
-  [KycStatus.Pending]: 'timeout',
-  [KycStatus.Rejected]: 'rejected',
-  [KycStatus.Review]: 'review',
-};
+export type SubmitKycResult = 'approved' | 'rejected' | 'awaitingDecision' | 'failed' | 'cancelled' | 'skipped';
 
-export type SubmitKycState = 'entry' | 'submitting' | 'success' | 'error';
-
-export type SubmitKycResult = 'approved' | 'failed' | 'skipped';
+// Unspecified included: after a successful submission any non-verdict means the
+// provider has not answered, which is the same thing to the user as pending.
+function isAwaitingDecision(status: KycStatus): boolean {
+  return status !== KycStatus.Approved && status !== KycStatus.Rejected;
+}
 
 type SubmitKycFlowStore = {
   state: SubmitKycState;
+  // Identifies one submission so a poll loop the user walked away from cannot
+  // write into a later one — these stores outlive the screen.
+  run: object | null;
   reset: () => void;
   submit: () => Promise<SubmitKycResult>;
 };
 
 export const useSubmitKycFlowStore = createBaseStore<SubmitKycFlowStore>((set, get) => ({
   state: 'entry',
+  run: null,
 
-  reset: () => set({ state: 'entry' }),
+  reset: () => set({ run: null, state: 'entry' }),
 
   submit: async () => {
-    if (get().state === 'submitting') return 'skipped';
+    const { state } = get();
+    if (state === 'submitting' || state === 'reviewing') return 'skipped';
     const { session } = useCashSetupSessionStore.getState();
     if (session.status !== 'phoneVerified' || !session.identity || !session.governmentId) return 'skipped';
+    const { bootstrapToken, identity, governmentId } = session;
 
-    set({ state: 'submitting' });
+    const run = {};
+    set({ run, state: 'submitting' });
     analytics.track(analytics.event.cashKycSubmitted);
+
+    const isStale = () => get().run !== run;
+    let trackedAwaitingDecision = false;
+    const enterReviewing = () => {
+      if (!trackedAwaitingDecision) {
+        trackedAwaitingDecision = true;
+        analytics.track(analytics.event.cashKycAwaitingDecision, { source: 'submit' });
+      }
+      set({ state: 'reviewing' });
+    };
+
+    let kycStatus: KycStatus;
     try {
-      const { bootstrapToken, identity, governmentId } = session;
-      let { kycStatus } = await submitOnboarding({ bootstrapToken, countryCode: US_COUNTRY_CODE, identity, governmentId });
-
-      for (let attempt = 0; kycStatus === KycStatus.Pending && attempt < KYC_POLL_ATTEMPTS; attempt++) {
-        await delay(KYC_POLL_INTERVAL_MS);
-        ({ kycStatus } = await getUserStatus({ bootstrapToken }));
-      }
-
-      if (kycStatus !== KycStatus.Approved) {
-        const reason = KYC_FAILURE_REASONS[kycStatus];
-        logger.error(new RainbowError(`[useSubmitKycFlow]: KYC not approved: ${reason}`));
-        analytics.track(analytics.event.cashKycFailed, { reason });
-        set({ state: 'error' });
-        return 'failed';
-      }
-
-      analytics.track(analytics.event.cashKycApproved);
-      set({ state: 'success' });
-      return 'approved';
+      ({ kycStatus } = await submitOnboarding({ bootstrapToken, countryCode: US_COUNTRY_CODE, identity, governmentId }));
     } catch (e) {
+      if (isStale()) return 'cancelled';
       logger.error(new RainbowError('[useSubmitKycFlow]: Failed to submit KYC', e));
       analytics.track(analytics.event.cashKycFailed, { reason: e instanceof Error ? e.message : String(e) });
       set({ state: 'error' });
       return 'failed';
     }
+    if (isStale()) return 'cancelled';
+
+    const reviewingAt = Date.now() + getRemoteConfig().cash_kyc_review_delay_ms;
+
+    while (isAwaitingDecision(kycStatus)) {
+      if (Date.now() >= reviewingAt) enterReviewing();
+      await delay(KYC_POLL_INTERVAL_MS);
+      if (isStale()) return 'cancelled';
+      try {
+        ({ kycStatus } = await getUserStatus({ bootstrapToken }));
+      } catch (e) {
+        if (isStale()) return 'cancelled';
+        // The identity data is already with the provider, so a status we cannot
+        // read is still an undecided one — never the retryable entry error.
+        logger.warn('[useSubmitKycFlow]: KYC status poll failed', { error: e });
+        enterReviewing();
+        return 'awaitingDecision';
+      }
+      if (isStale()) return 'cancelled';
+    }
+
+    if (kycStatus === KycStatus.Approved) {
+      analytics.track(analytics.event.cashKycApproved);
+      set({ state: 'approved' });
+      return 'approved';
+    }
+
+    analytics.track(analytics.event.cashKycFailed, { reason: 'rejected' });
+    set({ state: 'rejected' });
+    return 'rejected';
   },
 }));
 

--- a/src/features/cash/screens/cash-deposit-setup/steps/useVerifyPhoneFlow.ts
+++ b/src/features/cash/screens/cash-deposit-setup/steps/useVerifyPhoneFlow.ts
@@ -5,6 +5,7 @@ import { createStoreActions } from '@storesjs/stores';
 import { time } from '@/framework/core/utils/time';
 import Routes from '@/navigation/routesNames';
 
+import { type KycOutcome } from '../../../services/userClient';
 import { selectResendAfter, useCashSetupSessionStore } from '../../../stores/cashSetupSessionStore';
 import { useVerifyPhoneFlowStore, type VerifyPhoneState } from '../../../stores/verifyPhoneFlowStore';
 import { CashDepositSetupNavigation } from '../cashDepositSetupNavigator';
@@ -15,6 +16,8 @@ const verifyPhoneFlowActions = createStoreActions(useVerifyPhoneFlowStore);
 export function useVerifyPhoneFlow(): {
   state: VerifyPhoneState;
   code: string;
+  kycOutcome: KycOutcome | null;
+  continueAfterKyc: () => void;
   setCode: (code: string) => void;
   submit: () => Promise<void>;
   resend: () => Promise<void>;
@@ -24,6 +27,7 @@ export function useVerifyPhoneFlow(): {
   const { next, back } = useCashDepositSetupNavigation();
   const state = useVerifyPhoneFlowStore(s => s.state);
   const code = useVerifyPhoneFlowStore(s => s.code);
+  const kycOutcome = useVerifyPhoneFlowStore(s => s.kycOutcome);
   const resending = useVerifyPhoneFlowStore(s => s.resending !== null);
   const resendAfter = useCashSetupSessionStore(selectResendAfter);
   const [resendCooldownSeconds, setResendCooldownSeconds] = useState(0);
@@ -31,9 +35,13 @@ export function useVerifyPhoneFlow(): {
   const submit = useCallback(async () => {
     const result = await verifyPhoneFlowActions.submit();
     if (result === 'verified') next();
-    if (result === 'verifiedKycApproved') CashDepositSetupNavigation.navigate(Routes.CASH_SETUP_PASSKEY);
     if (result === 'signupAlreadyComplete') back();
   }, [back, next]);
+
+  const continueAfterKyc = useCallback(() => {
+    CashDepositSetupNavigation.navigate(Routes.CASH_SETUP_PASSKEY);
+    verifyPhoneFlowActions.clearKycOutcome();
+  }, []);
 
   useEffect(() => {
     if (resendAfter == null) {
@@ -54,6 +62,8 @@ export function useVerifyPhoneFlow(): {
   return {
     state,
     code,
+    kycOutcome,
+    continueAfterKyc,
     setCode: verifyPhoneFlowActions.setCode,
     submit,
     resend: verifyPhoneFlowActions.resend,

--- a/src/features/cash/services/userClient.ts
+++ b/src/features/cash/services/userClient.ts
@@ -15,7 +15,11 @@ const SIGNUP_ALREADY_COMPLETE = 1322;
 
 const MOCK_REGISTERED_WITHOUT_PASSKEY_NUMBER = '5550001304';
 const MOCK_REGISTERED_WITH_PASSKEY_NUMBER = '5550001303';
+const MOCK_RESUME_KYC_PENDING_NUMBER = '5550001305';
 const MOCK_SIGNUP_ALREADY_COMPLETE_CODE = '001322';
+// The pending account's KYC status rides its resume handles, so the mocks stay stateless.
+const MOCK_KYC_PENDING_RESUME_ID = 'e2e-resume-id-kyc-pending';
+const MOCK_KYC_PENDING_BOOTSTRAP_TOKEN = 'bst_e2e_kyc_pending';
 
 function getPlatformErrorCode(error: unknown): number | null {
   if (!(error instanceof RainbowFetchError)) return null;
@@ -73,6 +77,9 @@ export enum KycStatus {
   Rejected = 'KYC_STATUS_REJECTED',
   Review = 'KYC_STATUS_REVIEW',
 }
+
+// Pending and Review are one state to the app: the provider has not decided yet.
+export type KycOutcome = 'reviewing' | 'approved' | 'rejected';
 
 export type CreateUserWithPhoneResult =
   | { outcome: 'created'; userId: string; resendAfter: number }
@@ -159,7 +166,8 @@ type GetUserStatusResponse = {
 export async function createUserWithPhone({ nationalNumber }: { nationalNumber: string }): Promise<CreateUserWithPhoneResult> {
   if (IS_TESTING === 'true') {
     await delay(time.seconds(1));
-    if (nationalNumber === MOCK_REGISTERED_WITHOUT_PASSKEY_NUMBER) return { outcome: 'registeredWithoutPasskey' };
+    if (nationalNumber === MOCK_REGISTERED_WITHOUT_PASSKEY_NUMBER || nationalNumber === MOCK_RESUME_KYC_PENDING_NUMBER)
+      return { outcome: 'registeredWithoutPasskey' };
     if (nationalNumber === MOCK_REGISTERED_WITH_PASSKEY_NUMBER) return { outcome: 'registeredWithPasskey' };
     return { outcome: 'created', userId: 'e2e-user-id', resendAfter: Date.now() + time.seconds(30) };
   }
@@ -311,7 +319,7 @@ export async function finalizeAuth({
 export async function getUserStatus({ bootstrapToken }: GetUserStatusParams): Promise<{ kycStatus: KycStatus }> {
   if (IS_TESTING === 'true') {
     await delay(time.seconds(1));
-    return { kycStatus: KycStatus.Approved };
+    return { kycStatus: bootstrapToken === MOCK_KYC_PENDING_BOOTSTRAP_TOKEN ? KycStatus.Pending : KycStatus.Approved };
   }
 
   const { data } = await getCashPlatformClient().get<GetUserStatusResponse>('/status/GetUserStatus', {
@@ -327,7 +335,8 @@ export async function startSignupResume({
 }): Promise<{ resumeId: string; resendAfter: number }> {
   if (IS_TESTING === 'true') {
     await delay(time.seconds(1));
-    return { resumeId: 'e2e-resume-id', resendAfter: Date.now() + time.seconds(30) };
+    const resumeId = nationalNumber === MOCK_RESUME_KYC_PENDING_NUMBER ? MOCK_KYC_PENDING_RESUME_ID : 'e2e-resume-id';
+    return { resumeId, resendAfter: Date.now() + time.seconds(30) };
   }
 
   const { data } = await getCashPlatformClient().post<{ resumeId: string; resendAfter: unknown }>('/signup/resume/StartSignupResume', {
@@ -345,7 +354,8 @@ export async function finishSignupResume({ resumeId, code }: { resumeId: string;
     await delay(time.seconds(1));
     if (code === MOCK_SIGNUP_ALREADY_COMPLETE_CODE) return { outcome: 'signupAlreadyComplete' };
     if (code !== '000000') throw new Error('Invalid verification code');
-    return { outcome: 'verified', bootstrapToken: 'bst_e2e', expiresAt: Date.now() + time.hours(1) };
+    const bootstrapToken = resumeId === MOCK_KYC_PENDING_RESUME_ID ? MOCK_KYC_PENDING_BOOTSTRAP_TOKEN : 'bst_e2e';
+    return { outcome: 'verified', bootstrapToken, expiresAt: Date.now() + time.hours(1) };
   }
 
   try {

--- a/src/features/cash/stores/verifyPhoneFlowStore.test.ts
+++ b/src/features/cash/stores/verifyPhoneFlowStore.test.ts
@@ -13,6 +13,9 @@ jest.mock('@/analytics', () => ({
       cashPhoneVerified: 'cash.phone_verified',
       cashPhoneVerifyFailed: 'cash.phone_verify_failed',
       cashPhoneAlreadyRegistered: 'cash.phone_already_registered',
+      cashKycApproved: 'cash.kyc_approved',
+      cashKycAwaitingDecision: 'cash.kyc_awaiting_decision',
+      cashKycFailed: 'cash.kyc_failed',
     },
   },
 }));
@@ -71,7 +74,7 @@ beforeEach(() => {
   useVerifyPhoneFlowStore.getState().reset();
   mockVerifyPhone.mockResolvedValue(TOKEN);
   mockFinishSignupResume.mockResolvedValue({ outcome: 'verified', ...TOKEN });
-  mockGetUserStatus.mockResolvedValue({ kycStatus: KycStatus.Pending });
+  mockGetUserStatus.mockResolvedValue({ kycStatus: KycStatus.Unspecified });
   mockResendPhoneCode.mockResolvedValue({ resendAfter: RESEND_AFTER });
   mockStartSignupResume.mockResolvedValue({ resumeId: 'rcv_2', resendAfter: RESEND_AFTER });
 });
@@ -108,17 +111,47 @@ describe('useVerifyPhoneFlowStore.submit', () => {
     expect(track).toHaveBeenCalledWith('cash.phone_verified', { mode: 'resume' });
   });
 
-  it('reports approved KYC when the resumed account already passed it', async () => {
+  it.each([
+    { kycStatus: KycStatus.Approved, expected: 'approved' },
+    { kycStatus: KycStatus.Pending, expected: 'reviewing' },
+    { kycStatus: KycStatus.Review, expected: 'reviewing' },
+    { kycStatus: KycStatus.Rejected, expected: 'rejected' },
+  ])('surfaces $expected for a resumed account whose KYC is $kycStatus', async ({ kycStatus, expected }) => {
     submitPhone({ kind: 'resume', resumeId: 'rcv_1' });
-    mockGetUserStatus.mockResolvedValue({ kycStatus: KycStatus.Approved });
+    mockGetUserStatus.mockResolvedValue({ kycStatus });
     flow().setCode(CODE);
 
-    await expect(flow().submit()).resolves.toBe('verifiedKycApproved');
+    await expect(flow().submit()).resolves.toBe('verifiedKycOutcome');
 
     expect(mockGetUserStatus).toHaveBeenCalledWith({ bootstrapToken: TOKEN.bootstrapToken });
+    expect(flow().kycOutcome).toBe(expected);
     expect(session()).toMatchObject({ status: 'phoneVerified', bootstrapToken: TOKEN.bootstrapToken });
     expect(track).toHaveBeenCalledWith('cash.phone_verified', { mode: 'resume' });
     expect(flow().state).toBe('verified');
+  });
+
+  it.each([
+    { kycStatus: KycStatus.Approved, event: 'cash.kyc_approved', payload: undefined },
+    { kycStatus: KycStatus.Pending, event: 'cash.kyc_awaiting_decision', payload: { source: 'resume' } },
+    { kycStatus: KycStatus.Rejected, event: 'cash.kyc_failed', payload: { reason: 'rejected' } },
+  ])('tracks $event when a resumed account reports $kycStatus', async ({ event, kycStatus, payload }) => {
+    submitPhone({ kind: 'resume', resumeId: 'rcv_1' });
+    mockGetUserStatus.mockResolvedValue({ kycStatus });
+    flow().setCode(CODE);
+
+    await flow().submit();
+
+    expect(track).toHaveBeenCalledWith(event, ...(payload ? [payload] : []));
+  });
+
+  it('sends a resumed account that never submitted KYC through the KYC steps', async () => {
+    submitPhone({ kind: 'resume', resumeId: 'rcv_1' });
+    mockGetUserStatus.mockResolvedValue({ kycStatus: KycStatus.Unspecified });
+    flow().setCode(CODE);
+
+    await expect(flow().submit()).resolves.toBe('verified');
+
+    expect(flow().kycOutcome).toBeNull();
   });
 
   it('retries a failed resume status check once after a delay', async () => {
@@ -126,10 +159,11 @@ describe('useVerifyPhoneFlowStore.submit', () => {
     mockGetUserStatus.mockRejectedValueOnce(new Error('network down')).mockResolvedValueOnce({ kycStatus: KycStatus.Approved });
     flow().setCode(CODE);
 
-    await expect(flow().submit()).resolves.toBe('verifiedKycApproved');
+    await expect(flow().submit()).resolves.toBe('verifiedKycOutcome');
 
     expect(mockGetUserStatus).toHaveBeenCalledTimes(2);
     expect(mockDelay).toHaveBeenCalledWith(2000);
+    expect(flow().kycOutcome).toBe('approved');
     expect(session()).toMatchObject({ status: 'phoneVerified', bootstrapToken: TOKEN.bootstrapToken });
   });
 
@@ -141,6 +175,7 @@ describe('useVerifyPhoneFlowStore.submit', () => {
     await expect(flow().submit()).resolves.toBe('verified');
 
     expect(mockGetUserStatus).toHaveBeenCalledTimes(2);
+    expect(flow().kycOutcome).toBeNull();
     expect(session()).toMatchObject({ status: 'phoneVerified', bootstrapToken: TOKEN.bootstrapToken });
     expect(track).toHaveBeenCalledWith('cash.phone_verified', { mode: 'resume' });
     expect(track).not.toHaveBeenCalledWith('cash.phone_verify_failed', expect.anything());

--- a/src/features/cash/stores/verifyPhoneFlowStore.ts
+++ b/src/features/cash/stores/verifyPhoneFlowStore.ts
@@ -5,37 +5,65 @@ import { time } from '@/framework/core/utils/time';
 import { logger, RainbowError } from '@/logger';
 import { delay } from '@/utils/delay';
 
-import { finishSignupResume, getUserStatus, KycStatus, resendPhoneCode, startSignupResume, verifyPhone } from '../services/userClient';
+import {
+  finishSignupResume,
+  getUserStatus,
+  KycStatus,
+  resendPhoneCode,
+  startSignupResume,
+  verifyPhone,
+  type KycOutcome,
+} from '../services/userClient';
 import { useCashSetupSessionStore, type PhoneChallenge } from './cashSetupSessionStore';
 
 export const OTP_LENGTH = 6;
 
 export type VerifyPhoneState = 'entry' | 'verifying' | 'verified' | 'error';
 
-export type VerifyPhoneResult = 'verified' | 'verifiedKycApproved' | 'failed' | 'signupAlreadyComplete';
+export type VerifyPhoneResult = 'verified' | 'verifiedKycOutcome' | 'failed' | 'signupAlreadyComplete';
 
-// Best-effort: failing only costs an approved user a redundant pass through
-// KYC entry, so a transient status failure gets one delayed retry.
-async function getIsKycApproved(bootstrapToken: string): Promise<boolean> {
-  const check = async () => (await getUserStatus({ bootstrapToken })).kycStatus === KycStatus.Approved;
+// Null means the wizard proceeds to the KYC steps: either nothing was ever
+// submitted, or the status could not be read and a redundant pass is the safe
+// guess — showing "we're reviewing" to someone who never submitted strands them.
+function toKycOutcome(status: KycStatus): KycOutcome | null {
+  switch (status) {
+    case KycStatus.Approved:
+      return 'approved';
+    case KycStatus.Rejected:
+      return 'rejected';
+    case KycStatus.Pending:
+    case KycStatus.Review:
+      return 'reviewing';
+    case KycStatus.Unspecified:
+      return null;
+  }
+}
+
+// Best-effort: failing only costs the user a redundant pass through KYC entry,
+// so a transient status failure gets one delayed retry.
+async function getResumeKycOutcome(bootstrapToken: string): Promise<KycOutcome | null> {
+  const check = async () => toKycOutcome((await getUserStatus({ bootstrapToken })).kycStatus);
   return check()
     .catch(() => delay(time.seconds(2)).then(check))
-    .catch(() => false);
+    .catch(() => null);
 }
 
 type VerifyPhoneFlowStore = {
   state: VerifyPhoneState;
   code: string;
+  kycOutcome: KycOutcome | null;
   resending: PhoneChallenge | null;
   setCode: (code: string) => void;
   submit: () => Promise<VerifyPhoneResult>;
   resend: () => Promise<void>;
+  clearKycOutcome: () => void;
   reset: () => void;
 };
 
 export const useVerifyPhoneFlowStore = createBaseStore<VerifyPhoneFlowStore>((set, get) => ({
   state: 'entry',
   code: '',
+  kycOutcome: null,
   resending: null,
 
   setCode: code => set(({ state }) => ({ code, state: state === 'error' ? 'entry' : state })),
@@ -68,10 +96,16 @@ export const useVerifyPhoneFlowStore = createBaseStore<VerifyPhoneFlowStore>((se
 
       sessionStore.setPhoneVerified(challenge, { bootstrapToken: result.bootstrapToken, expiresAt: result.expiresAt });
       analytics.track(analytics.event.cashPhoneVerified, { mode: challenge.kind });
-      // A resumed account may have completed KYC in an earlier signup attempt.
-      const skipKyc = challenge.kind === 'resume' && (await getIsKycApproved(result.bootstrapToken));
-      set({ state: 'verified' });
-      return skipKyc ? 'verifiedKycApproved' : 'verified';
+      // A resumed account may have submitted KYC in an earlier signup attempt.
+      const kycOutcome = challenge.kind === 'resume' ? await getResumeKycOutcome(result.bootstrapToken) : null;
+      if (kycOutcome === 'approved') analytics.track(analytics.event.cashKycApproved);
+      else if (kycOutcome === 'reviewing') analytics.track(analytics.event.cashKycAwaitingDecision, { source: 'resume' });
+      else if (kycOutcome === 'rejected') analytics.track(analytics.event.cashKycFailed, { reason: 'rejected' });
+      // Terminal, and deliberately not 'verifying': Setup's submission lock reads
+      // that state, so lingering there would disable every exit for the rest of
+      // the flow. Screen cleanup or a fresh phone submission resets the store.
+      set({ kycOutcome, state: 'verified' });
+      return kycOutcome ? 'verifiedKycOutcome' : 'verified';
     } catch (e) {
       if (!sessionStore.getIsCurrentChallenge(challenge)) {
         set(state => (state.state === 'verifying' ? { code: '', state: 'entry' } : state));
@@ -114,5 +148,9 @@ export const useVerifyPhoneFlowStore = createBaseStore<VerifyPhoneFlowStore>((se
     }
   },
 
-  reset: () => set({ code: '', resending: null, state: 'entry' }),
+  // Narrower than reset() on purpose: the step stays mounted behind the pager, so
+  // restoring 'entry' would re-enable its OTP input and flash the keyboard.
+  clearKycOutcome: () => set({ kycOutcome: null }),
+
+  reset: () => set({ code: '', kycOutcome: null, resending: null, state: 'entry' }),
 }));

--- a/src/features/config/stores/remoteConfig.ts
+++ b/src/features/config/stores/remoteConfig.ts
@@ -38,6 +38,7 @@ export interface RainbowConfig extends Record<
   /* Numbers */
   trace_call_block_number_offset: number;
   cash_pending_view_delay_ms: number;
+  cash_kyc_review_delay_ms: number;
 
   /* Booleans */
   f2c_enabled: boolean;
@@ -172,6 +173,7 @@ export const DEFAULT_CONFIG = {
   /* Numbers */
   trace_call_block_number_offset: 20,
   cash_pending_view_delay_ms: time.seconds(30),
+  cash_kyc_review_delay_ms: time.seconds(60),
 
   /* Booleans */
   f2c_enabled: true,

--- a/src/languages/en_US.json
+++ b/src/languages/en_US.json
@@ -1613,13 +1613,22 @@
           "date_of_birth": "Date of Birth",
           "ssn": "Social Security Number",
           "edit": "Edit",
+          "error_title": "We couldn’t verify your details",
+          "error_description": "Please double-check your details and try again.",
+          "edit_details": "Edit Details"
+        },
+        "kyc": {
           "verifying_title": "Verifying your identity...",
           "verifying_description": "This can take up to a few minutes.",
           "verified_title": "Identity verified",
           "verified_description": "We found a match based on your details. Please review and confirm everything looks correct.",
-          "error_title": "We couldn’t verify your details",
-          "error_description": "Please double-check your details and try again.",
-          "edit_details": "Edit Details"
+          "reviewing_title": "We’re reviewing your information",
+          "reviewing_description": "Your verification is still in progress. You can leave this screen and check back later.",
+          "reviewing_action": "Got it",
+          "rejected_title": "There was an issue verifying your details",
+          "rejected_description": "We weren’t able to verify your identity. Contact support if you think this is a mistake.",
+          "contact_support": "Contact Support",
+          "close": "Close"
         },
         "passkey": {
           "title": "Add a Passkey",


### PR DESCRIPTION
Fixed: APP-3945

## Why?

KYC decisions reach us by webhook on the provider's schedule — sometimes seconds, sometimes days. We polled for 30 seconds and treated anything still undecided as a hard failure, so a user whose review was merely slow was told we couldn't verify their details and pushed back to re-enter them. Their submission was already with the provider, so re-entering could not help, and nothing in the app remembered it.

"No verdict yet" is a normal outcome, not a failure. This makes waiting a state the user can walk away from and come back to.

While setting up, the in-progress sheet now becomes "We're reviewing your information" once the wait passes a threshold (remotely configurable, currently 60 seconds), with a **Got it** that closes setup while verification continues in the background. Polling carries on underneath the sheet, so a decision landing a few seconds later still resolves in place rather than sending the user away.

Coming back, the user re-authenticates with phone + OTP as they do today and is routed by what their verification actually says: still under review, approved (straight on to the passkey step, acknowledged with the existing "Identity verified" sheet), or rejected. Rejection is terminal and offers support rather than a pointless retry.

A pending decision is no longer counted as a verification failure in our funnel.

## Approach

Three decisions worth knowing about before reading the diff:

**Submission is the point of no return.** Once the provider has the identity data, nothing the user retypes changes the outcome, so from that moment the flow can only end in approved, rejected, or still-waiting. Any failure to *read* the status while that submission is in flight — a dropped connection, a backgrounded app, an expired credential — resolves to the waiting state rather than the retryable "check your details" error. That error now belongs solely to the submission itself failing, where retrying genuinely helps.

**On return, an unreadable status sends the user through KYC again.** The status read after the OTP gets one retry two seconds later; if both attempts fail we route the user into the identity steps. A failed read is indistinguishable from an account that never submitted, and showing "we're reviewing" to someone who never submitted would strand them with no way to finish signup. The repeat costs the user typing and nothing else: `SubmitOnboarding` is idempotent, so the resubmission creates no duplicate and comes back with the real status, which puts the flow back on the right branch by itself.

**Nothing about a pending decision is stored on device.** Before a passkey exists the app holds no durable credential, so a cached status could only ever be stale and unverifiable while still requiring an OTP to act on. The status is re-read from the server on each return instead.

## Screen recordings / screenshots


https://github.com/user-attachments/assets/bdf9e7d6-d24a-49e4-b92f-6e3a36655c08


https://github.com/user-attachments/assets/c89a25c7-c7df-4425-b393-484d3c8f6536


## What to test

1. Complete setup through to Review and confirm. A decision that arrives quickly behaves exactly as before: "Identity verified", then Continue.
2. With an identity whose review stays pending, wait out the threshold. The sheet should switch to "We're reviewing your information"; **Got it** should close setup entirely.
3. Reopen Add Cash and enter the same number. After the OTP you should land on the state matching that account's real verification status — still reviewing, or "Identity verified" leading to the passkey step.
4. Repeat with an identity that gets rejected. The rejection sheet should be terminal: **Contact Support** opens the support page and leaves setup, **Close** just leaves setup.
5. Within a single setup session, confirm you are never returned to the identity/SSN screens after a submission has gone through. On return the status read can fail twice, and then the KYC steps repeat by design — see Approach.
