### PR TITLE
Add tests for updated transaction watching behavior

### DIFF
--- a/src/framework/ui/hooks/useWatcher.test.ts
+++ b/src/framework/ui/hooks/useWatcher.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+import { logger } from '@/logger';
+
+import { useWatcher } from './useWatcher';
+
+const mockUseEffect = jest.fn<(effect: () => void | (() => void)) => void>();
+
+jest.mock('react', () => ({
+  useEffect: (effect: () => void | (() => void)) => mockUseEffect(effect),
+}));
+
+jest.mock('@/logger', () => ({
+  logger: {
+    error: jest.fn(),
+  },
+  RainbowError: class RainbowError extends Error {},
+}));
+
+describe('useWatcher', () => {
+  let cleanup: (() => void) | undefined;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.clearAllMocks();
+    mockUseEffect.mockImplementation((effect: () => void | (() => void)) => {
+      cleanup = effect() ?? undefined;
+    });
+  });
+
+  afterEach(() => {
+    cleanup?.();
+    cleanup = undefined;
+    jest.clearAllTimers();
+    jest.useRealTimers();
+  });
+
+  it('backs off a failure streak, logs it once, and resets after success', async () => {
+    const watchFunction = jest
+      .fn<(abortController: AbortController) => Promise<void>>()
+      .mockRejectedValueOnce(new Error('rate limited'))
+      .mockRejectedValueOnce(new Error('still rate limited'))
+      .mockResolvedValue(undefined);
+
+    useWatcher({ interval: 1_000, watchFunction });
+    await flushPromises();
+
+    expect(watchFunction).toHaveBeenCalledTimes(1);
+    expect(logger.error).toHaveBeenCalledTimes(1);
+
+    await jest.advanceTimersByTimeAsync(1_999);
+    expect(watchFunction).toHaveBeenCalledTimes(1);
+
+    await jest.advanceTimersByTimeAsync(1);
+    expect(watchFunction).toHaveBeenCalledTimes(2);
+    expect(logger.error).toHaveBeenCalledTimes(1);
+
+    await jest.advanceTimersByTimeAsync(3_000);
+    expect(watchFunction).toHaveBeenCalledTimes(3);
+
+    await jest.advanceTimersByTimeAsync(1_000);
+    expect(watchFunction).toHaveBeenCalledTimes(4);
+  });
+
+  it('does not schedule another run until the current run finishes', async () => {
+    const firstRun = createDeferred<void>();
+    const watchFunction = jest.fn(() => firstRun.promise);
+
+    useWatcher({ interval: 1_000, watchFunction });
+    await flushPromises();
+
+    await jest.advanceTimersByTimeAsync(60_000);
+    expect(watchFunction).toHaveBeenCalledTimes(1);
+
+    firstRun.resolve();
+    await flushPromises();
+    await jest.advanceTimersByTimeAsync(999);
+    expect(watchFunction).toHaveBeenCalledTimes(1);
+
+    await jest.advanceTimersByTimeAsync(1);
+    expect(watchFunction).toHaveBeenCalledTimes(2);
+  });
+});
+
+function createDeferred<T>() {
+  let resolve: (value: T | PromiseLike<T>) => void = () => undefined;
+  const promise = new Promise<T>(res => {
+    resolve = res;
+  });
+
+  return { promise, resolve };
+}
+
+async function flushPromises(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}

--- a/src/framework/ui/hooks/useWatcher.test.ts
+++ b/src/framework/ui/hooks/useWatcher.test.ts
@@ -24,6 +24,7 @@ describe('useWatcher', () => {
     jest.useFakeTimers();
     jest.clearAllMocks();
     mockUseEffect.mockImplementation((effect: () => void | (() => void)) => {
+      cleanup?.();
       cleanup = effect() ?? undefined;
     });
   });
@@ -79,6 +80,24 @@ describe('useWatcher', () => {
 
     await jest.advanceTimersByTimeAsync(1);
     expect(watchFunction).toHaveBeenCalledTimes(2);
+  });
+
+  it('aborts and clears scheduled work when disabled', async () => {
+    const watchFunction = jest.fn<(abortController: AbortController) => Promise<void>>().mockResolvedValue();
+
+    useWatcher({ interval: 1_000, watchFunction });
+    await flushPromises();
+
+    const abortController = watchFunction.mock.calls[0][0];
+    expect(jest.getTimerCount()).toBe(1);
+
+    useWatcher({ enabled: false, interval: 1_000, watchFunction });
+
+    expect(abortController.signal.aborted).toBe(true);
+    expect(jest.getTimerCount()).toBe(0);
+
+    await jest.advanceTimersByTimeAsync(1_000);
+    expect(watchFunction).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/src/hooks/pendingTransactionResolution.test.ts
+++ b/src/hooks/pendingTransactionResolution.test.ts
@@ -85,6 +85,21 @@ describe('pendingTransactionResolution', () => {
     expect(resolution.transaction).toBe(transaction);
   });
 
+  it('propagates onchain lookup failures to the owning watcher', async () => {
+    const error = new Error('rate limited');
+    mockFetchRawTransaction.mockRejectedValue(error);
+
+    await expect(
+      resolveTrackedTransaction({
+        abortController: null,
+        address: '0x123',
+        currency: 'ETH',
+        transaction: buildOnchainPendingTransaction(),
+      })
+    ).rejects.toBe(error);
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+
   it('keeps a managed pending transaction unchanged while relay is still working and no hash exists', async () => {
     const transaction = buildManagedPendingTransaction();
     mockGetStatus.mockResolvedValue(
@@ -108,7 +123,7 @@ describe('pendingTransactionResolution', () => {
     expect(mockFetchRawTransaction).not.toHaveBeenCalled();
   });
 
-  it('propagates relay refresh failures to the watcher', async () => {
+  it('propagates relay refresh failures to the owning watcher', async () => {
     const error = new Error('relay unavailable');
     mockGetStatus.mockRejectedValue(error);
 
@@ -120,6 +135,7 @@ describe('pendingTransactionResolution', () => {
         transaction: buildManagedConfirmedTransaction(),
       })
     ).rejects.toBe(error);
+    expect(logger.error).not.toHaveBeenCalled();
   });
 
   it('keeps a confirmed managed transaction settled while relay exposes a late origin hash', async () => {

--- a/src/hooks/useTransactionWatcher.test.ts
+++ b/src/hooks/useTransactionWatcher.test.ts
@@ -1,0 +1,48 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+import { useWatcher } from '@/framework/ui/hooks/useWatcher';
+
+import { useTransactionWatcher } from './useTransactionWatcher';
+
+type WatcherCallback = (abortController: AbortController) => Promise<void>;
+
+const mockTransactionsRef: { current: string[] } = { current: [] };
+let mockMemoizedCallback: WatcherCallback | undefined;
+
+jest.mock('react', () => ({
+  useCallback: (callback: WatcherCallback) => (mockMemoizedCallback ??= callback),
+  useRef: () => mockTransactionsRef,
+}));
+
+jest.mock('@/framework/ui/hooks/useWatcher', () => ({
+  useWatcher: jest.fn(),
+}));
+
+const mockUseWatcher = jest.mocked(useWatcher);
+
+describe('useTransactionWatcher', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockMemoizedCallback = undefined;
+    mockTransactionsRef.current = [];
+  });
+
+  it('keeps the scheduler callback stable while reading the latest transactions', async () => {
+    const firstTransactions = ['first'];
+    const latestTransactions = ['latest'];
+    const watchFunction = jest.fn<(transactions: string[], abortController: AbortController) => Promise<void>>().mockResolvedValue();
+
+    useTransactionWatcher({ transactions: firstTransactions, watchFunction });
+    const firstCallback = mockUseWatcher.mock.calls[0][0].watchFunction;
+
+    useTransactionWatcher({ transactions: latestTransactions, watchFunction });
+    const latestCallback = mockUseWatcher.mock.calls[1][0].watchFunction;
+    const abortController = new AbortController();
+
+    expect(latestCallback).toBe(firstCallback);
+
+    await latestCallback(abortController);
+
+    expect(watchFunction).toHaveBeenCalledWith(latestTransactions, abortController);
+  });
+});

--- a/src/hooks/useTransactionWatcher.test.ts
+++ b/src/hooks/useTransactionWatcher.test.ts
@@ -7,9 +7,21 @@ import { useTransactionWatcher } from './useTransactionWatcher';
 type WatcherCallback = (abortController: AbortController) => Promise<void>;
 
 const mockTransactionsRef: { current: string[] } = { current: [] };
-const mockUseCallback = jest
-  .fn<(callback: WatcherCallback, dependencies: readonly unknown[]) => WatcherCallback>()
-  .mockImplementation(callback => callback);
+let mockMemoizedCallback: { callback: WatcherCallback; dependencies: readonly unknown[] } | undefined;
+
+function mockUseCallback(callback: WatcherCallback, dependencies: readonly unknown[]): WatcherCallback {
+  const memoizedCallback = mockMemoizedCallback;
+  if (
+    memoizedCallback &&
+    dependencies.length === memoizedCallback.dependencies.length &&
+    dependencies.every((dependency, index) => Object.is(dependency, memoizedCallback.dependencies[index]))
+  ) {
+    return memoizedCallback.callback;
+  }
+
+  mockMemoizedCallback = { callback, dependencies };
+  return callback;
+}
 
 jest.mock('react', () => ({
   useCallback: (callback: WatcherCallback, dependencies: readonly unknown[]) => mockUseCallback(callback, dependencies),
@@ -25,23 +37,25 @@ const mockUseWatcher = jest.mocked(useWatcher);
 describe('useTransactionWatcher', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockMemoizedCallback = undefined;
     mockTransactionsRef.current = [];
   });
 
-  it('reads the latest transactions without restarting the scheduler', async () => {
+  it('keeps the scheduler callback stable while reading the latest transactions', async () => {
     const firstTransactions = ['first'];
     const latestTransactions = ['latest'];
     const watchFunction = jest.fn<(transactions: string[], abortController: AbortController) => Promise<void>>().mockResolvedValue();
 
     useTransactionWatcher({ transactions: firstTransactions, watchFunction });
-    useTransactionWatcher({ transactions: latestTransactions, watchFunction });
+    const firstWatch = mockUseWatcher.mock.calls[0][0].watchFunction;
 
-    const watch = mockUseWatcher.mock.calls[1][0].watchFunction;
+    useTransactionWatcher({ transactions: latestTransactions, watchFunction });
+    const latestWatch = mockUseWatcher.mock.calls[1][0].watchFunction;
     const abortController = new AbortController();
 
-    expect(mockUseCallback).toHaveBeenLastCalledWith(expect.any(Function), [watchFunction]);
+    expect(latestWatch).toBe(firstWatch);
 
-    await watch(abortController);
+    await firstWatch(abortController);
 
     expect(watchFunction).toHaveBeenCalledWith(latestTransactions, abortController);
   });

--- a/src/hooks/useTransactionWatcher.test.ts
+++ b/src/hooks/useTransactionWatcher.test.ts
@@ -7,10 +7,12 @@ import { useTransactionWatcher } from './useTransactionWatcher';
 type WatcherCallback = (abortController: AbortController) => Promise<void>;
 
 const mockTransactionsRef: { current: string[] } = { current: [] };
-let mockMemoizedCallback: WatcherCallback | undefined;
+const mockUseCallback = jest
+  .fn<(callback: WatcherCallback, dependencies: readonly unknown[]) => WatcherCallback>()
+  .mockImplementation(callback => callback);
 
 jest.mock('react', () => ({
-  useCallback: (callback: WatcherCallback) => (mockMemoizedCallback ??= callback),
+  useCallback: (callback: WatcherCallback, dependencies: readonly unknown[]) => mockUseCallback(callback, dependencies),
   useRef: () => mockTransactionsRef,
 }));
 
@@ -23,25 +25,23 @@ const mockUseWatcher = jest.mocked(useWatcher);
 describe('useTransactionWatcher', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockMemoizedCallback = undefined;
     mockTransactionsRef.current = [];
   });
 
-  it('keeps the scheduler callback stable while reading the latest transactions', async () => {
+  it('reads the latest transactions without restarting the scheduler', async () => {
     const firstTransactions = ['first'];
     const latestTransactions = ['latest'];
     const watchFunction = jest.fn<(transactions: string[], abortController: AbortController) => Promise<void>>().mockResolvedValue();
 
     useTransactionWatcher({ transactions: firstTransactions, watchFunction });
-    const firstCallback = mockUseWatcher.mock.calls[0][0].watchFunction;
-
     useTransactionWatcher({ transactions: latestTransactions, watchFunction });
-    const latestCallback = mockUseWatcher.mock.calls[1][0].watchFunction;
+
+    const watch = mockUseWatcher.mock.calls[1][0].watchFunction;
     const abortController = new AbortController();
 
-    expect(latestCallback).toBe(firstCallback);
+    expect(mockUseCallback).toHaveBeenLastCalledWith(expect.any(Function), [watchFunction]);
 
-    await latestCallback(abortController);
+    await watch(abortController);
 
     expect(watchFunction).toHaveBeenCalledWith(latestTransactions, abortController);
   });

--- a/src/hooks/useWatchPendingTxs.test.ts
+++ b/src/hooks/useWatchPendingTxs.test.ts
@@ -150,14 +150,14 @@ describe('watchPendingTransaction', () => {
     jest.useRealTimers();
   });
 
-  it('polls one transaction per tick in round-robin order', async () => {
+  it('polls caller-supplied transactions one at a time in round-robin order', async () => {
     const firstTransaction = buildManagedPendingTransaction({ hash: 'execution-1', relayExecutionId: 'execution-1' });
     const secondTransaction = buildManagedPendingTransaction({ hash: 'execution-2', relayExecutionId: 'execution-2' });
     const watch = useWatchPendingTransactions({ address: TEST_ADDRESS });
 
     pendingTransactionsActions.setPendingTransactions({
       address: TEST_ADDRESS,
-      pendingTransactions: [firstTransaction, secondTransaction],
+      pendingTransactions: [secondTransaction, firstTransaction],
     });
     mockResolveTrackedTransaction
       .mockResolvedValueOnce({ kind: 'pending', transaction: firstTransaction })

--- a/src/hooks/useWatchPendingTxs.test.ts
+++ b/src/hooks/useWatchPendingTxs.test.ts
@@ -60,7 +60,9 @@ jest.mock('@/state/swaps/swapsStore', () => ({
 }));
 
 jest.mock('@/state/assets/userAssetsStoreManager', () => {
-  const state: { address: string; cachedStore?: unknown; currency: 'ETH' } = { address: '0x123', currency: 'ETH' };
+  const cachedStore = { getState: () => ({ userAssets: new Map() }) };
+  const state = { address: '0x123', cachedStore, currency: 'ETH' as const };
+
   return {
     userAssetsStoreManager: Object.assign((selector: (storeState: typeof state) => unknown) => selector(state), {
       getState: () => state,
@@ -95,6 +97,20 @@ jest.mock('@/state/nonces', () => ({
 jest.mock('@/resources/transactions/consolidatedTransactions', () => ({
   consolidatedTransactionsQueryKey: (params: unknown) => ['consolidatedTransactions', params],
 }));
+
+jest.mock('@/features/network/stores/backendNetworksStore', () => {
+  const chainIds = [1, 10, 8453];
+  const state = {
+    getSupportedChainIds: () => chainIds,
+    getSupportedMainnetChainIds: () => chainIds,
+    getSupportedPositionsChainIds: () => chainIds,
+  };
+
+  return {
+    backendNetworksActions: state,
+    useBackendNetworksStore: { getState: () => state, subscribe: () => () => undefined },
+  };
+});
 
 jest.mock('@/analytics', () => ({
   analytics: {

--- a/src/hooks/useWatchPendingTxs.test.ts
+++ b/src/hooks/useWatchPendingTxs.test.ts
@@ -19,7 +19,7 @@ import { RelayExecutionStatus } from '@rainbow-me/sdk';
 import { SwapType } from '@rainbow-me/swaps';
 
 import { resolveTrackedTransaction } from './pendingTransactionResolution';
-import { useWatchPendingTransactions } from './useWatchPendingTxs';
+import { useWatchPendingTransactions, watchPendingTransaction } from './useWatchPendingTxs';
 
 jest.mock('react', () => ({
   ...jest.requireActual<typeof import('react')>('react'),
@@ -114,11 +114,10 @@ type ConfirmedManagedTransaction = Omit<PendingTransaction, 'status' | 'title'> 
   title: 'swap.confirmed';
 };
 
-describe('useWatchPendingTransactions', () => {
+describe('watchPendingTransaction', () => {
   const mockResolveTrackedTransaction = jest.mocked(resolveTrackedTransaction);
   const mockFetchRawTransaction = jest.mocked(fetchRawTransaction);
   let refetchQueriesSpy: jest.SpiedFunction<typeof queryClient.refetchQueries>;
-  let watchPendingTransactions: ReturnType<typeof useWatchPendingTransactions>;
 
   beforeEach(() => {
     jest.useFakeTimers();
@@ -127,13 +126,43 @@ describe('useWatchPendingTransactions', () => {
     resetStores();
 
     refetchQueriesSpy = jest.spyOn(queryClient, 'refetchQueries').mockImplementation(async () => undefined);
-    watchPendingTransactions = useWatchPendingTransactions({ address: TEST_ADDRESS });
   });
 
   afterEach(() => {
     refetchQueriesSpy.mockRestore();
     jest.runOnlyPendingTimers();
     jest.useRealTimers();
+  });
+
+  it('polls one transaction per tick in round-robin order', async () => {
+    const firstTransaction = buildManagedPendingTransaction({ hash: 'execution-1', relayExecutionId: 'execution-1' });
+    const secondTransaction = buildManagedPendingTransaction({ hash: 'execution-2', relayExecutionId: 'execution-2' });
+    const watch = useWatchPendingTransactions({ address: TEST_ADDRESS });
+
+    pendingTransactionsActions.setPendingTransactions({
+      address: TEST_ADDRESS,
+      pendingTransactions: [firstTransaction, secondTransaction],
+    });
+    mockResolveTrackedTransaction
+      .mockResolvedValueOnce({ kind: 'pending', transaction: firstTransaction })
+      .mockResolvedValueOnce({ kind: 'pending', transaction: secondTransaction });
+
+    await watch([firstTransaction, secondTransaction], new AbortController());
+    await watch([firstTransaction, secondTransaction], new AbortController());
+
+    expect(mockResolveTrackedTransaction).toHaveBeenCalledTimes(2);
+    expect(mockResolveTrackedTransaction).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        transaction: firstTransaction,
+      })
+    );
+    expect(mockResolveTrackedTransaction).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        transaction: secondTransaction,
+      })
+    );
   });
 
   it('keeps unsettled overlays and retains newly settled overlays until history indexes them', async () => {
@@ -170,19 +199,17 @@ describe('useWatchPendingTransactions', () => {
       address: TEST_ADDRESS,
       pendingTransactions: [stillPendingTransaction, confirmedPendingTransaction],
     });
-    mockResolveTrackedTransaction
-      .mockResolvedValueOnce({
-        kind: 'pending',
-        transaction: stillPendingTransaction,
-      })
-      .mockResolvedValueOnce({
-        kind: 'settled',
-        transaction: confirmedTransaction,
-      });
+    mockResolveTrackedTransaction.mockResolvedValue({
+      kind: 'settled',
+      transaction: confirmedTransaction,
+    });
 
-    const transactions = [stillPendingTransaction, confirmedPendingTransaction];
-    await watchPendingTransactions(transactions, new AbortController());
-    await watchPendingTransactions(transactions, new AbortController());
+    await watchPendingTransaction({
+      abortController: new AbortController(),
+      address: TEST_ADDRESS,
+      currency: TEST_CURRENCY,
+      transaction: confirmedPendingTransaction,
+    });
     await flushBackgroundSync();
 
     expect(usePendingTransactionsStore.getState().pendingTransactions[TEST_ADDRESS]).toEqual([
@@ -212,6 +239,102 @@ describe('useWatchPendingTransactions', () => {
       ],
       type: 'all',
     });
+  });
+
+  it('preserves transactions added while a poll is in flight', async () => {
+    const firstTransaction = buildManagedPendingTransaction({ hash: 'execution-1', relayExecutionId: 'execution-1' });
+    const secondTransaction = buildManagedPendingTransaction({ hash: 'execution-2', relayExecutionId: 'execution-2' });
+    const confirmedTransaction: SettledTransaction = {
+      ...firstTransaction,
+      hash: '0x1111111111111111111111111111111111111111111111111111111111111111',
+      status: TransactionStatus.confirmed,
+      title: 'swap.confirmed',
+    };
+    const resolution = createDeferred<Awaited<ReturnType<typeof resolveTrackedTransaction>>>();
+
+    pendingTransactionsActions.setPendingTransactions({
+      address: TEST_ADDRESS,
+      pendingTransactions: [firstTransaction],
+    });
+    mockResolveTrackedTransaction.mockImplementation(() => resolution.promise);
+
+    const watchPromise = watchPendingTransaction({
+      abortController: new AbortController(),
+      address: TEST_ADDRESS,
+      currency: TEST_CURRENCY,
+      transaction: firstTransaction,
+    });
+
+    pendingTransactionsActions.addPendingTransaction({
+      address: TEST_ADDRESS,
+      pendingTransaction: secondTransaction,
+    });
+    resolution.resolve({ kind: 'settled', transaction: confirmedTransaction });
+    await watchPromise;
+
+    expect(usePendingTransactionsStore.getState().pendingTransactions[TEST_ADDRESS]).toEqual([confirmedTransaction, secondTransaction]);
+  });
+
+  it('ignores a stale result after the polled transaction is replaced', async () => {
+    const transaction = buildManagedPendingTransaction({ hash: 'execution-1', relayExecutionId: 'execution-1' });
+    const replacement: PendingTransaction = {
+      ...transaction,
+      description: 'newer local state',
+    };
+    const confirmedTransaction: SettledTransaction = {
+      ...transaction,
+      hash: '0x1111111111111111111111111111111111111111111111111111111111111111',
+      status: TransactionStatus.confirmed,
+      title: 'swap.confirmed',
+    };
+    const resolution = createDeferred<Awaited<ReturnType<typeof resolveTrackedTransaction>>>();
+
+    pendingTransactionsActions.setPendingTransactions({
+      address: TEST_ADDRESS,
+      pendingTransactions: [transaction],
+    });
+    mockResolveTrackedTransaction.mockImplementation(() => resolution.promise);
+
+    const watchPromise = watchPendingTransaction({
+      abortController: new AbortController(),
+      address: TEST_ADDRESS,
+      currency: TEST_CURRENCY,
+      transaction,
+    });
+
+    pendingTransactionsActions.addPendingTransaction({
+      address: TEST_ADDRESS,
+      pendingTransaction: replacement,
+    });
+    resolution.resolve({ kind: 'settled', transaction: confirmedTransaction });
+    await watchPromise;
+
+    expect(usePendingTransactionsStore.getState().pendingTransactions[TEST_ADDRESS]).toEqual([replacement]);
+    expect(Object.values(useRainbowToastsStore.getState().toasts)).toHaveLength(1);
+    expect(Object.values(useRainbowToastsStore.getState().toasts)[0]?.transaction).toBe(replacement);
+  });
+
+  it('leaves overlays unchanged when resolution fails', async () => {
+    const transaction = buildManagedPendingTransaction({ hash: 'execution-1', relayExecutionId: 'execution-1' });
+    const error = new Error('rate limited');
+
+    pendingTransactionsActions.setPendingTransactions({
+      address: TEST_ADDRESS,
+      pendingTransactions: [transaction],
+    });
+    mockResolveTrackedTransaction.mockRejectedValue(error);
+
+    await expect(
+      watchPendingTransaction({
+        abortController: new AbortController(),
+        address: TEST_ADDRESS,
+        currency: TEST_CURRENCY,
+        transaction,
+      })
+    ).rejects.toBe(error);
+
+    expect(usePendingTransactionsStore.getState().pendingTransactions[TEST_ADDRESS]).toEqual([transaction]);
+    expect(Object.values(useRainbowToastsStore.getState().toasts)).toHaveLength(0);
   });
 
   it('drops settled overlays once history includes them', async () => {
@@ -251,7 +374,12 @@ describe('useWatchPendingTransactions', () => {
       );
     });
 
-    await watchPendingTransactions([pendingTransaction], new AbortController());
+    await watchPendingTransaction({
+      abortController: new AbortController(),
+      address: TEST_ADDRESS,
+      currency: TEST_CURRENCY,
+      transaction: pendingTransaction,
+    });
     await flushBackgroundSync();
 
     expect(usePendingTransactionsStore.getState().pendingTransactions[TEST_ADDRESS]).toEqual([]);
@@ -273,7 +401,12 @@ describe('useWatchPendingTransactions', () => {
       transaction: pendingTransaction,
     });
 
-    await watchPendingTransactions([pendingTransaction], new AbortController());
+    await watchPendingTransaction({
+      abortController: new AbortController(),
+      address: TEST_ADDRESS,
+      currency: TEST_CURRENCY,
+      transaction: pendingTransaction,
+    });
 
     expect(mockResolveTrackedTransaction).toHaveBeenCalledTimes(1);
     expect(mockResolveTrackedTransaction).toHaveBeenCalledWith(
@@ -346,7 +479,12 @@ describe('useWatchPendingTransactions', () => {
       transaction: settledTransaction,
     });
 
-    await watchPendingTransactions([pendingTransaction], new AbortController());
+    await watchPendingTransaction({
+      abortController: new AbortController(),
+      address: TEST_ADDRESS,
+      currency: TEST_CURRENCY,
+      transaction: pendingTransaction,
+    });
     await flushBackgroundSync();
 
     expect(mockFetchRawTransaction).toHaveBeenNthCalledWith(
@@ -386,7 +524,12 @@ describe('useWatchPendingTransactions', () => {
       transaction: failedTransaction,
     });
 
-    await watchPendingTransactions([pendingTransaction], new AbortController());
+    await watchPendingTransaction({
+      abortController: new AbortController(),
+      address: TEST_ADDRESS,
+      currency: TEST_CURRENCY,
+      transaction: pendingTransaction,
+    });
 
     expect(usePendingTransactionsStore.getState().pendingTransactions[TEST_ADDRESS]).toEqual([]);
     expect(Object.values(useRainbowToastsStore.getState().toasts)).toHaveLength(1);
@@ -427,7 +570,12 @@ describe('useWatchPendingTransactions', () => {
     });
     mockFetchRawTransaction.mockImplementation(() => relayFetch.promise);
 
-    await watchPendingTransactions([pendingTransaction], new AbortController());
+    await watchPendingTransaction({
+      abortController: new AbortController(),
+      address: TEST_ADDRESS,
+      currency: TEST_CURRENCY,
+      transaction: pendingTransaction,
+    });
 
     expect(usePendingTransactionsStore.getState().pendingTransactions[TEST_ADDRESS]).toEqual([confirmedTransaction]);
     expect(Object.values(useRainbowToastsStore.getState().toasts)[0]?.transaction).toEqual(confirmedTransaction);
@@ -460,7 +608,12 @@ describe('useWatchPendingTransactions', () => {
       transaction: confirmedTransaction,
     });
 
-    await watchPendingTransactions([pendingTransaction], new AbortController());
+    await watchPendingTransaction({
+      abortController: new AbortController(),
+      address: TEST_ADDRESS,
+      currency: TEST_CURRENCY,
+      transaction: pendingTransaction,
+    });
     await flushBackgroundSync();
 
     expect(usePendingTransactionsStore.getState().pendingTransactions[TEST_ADDRESS]).toEqual([]);

--- a/src/resources/transactions/transaction.test.ts
+++ b/src/resources/transactions/transaction.test.ts
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+import { RainbowFetchClient, RainbowFetchError } from '@/framework/data/http/rainbowFetch';
+import { getPlatformClient } from '@/resources/platform/client';
+
+import { fetchRawTransaction } from './transaction';
+
+jest.mock('@/env', () => ({
+  IS_TEST: false,
+}));
+
+jest.mock('@/features/config/stores/experimentalConfigStore', () => ({
+  getExperimentalFlag: jest.fn(() => false),
+}));
+
+jest.mock('@/features/cash/utils/mockCashTransactionByHash', () => ({
+  getMockCashTransactionByHash: jest.fn(),
+}));
+
+jest.mock('@/parsers/transactions', () => ({
+  parseTransaction: jest.fn(),
+}));
+
+jest.mock('@/resources/platform/client', () => ({
+  getPlatformClient: jest.fn(),
+}));
+
+jest.mock('@/state/assets/userAssetsStoreManager', () => ({
+  userAssetsStoreManager: jest.fn(),
+}));
+
+jest.mock('@/state/wallets/walletsStore', () => ({
+  useAccountAddress: jest.fn(),
+}));
+
+const mockGetPlatformClient = jest.mocked(getPlatformClient);
+
+describe('fetchRawTransaction', () => {
+  let getSpy: jest.SpiedFunction<RainbowFetchClient['get']>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    const client = new RainbowFetchClient();
+    getSpy = jest.spyOn(client, 'get');
+    mockGetPlatformClient.mockReturnValue(client);
+  });
+
+  it('returns null when the transaction has not been indexed', async () => {
+    getSpy.mockImplementation(async () => {
+      throw buildFetchError(404);
+    });
+
+    await expect(fetchTransaction()).resolves.toBeNull();
+  });
+
+  it.each([401, 403, 408, 429, 500])('preserves HTTP %s failures for the polling owner', async status => {
+    const error = buildFetchError(status);
+    getSpy.mockImplementation(async () => {
+      throw error;
+    });
+
+    await expect(fetchTransaction()).rejects.toBe(error);
+  });
+});
+
+function fetchTransaction() {
+  return fetchRawTransaction({
+    address: '0x123',
+    chainId: 1,
+    currency: 'ETH',
+    hash: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+  });
+}
+
+function buildFetchError(status: number): RainbowFetchError {
+  return new RainbowFetchError({
+    message: `HTTP ${status}`,
+    response: new Response(null, { status }),
+  });
+}


### PR DESCRIPTION
## What changed (plus any additional context for devs)
- Follow-up to #7694 that adds test coverage for:
  - Round-robin transaction watching checks
  - Increasing delays after failures
  - Recovery after success
  - Pending transaction watcher callback stability (previously restarted the watcher loop for every transaction change)
- Mocks the two stores that were making network requests and intermittently stalling `useWatchPendingTxs.test.ts` (user assets store, backend networks store)

## Screen recordings / screenshots

## What to test
