### PR TITLE
feat(cash): switch to the production platform

### DIFF
--- a/globals.d.ts
+++ b/globals.d.ts
@@ -63,6 +63,7 @@ declare module 'react-native-dotenv' {
   export const BIVO_ENV: 'sandbox' | 'live';
   export const CASH_PLATFORM_BASE_URL: string;
   export const CASH_PLATFORM_API_KEY: string;
+  export const CASH_USE_PROD: 'true' | 'false';
   export const GELATO_API_KEY: string;
   export const RAINBOW_RELAY_URL: string;
   export const RAINBOW_RELAY_API_KEY: string;

--- a/src/features/cash/constants.ts
+++ b/src/features/cash/constants.ts
@@ -1,6 +1,7 @@
 import { ChainId, ChainName } from '@/features/network/types/backendNetworks';
 import { time } from '@/framework/core/utils/time';
 
+import { USES_STAGING_PLATFORM } from './services/cashPlatformClient';
 import { RampCryptoAsset, RampNetwork, type RampAsset } from './services/rampClient';
 
 export const USDC_NAME = 'USD Coin';
@@ -9,7 +10,11 @@ export const USDC_DECIMALS = 6;
 
 export const ORDER_POLL_INTERVAL_MS = time.seconds(2);
 
-export const CASH_BUY_DESTINATION_ASSET: RampAsset = { asset: RampCryptoAsset.USDC, network: RampNetwork.ArbitrumTestnet };
+/** Each platform admits exactly one destination: production `usdc/base`, staging `usdc/arbitrum_testnet`. */
+export const CASH_BUY_DESTINATION_ASSET: RampAsset = {
+  asset: RampCryptoAsset.USDC,
+  network: USES_STAGING_PLATFORM ? RampNetwork.ArbitrumTestnet : RampNetwork.Base,
+};
 
 /**
  * USDC deployments the ramp can deposit to, keyed by the wire `RampNetwork`. The
@@ -19,11 +24,6 @@ export const CASH_BUY_DESTINATION_ASSET: RampAsset = { asset: RampCryptoAsset.US
  * through the backend networks store, which never returns testnets.
  */
 export const CASH_USDC_BY_NETWORK: Partial<Record<RampNetwork, { chainId: ChainId; chainName: ChainName; address: string }>> = {
-  [RampNetwork.Arbitrum]: {
-    chainId: ChainId.arbitrum,
-    chainName: ChainName.arbitrum,
-    address: '0xaf88d065e77c8cc2239327c5edb3a432268e5831',
-  },
   [RampNetwork.ArbitrumTestnet]: {
     chainId: ChainId.arbitrumSepolia,
     chainName: ChainName.arbitrumSepolia,

--- a/src/features/cash/screens/add-cash-sheet/AddCashSheet.tsx
+++ b/src/features/cash/screens/add-cash-sheet/AddCashSheet.tsx
@@ -195,7 +195,11 @@ function AddCashActionButton({
   const accent = useForegroundColor('accent');
 
   return (
-    <Box paddingHorizontal="20px" paddingTop="24px" style={{ paddingBottom: isKeypad ? safeAreaInsetValues.bottom + 16 : 32 }}>
+    <Box
+      paddingHorizontal="20px"
+      paddingTop={isKeypad ? undefined : '24px'}
+      style={{ paddingBottom: isKeypad ? safeAreaInsetValues.bottom + 16 : 32 }}
+    >
       {hasLinkedCard ? (
         <HoldToActivateButton
           backgroundColor="accent"
@@ -293,7 +297,7 @@ function KeypadAmountContent({
       </Box>
       <KeypadFundingCaption />
       {linkedCard && <AddFromRow card={linkedCard} onPress={onAddFrom} />}
-      <Box as={Animated.View} entering={FadeIn.duration(160)} paddingBottom="8px">
+      <Box as={Animated.View} entering={FadeIn.duration(160)} paddingBottom="8px" paddingTop="24px">
         <NumberPad
           activeFieldId={amount.activeFieldId}
           fields={amount.fields}

--- a/src/features/cash/screens/cash-deposit-setup/CashDepositSetupScreen.tsx
+++ b/src/features/cash/screens/cash-deposit-setup/CashDepositSetupScreen.tsx
@@ -28,7 +28,6 @@ import { AllDoneStep } from './steps/AllDoneStep';
 import { CardAddedStep } from './steps/CardAddedStep';
 import { CardDetailsStep } from './steps/CardDetailsStep';
 import { ConfirmPhoneStep } from './steps/ConfirmPhoneStep';
-import { EmailStep } from './steps/EmailStep';
 import { IdentityStep } from './steps/IdentityStep';
 import { PasskeyStep } from './steps/PasskeyStep';
 import { PhoneStep } from './steps/PhoneStep';
@@ -46,7 +45,6 @@ const STEP_COMPONENTS: Record<CashDepositSetupRoute, React.ReactElement> = {
   [Routes.CASH_SETUP_SSN]: <SsnStep />,
   [Routes.CASH_SETUP_REVIEW]: <ReviewStep />,
   [Routes.CASH_SETUP_PASSKEY]: <PasskeyStep />,
-  [Routes.CASH_SETUP_EMAIL]: <EmailStep />,
   [Routes.CASH_SETUP_ALL_DONE]: <AllDoneStep />,
   [Routes.CASH_SETUP_CARD_DETAILS]: <CardDetailsStep />,
   [Routes.CASH_SETUP_CARD_ADDED]: <CardAddedStep />,

--- a/src/features/cash/screens/cash-deposit-setup/steps.ts
+++ b/src/features/cash/screens/cash-deposit-setup/steps.ts
@@ -11,13 +11,12 @@ export const SETUP_STEP_ORDER: readonly CashDepositSetupRoute[] = [
   Routes.CASH_SETUP_SSN,
   Routes.CASH_SETUP_REVIEW,
   Routes.CASH_SETUP_PASSKEY,
-  Routes.CASH_SETUP_EMAIL,
   Routes.CASH_SETUP_ALL_DONE,
   Routes.CASH_SETUP_CARD_DETAILS,
   Routes.CASH_SETUP_CARD_ADDED,
 ];
 
-type SetupBackGroup = 'signup' | 'kyc' | 'passkey' | 'email' | 'card' | 'cardAdded';
+type SetupBackGroup = 'signup' | 'kyc' | 'passkey' | 'card' | 'cardAdded';
 
 /**
  * Back navigation only works within a group; navigating across a boundary clears history, so
@@ -31,7 +30,6 @@ export const SETUP_STEP_GROUP: Record<CashDepositSetupRoute, SetupBackGroup> = {
   [Routes.CASH_SETUP_SSN]: 'kyc',
   [Routes.CASH_SETUP_REVIEW]: 'kyc',
   [Routes.CASH_SETUP_PASSKEY]: 'passkey',
-  [Routes.CASH_SETUP_EMAIL]: 'email',
   [Routes.CASH_SETUP_ALL_DONE]: 'card',
   [Routes.CASH_SETUP_CARD_DETAILS]: 'card',
   [Routes.CASH_SETUP_CARD_ADDED]: 'cardAdded',

--- a/src/features/cash/screens/cash-deposit-setup/steps/EmailStep.tsx
+++ b/src/features/cash/screens/cash-deposit-setup/steps/EmailStep.tsx
@@ -1,9 +1,0 @@
-import React, { memo } from 'react';
-
-import * as i18n from '@/languages';
-
-import { SetupStepLayout } from '../components/SetupStepLayout';
-
-export const EmailStep = memo(function EmailStep() {
-  return <SetupStepLayout title={i18n.t(i18n.l.cash.deposit_setup.email.title)} />;
-});

--- a/src/features/cash/services/cashPlatformClient.ts
+++ b/src/features/cash/services/cashPlatformClient.ts
@@ -1,17 +1,22 @@
-import { CASH_PLATFORM_API_KEY, CASH_PLATFORM_BASE_URL } from 'react-native-dotenv';
+import { CASH_PLATFORM_API_KEY, CASH_PLATFORM_BASE_URL, CASH_USE_PROD } from 'react-native-dotenv';
 
 import { RainbowFetchClient } from '@/framework/data/http/rainbowFetch';
+import { getPlatformClient } from '@/resources/platform/client';
 
-let platformClient: RainbowFetchClient | undefined;
+let stagingClient: RainbowFetchClient | undefined;
 
 export function buildAuthenticatedHeader(token: string) {
   return { Authorization: `Bearer ${token}` };
 }
 
-// TODO: replace with src/resources/platform/client.ts
-// once cash related backend is completely deployed to production
+// Production unless CASH_USE_PROD=false in .env, which keeps the staging platform
+// reachable while cash backend changes roll out.
+export const USES_STAGING_PLATFORM = CASH_USE_PROD === 'false';
+
 export function getCashPlatformClient(): RainbowFetchClient {
-  return (platformClient ??= new RainbowFetchClient({
+  if (!USES_STAGING_PLATFORM) return getPlatformClient();
+
+  return (stagingClient ??= new RainbowFetchClient({
     baseURL: `${CASH_PLATFORM_BASE_URL}/v1`,
     headers: {
       Authorization: `Bearer ${CASH_PLATFORM_API_KEY}`,

--- a/src/features/cash/services/rampClient.ts
+++ b/src/features/cash/services/rampClient.ts
@@ -29,7 +29,6 @@ export enum RampCryptoAsset {
 
 export enum RampNetwork {
   Unspecified = 'NETWORK_UNSPECIFIED',
-  Arbitrum = 'NETWORK_ARBITRUM',
   ArbitrumTestnet = 'NETWORK_ARBITRUM_TESTNET',
   Base = 'NETWORK_BASE',
 }

--- a/src/features/cash/stores/cashBuyOrderStore.test.ts
+++ b/src/features/cash/stores/cashBuyOrderStore.test.ts
@@ -55,7 +55,12 @@ const PURCHASE_TRANSACTION = { hash: '0xtx', type: 'purchase' };
 
 // ---- Fixtures --------------------------------------------------------------
 
-const SPEC: BuyOrderSpec = { cardId: 'card-1', depositAmount: '50', id: 'order-1', walletAddress: '0xabc' };
+// The client submits the checksummed account address; the ramp echoes it back lowercased. Both forms are
+// fixtures on purpose — an all-lowercase address cannot express the difference the store has to reconcile.
+const WALLET_ADDRESS = '0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed';
+const RAMP_WALLET_ADDRESS = WALLET_ADDRESS.toLowerCase();
+
+const SPEC: BuyOrderSpec = { cardId: 'card-1', depositAmount: '50', id: 'order-1', walletAddress: WALLET_ADDRESS };
 const SUBMITTED_AT = 1750789885000;
 const CREATED_PENDING_ORDER: CreatedBuyOrder = {
   id: SPEC.id,
@@ -69,7 +74,7 @@ const ORDER_COMMON = {
   cryptoAmount: { amount: '50', asset: { asset: RampCryptoAsset.USDC, network: RampNetwork.Base } },
   fiatAmount: { amount: '50', currency: 'USD' },
   createdTime: '2026-06-24T18:31:25.000Z',
-  walletAddress: '0xabc',
+  walletAddress: RAMP_WALLET_ADDRESS,
 };
 const PENDING_ORDER: Exclude<BuyOrder, TerminalBuyOrder> = { ...ORDER_COMMON, status: OrderStatus.Pending };
 const PROCESSING_ORDER: Exclude<BuyOrder, TerminalBuyOrder> = { ...ORDER_COMMON, status: OrderStatus.Processing };
@@ -85,8 +90,8 @@ const FAILED_PAYMENT_ORDER: Extract<BuyOrder, { status: OrderStatus.Failed }> = 
   failureReason: OrderFailureReason.PaymentRejected,
 };
 
-const SUBMIT_INPUT = { cardId: 'card-1', depositAmount: '50', walletAddress: '0xabc' };
-const LINKED_WALLET = { id: 'wallet-1', address: '0xabc' };
+const SUBMIT_INPUT = { cardId: 'card-1', depositAmount: '50', walletAddress: WALLET_ADDRESS };
+const LINKED_WALLET = { id: 'wallet-1', address: RAMP_WALLET_ADDRESS };
 
 function fetchError(status: number): RainbowFetchError {
   return new RainbowFetchError({ message: 'not found', response: { status } as Response });
@@ -292,13 +297,26 @@ describe('syncActiveOrder', () => {
 
     await getState().syncActiveOrder();
 
-    expect(buildPurchaseTransaction).toHaveBeenCalledWith({ order: COMPLETED_ORDER, walletAddress: COMPLETED_ORDER.walletAddress });
+    expect(buildPurchaseTransaction).toHaveBeenCalledWith({ order: COMPLETED_ORDER, walletAddress: WALLET_ADDRESS });
     expect(addPendingTransaction).toHaveBeenCalledWith({
-      address: COMPLETED_ORDER.walletAddress,
+      address: WALLET_ADDRESS,
       pendingTransaction: PURCHASE_TRANSACTION,
     });
     expect(getState().status).toEqual({ step: 'success', order: COMPLETED_ORDER });
     expect(phase()).toBe('success');
+  });
+
+  // usePendingTransactionsStore is a raw-keyed map and every reader looks the row up under the app's
+  // checksummed account address, so filing it under the ramp's lowercased echo hides it from all of them.
+  it('keys the pending transaction by the checksummed address, not the ramp echo', async () => {
+    startPolling(PROCESSING_ORDER);
+    getOrder.mockResolvedValue(COMPLETED_ORDER);
+
+    await getState().syncActiveOrder();
+
+    const { address } = addPendingTransaction.mock.calls[0][0];
+    expect(address).toBe(WALLET_ADDRESS);
+    expect(address).not.toBe(COMPLETED_ORDER.walletAddress);
   });
 
   it('surfaces a payment-rejected error when polling resolves to failed', async () => {

--- a/src/features/cash/stores/cashBuyOrderStore.ts
+++ b/src/features/cash/stores/cashBuyOrderStore.ts
@@ -2,6 +2,7 @@ import { createBaseStore, createStoreActions } from '@storesjs/stores';
 import { v4 as uuidv4 } from 'uuid';
 
 import { analytics } from '@/analytics';
+import { requireAddress } from '@/features/address/core/requireAddress';
 import { logger, RainbowError } from '@/logger';
 import { pendingTransactionsActions } from '@/state/pendingTransactions';
 
@@ -91,9 +92,12 @@ export const useCashBuyOrderStore = createBaseStore<CashBuyOrderState>(
           timeToUsdcMs: new Date(order.completedTime).getTime() - new Date(order.createdTime).getTime(),
         });
         try {
+          // The ramp echoes the address lowercased, while every reader of the pending-transaction store
+          // keys off the app's checksummed account address.
+          const walletAddress = requireAddress(order.walletAddress, '[cashBuyOrderStore] ramp returned an invalid wallet address');
           pendingTransactionsActions.addPendingTransaction({
-            address: order.walletAddress,
-            pendingTransaction: buildCashPurchaseTransaction({ order, walletAddress: order.walletAddress }),
+            address: walletAddress,
+            pendingTransaction: buildCashPurchaseTransaction({ order, walletAddress }),
           });
         } catch (error) {
           logger.error(new RainbowError('[cashBuyOrderStore] failed to enqueue purchase transaction', { error }), {

--- a/src/languages/en_US.json
+++ b/src/languages/en_US.json
@@ -1638,7 +1638,6 @@
           "error_description": "We couldn’t add your passkey. Please try again.",
           "try_again": "Try Again"
         },
-        "email": { "title": "Enter email" },
         "all_done": {
           "title": "You’re all done!",
           "description": "You’re good to go. Add a payment method and you’re ready.",

--- a/src/navigation/routesNames.ts
+++ b/src/navigation/routesNames.ts
@@ -71,7 +71,6 @@ const Routes = {
   CASH_SETUP_SSN: 'CashSetupSsn',
   CASH_SETUP_REVIEW: 'CashSetupReview',
   CASH_SETUP_PASSKEY: 'CashSetupPasskey',
-  CASH_SETUP_EMAIL: 'CashSetupEmail',
   CASH_SETUP_ALL_DONE: 'CashSetupAllDone',
   CASH_SETUP_CARD_DETAILS: 'CashSetupCardDetails',
   CASH_SETUP_CARD_ADDED: 'CashSetupCardAdded',

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -155,7 +155,6 @@ export type CashDepositSetupRoute =
   | typeof Routes.CASH_SETUP_SSN
   | typeof Routes.CASH_SETUP_REVIEW
   | typeof Routes.CASH_SETUP_PASSKEY
-  | typeof Routes.CASH_SETUP_EMAIL
   | typeof Routes.CASH_SETUP_ALL_DONE
   | typeof Routes.CASH_SETUP_CARD_DETAILS
   | typeof Routes.CASH_SETUP_CARD_ADDED;


### PR DESCRIPTION
Fixes APP-3975

## What changed (plus any additional context for devs)

**Cash now talks to the production platform.** Cash was the only feature resolving its own platform client: `getCashPlatformClient()` built a `RainbowFetchClient` from `CASH_PLATFORM_BASE_URL`/`CASH_PLATFORM_API_KEY`, so signup, KYC, passkey, auth and ramp calls ran against a different backend than the rest of the app, which goes through `getPlatformClient()` and `PLATFORM_BASE_URL`. `getCashPlatformClient()` now returns that shared production client.

The staging path is kept behind a flag rather than deleted, so pointing cash back at staging is one line of `.env`:

```
CASH_USE_PROD=false
```

Anything other than the literal `false` — including an unset variable — resolves to production, so no build needs the new key: the dotenv transform runs with `allowUndefined: true`, and `.env.example` doesn't carry these vars.

Two notes for reviewers:

- Every cash service still calls `getCashPlatformClient()`. No call site changed, only what it returns.
- Calls that don't carry a user token now send `PLATFORM_API_KEY` instead of `CASH_PLATFORM_API_KEY`. Bootstrap- and JWT-authenticated calls are unaffected: per-request `headers` replace the client's defaults in `RainbowFetchClient`, so those requests still carry only the user token.

**Removed the email setup step.** It rendered a title and nothing else — no input, no submit, no wiring — so the setup pager now goes from Passkey straight to All done. The route, its `SETUP_STEP_ORDER` entry, the `CashDepositSetupRoute` union member and the orphaned `en_US` string go with it.

**Fixed the keypad padding on Add Cash.** The action button carried a 24px top padding in both layouts, so in the keypad layout the gap sat between the number pad and the button while the pad stayed flush against the row above it. The keypad layout now spends that 24px above the number pad; the preset layout is unchanged.

## Screen recordings / screenshots

| Before | After |
|--------|--------|
| <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-08-07 at 17 42 17" src="https://github.com/user-attachments/assets/d2b0060b-e9ad-4043-aaab-e6b213010047" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-08-07 at 17 48 02" src="https://github.com/user-attachments/assets/594525bf-3bb7-4b82-aeb4-d4475aebee65" /> |



