### PR TITLE
feat(CASH): remove credit card

### DIFF
--- a/src/features/cash/components/CashStatusHalfSheet.tsx
+++ b/src/features/cash/components/CashStatusHalfSheet.tsx
@@ -104,7 +104,7 @@ export const CashStatusHalfSheet = memo(function CashStatusHalfSheet(props: Cash
                   <Box gap={16} paddingTop="32px">
                     <CashActionButton {...props.primaryAction} variant="tinted" />
                     {props.secondaryAction && (
-                      <CashActionButton color={props.status === 'warning' ? 'red' : 'blue'} {...props.secondaryAction} variant="plain" />
+                      <CashActionButton {...props.secondaryAction} color={props.status === 'warning' ? 'red' : 'blue'} variant="plain" />
                     )}
                   </Box>
                 )}

--- a/src/features/cash/components/CashStatusHalfSheet.tsx
+++ b/src/features/cash/components/CashStatusHalfSheet.tsx
@@ -11,7 +11,9 @@ import { useCashHalfSheetVisibilityStore } from '../stores/cashHalfSheetVisibili
 import { CashActionButton } from './CashActionButton';
 
 type HalfSheetAction = {
+  disabled?: boolean;
   label: string;
+  loading?: boolean;
   onPress: () => void;
   testID: string;
 };
@@ -88,37 +90,21 @@ export const CashStatusHalfSheet = memo(function CashStatusHalfSheet(props: Cash
 
                 {props.status === 'success' && (
                   <Box paddingTop="32px">
-                    <CashActionButton label={props.action.label} onPress={props.action.onPress} shadow testID={props.action.testID} />
+                    <CashActionButton {...props.action} shadow />
                   </Box>
                 )}
 
                 {props.status === 'reviewing' && (
                   <Box paddingTop="32px">
-                    <CashActionButton
-                      label={props.action.label}
-                      onPress={props.action.onPress}
-                      testID={props.action.testID}
-                      variant="tinted"
-                    />
+                    <CashActionButton {...props.action} variant="tinted" />
                   </Box>
                 )}
 
                 {isAlert && (
                   <Box gap={16} paddingTop="32px">
-                    <CashActionButton
-                      label={props.primaryAction.label}
-                      onPress={props.primaryAction.onPress}
-                      testID={props.primaryAction.testID}
-                      variant="tinted"
-                    />
+                    <CashActionButton {...props.primaryAction} variant="tinted" />
                     {props.secondaryAction && (
-                      <CashActionButton
-                        color={props.status === 'warning' ? 'red' : 'blue'}
-                        label={props.secondaryAction.label}
-                        onPress={props.secondaryAction.onPress}
-                        testID={props.secondaryAction.testID}
-                        variant="plain"
-                      />
+                      <CashActionButton color={props.status === 'warning' ? 'red' : 'blue'} {...props.secondaryAction} variant="plain" />
                     )}
                   </Box>
                 )}

--- a/src/features/cash/components/VisaBadge.tsx
+++ b/src/features/cash/components/VisaBadge.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { StyleSheet } from 'react-native';
+
+import { Box, Text, type TextProps } from '@/design-system';
+
+const SIZES = {
+  small: { height: 20, textSize: 'icon 8px', width: 28 },
+  large: { height: 26, textSize: 'icon 10px', width: 36 },
+} satisfies Record<string, { height: number; textSize: TextProps['size']; width: number }>;
+
+export function VisaBadge({ size = 'small' }: { size?: keyof typeof SIZES }) {
+  const { height, textSize, width } = SIZES[size];
+
+  return (
+    <Box
+      alignItems="center"
+      borderRadius={6}
+      height={{ custom: height }}
+      justifyContent="center"
+      style={styles.badge}
+      width={{ custom: width }}
+    >
+      <Text align="center" color="white" size={textSize} weight="heavy">
+        {'VISA'}
+      </Text>
+    </Box>
+  );
+}
+
+const styles = StyleSheet.create({
+  badge: {
+    backgroundColor: '#1B33C3',
+  },
+});

--- a/src/features/cash/screens/add-cash-sheet/AddCardHint.tsx
+++ b/src/features/cash/screens/add-cash-sheet/AddCardHint.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { StyleSheet } from 'react-native';
+
+import { Box, Text, useForegroundColor } from '@/design-system';
+import * as i18n from '@/languages';
+
+export function AddCardHint() {
+  const shadowFar = useForegroundColor('shadowFar');
+
+  return (
+    <Box alignItems="center" paddingTop="28px">
+      <Box
+        alignItems="center"
+        background="surfaceSecondaryElevated"
+        flexDirection="row"
+        gap={8}
+        style={[styles.pill, { shadowColor: shadowFar }]}
+      >
+        <Text color="labelQuaternary" size="icon 12px" weight="heavy">
+          {'􀍰'}
+        </Text>
+        <Text color="labelTertiary" size="15pt" weight="bold">
+          {i18n.t(i18n.l.cash.add_cash_screen.add_a_card_to_continue)}
+        </Text>
+      </Box>
+    </Box>
+  );
+}
+
+const styles = StyleSheet.create({
+  pill: {
+    borderCurve: 'continuous',
+    borderRadius: 20,
+    paddingLeft: 10,
+    paddingRight: 14,
+    paddingVertical: 12,
+    shadowOffset: { width: 0, height: 6 },
+    shadowOpacity: 0.06,
+    shadowRadius: 18,
+  },
+});

--- a/src/features/cash/screens/add-cash-sheet/AddCashSheet.tsx
+++ b/src/features/cash/screens/add-cash-sheet/AddCashSheet.tsx
@@ -455,8 +455,9 @@ export const AddCashSheet = memo(function AddCashSheet() {
   }, [navigation]);
 
   const handleAddFrom = useCallback(() => {
+    if (isProcessing) return;
     navigation.navigate(Routes.CASH_PAYMENT_METHODS_SHEET);
-  }, [navigation]);
+  }, [isProcessing, navigation]);
 
   const handleSettings = useCallback(() => {
     // TODO(cash): open cash settings once they land.

--- a/src/features/cash/screens/add-cash-sheet/AddCashSheet.tsx
+++ b/src/features/cash/screens/add-cash-sheet/AddCashSheet.tsx
@@ -34,6 +34,7 @@ import safeAreaInsetValues from '@/utils/safeAreaInsetValues';
 import { sanitizeAmount } from '@/worklets/strings';
 
 import { AccountAvatar } from './AccountAvatar';
+import { AddCardHint } from './AddCardHint';
 import { AddFromRow } from './AddFromRow';
 import { AmountDisplay } from './AmountDisplay';
 import { PendingOrderContent } from './PendingOrderContent';
@@ -256,7 +257,7 @@ function PresetAmountContent({
     <>
       <AddCashHeader onSettings={onSettings} topPadding="28px" />
       <AmountPresetGrid onMore={onMore} onSelectPreset={onSelectPreset} selectedAmount={amount.selectedPresetAmount} />
-      {linkedCard && <AddFromRow card={linkedCard} onPress={onAddFrom} />}
+      {linkedCard ? <AddFromRow card={linkedCard} onPress={onAddFrom} /> : <AddCardHint />}
       <AddCashActionButton
         canSubmitAmount={canSubmitAmount}
         hasLinkedCard={linkedCard != null}
@@ -295,8 +296,14 @@ function KeypadAmountContent({
       <Box as={Animated.View} entering={FadeIn.duration(160)} exiting={FadeOut.duration(160)} style={styles.amountArea}>
         <AmountDisplay displayedAmount={amount.displayedAmount} />
       </Box>
-      <KeypadFundingCaption />
-      {linkedCard && <AddFromRow card={linkedCard} onPress={onAddFrom} />}
+      {linkedCard ? (
+        <>
+          <KeypadFundingCaption />
+          <AddFromRow card={linkedCard} onPress={onAddFrom} />
+        </>
+      ) : (
+        <AddCardHint />
+      )}
       <Box as={Animated.View} entering={FadeIn.duration(160)} paddingBottom="8px" paddingTop="24px">
         <NumberPad
           activeFieldId={amount.activeFieldId}
@@ -448,8 +455,8 @@ export const AddCashSheet = memo(function AddCashSheet() {
   }, [navigation]);
 
   const handleAddFrom = useCallback(() => {
-    // TODO(cash): open the payment-method picker (APP-3780)
-  }, []);
+    navigation.navigate(Routes.CASH_PAYMENT_METHODS_SHEET);
+  }, [navigation]);
 
   const handleSettings = useCallback(() => {
     // TODO(cash): open cash settings once they land.

--- a/src/features/cash/screens/add-cash-sheet/AddFromRow.tsx
+++ b/src/features/cash/screens/add-cash-sheet/AddFromRow.tsx
@@ -3,25 +3,9 @@ import { StyleSheet } from 'react-native';
 
 import ButtonPressAnimation from '@/components/animations/ButtonPressAnimation';
 import { Box, Inline, Text, useForegroundColor } from '@/design-system';
-import { type LinkedCard } from '@/features/cash/stores/cashPaymentMethodStore';
+import { VisaBadge } from '@/features/cash/components/VisaBadge';
+import type { LinkedCard } from '@/features/cash/stores/cashPaymentMethodStore';
 import * as i18n from '@/languages';
-
-function VisaBadge() {
-  return (
-    <Box
-      alignItems="center"
-      borderRadius={6}
-      height={{ custom: 20 }}
-      justifyContent="center"
-      style={styles.visaBadge}
-      width={{ custom: 28 }}
-    >
-      <Text align="center" color="white" size="icon 8px" weight="heavy">
-        {'VISA'}
-      </Text>
-    </Box>
-  );
-}
 
 export function AddFromRow({ card, onPress }: { card: LinkedCard; onPress: () => void }) {
   const separatorTertiary = useForegroundColor('separatorTertiary');
@@ -57,8 +41,5 @@ const styles = StyleSheet.create({
     borderRadius: 1,
     height: 1,
     marginHorizontal: 28,
-  },
-  visaBadge: {
-    backgroundColor: '#1B33C3',
   },
 });

--- a/src/features/cash/screens/payment-methods-sheet/PaymentMethodsSheet.tsx
+++ b/src/features/cash/screens/payment-methods-sheet/PaymentMethodsSheet.tsx
@@ -1,0 +1,139 @@
+import React, { memo, useCallback, useEffect, useState } from 'react';
+import { StyleSheet } from 'react-native';
+
+import { createStoreActions } from '@storesjs/stores';
+
+import { AbsolutePortalRoot } from '@/components/AbsolutePortal';
+import { DropdownMenu, type MenuItem } from '@/components/DropdownMenu';
+import { PanelSheet } from '@/components/PanelSheet/PanelSheet';
+import { Box, Text, useForegroundColor } from '@/design-system';
+import { CashStatusHalfSheet } from '@/features/cash/components/CashStatusHalfSheet';
+import { VisaBadge } from '@/features/cash/components/VisaBadge';
+import { useCardRemovalFlowStore } from '@/features/cash/stores/cardRemovalFlowStore';
+import { useCashLinkedCard, type LinkedCard } from '@/features/cash/stores/cashPaymentMethodStore';
+import { WrappedAlert as Alert } from '@/helpers/alert';
+import * as i18n from '@/languages';
+import { useNavigation } from '@/navigation/Navigation';
+
+const l = i18n.l.cash.payment_methods;
+const cardRemovalFlowActions = createStoreActions(useCardRemovalFlowStore);
+
+type CardAction = 'remove';
+
+function CardRow({ card, onRemove }: { card: LinkedCard; onRemove: (card: LinkedCard) => void }) {
+  const handlePressMenuItem = useCallback(() => onRemove(card), [card, onRemove]);
+  const menuConfig = {
+    menuItems: [
+      {
+        actionKey: 'remove',
+        actionTitle: i18n.t(l.remove_card),
+        destructive: true,
+        icon: { iconType: 'SYSTEM', iconValue: 'trash' },
+      },
+    ] satisfies MenuItem<CardAction>[],
+  };
+
+  return (
+    <Box alignItems="center" flexDirection="row" justifyContent="space-between" paddingHorizontal="10px">
+      <Box alignItems="center" flexDirection="row" gap={16}>
+        <VisaBadge size="large" />
+        <Box gap={10}>
+          <Text color="label" size="17pt" weight="bold">
+            {card.brand}
+          </Text>
+          <Text color="labelQuaternary" size="13pt" weight="bold">
+            {`*${card.last4}`}
+          </Text>
+        </Box>
+      </Box>
+      <DropdownMenu<CardAction>
+        menuConfig={menuConfig}
+        onPressMenuItem={handlePressMenuItem}
+        testID={`cash-payment-methods-card-menu-${card.id}`}
+      >
+        <Text color="blue" size="17pt" weight="heavy">
+          {'􀍠'}
+        </Text>
+      </DropdownMenu>
+    </Box>
+  );
+}
+
+export const PaymentMethodsSheet = memo(function PaymentMethodsSheet() {
+  const linkedCard = useCashLinkedCard();
+  const isRemoving = useCardRemovalFlowStore(state => state.state === 'removing');
+  const separatorTertiary = useForegroundColor('separatorTertiary');
+  const navigation = useNavigation();
+  const [cardPendingRemoval, setCardPendingRemoval] = useState<LinkedCard | null>(null);
+
+  const handleConfirmRemoval = useCallback(async (card: LinkedCard) => {
+    if ((await cardRemovalFlowActions.remove(card)) !== 'failed') return;
+    setCardPendingRemoval(null);
+    Alert.alert(i18n.t(l.remove_error_title), i18n.t(l.remove_error_description));
+  }, []);
+
+  useEffect(
+    () =>
+      navigation.addListener('beforeRemove', event => {
+        if (useCardRemovalFlowStore.getState().state === 'removing') event.preventDefault();
+      }),
+    [navigation]
+  );
+
+  useEffect(() => {
+    if (linkedCard || !navigation.isFocused()) return;
+    navigation.goBack();
+  }, [linkedCard, navigation]);
+
+  return (
+    <>
+      <PanelSheet showHandle={false}>
+        <Box paddingBottom="24px" paddingTop="28px" style={styles.content} testID="cash-payment-methods-sheet">
+          <Text align="center" color="label" size="20pt" weight="heavy">
+            {i18n.t(l.title)}
+          </Text>
+          <Box style={[styles.separator, { backgroundColor: separatorTertiary }]} />
+          {linkedCard && <CardRow card={linkedCard} onRemove={setCardPendingRemoval} />}
+        </Box>
+      </PanelSheet>
+      {cardPendingRemoval && (
+        <CashStatusHalfSheet
+          description={i18n.t(l.remove_description, { card: cardPendingRemoval.brand })}
+          primaryAction={{
+            disabled: isRemoving,
+            label: i18n.t(l.keep_card),
+            onPress: () => setCardPendingRemoval(null),
+            testID: 'cash-remove-card-keep',
+          }}
+          secondaryAction={{
+            label: i18n.t(l.remove_card),
+            loading: isRemoving,
+            onPress: () => {
+              void handleConfirmRemoval(cardPendingRemoval);
+            },
+            testID: 'cash-remove-card-confirm',
+          }}
+          status="warning"
+          testID="cash-remove-card-sheet"
+          title={i18n.t(l.remove_title)}
+        />
+      )}
+      <AbsolutePortalRoot style={styles.portal} />
+    </>
+  );
+});
+
+const styles = StyleSheet.create({
+  content: {
+    paddingHorizontal: 14,
+  },
+  portal: {
+    zIndex: 30001,
+  },
+  separator: {
+    borderRadius: 1,
+    height: 1,
+    marginBottom: 18,
+    marginTop: 24,
+  },
+});

--- a/src/features/cash/screens/payment-methods-sheet/PaymentMethodsSheet.tsx
+++ b/src/features/cash/screens/payment-methods-sheet/PaymentMethodsSheet.tsx
@@ -67,7 +67,12 @@ export const PaymentMethodsSheet = memo(function PaymentMethodsSheet() {
   const [cardPendingRemoval, setCardPendingRemoval] = useState<LinkedCard | null>(null);
 
   const handleConfirmRemoval = useCallback(async (card: LinkedCard) => {
-    if ((await cardRemovalFlowActions.remove(card)) !== 'failed') return;
+    const result = await cardRemovalFlowActions.remove(card);
+    if (result === 'removed') {
+      setCardPendingRemoval(null);
+      return;
+    }
+    if (result !== 'failed') return;
     setCardPendingRemoval(null);
     Alert.alert(i18n.t(l.remove_error_title), i18n.t(l.remove_error_description));
   }, []);

--- a/src/features/cash/services/cardRemovalService.ts
+++ b/src/features/cash/services/cardRemovalService.ts
@@ -1,0 +1,23 @@
+import { isPasskeyCancellation } from './cashPasskeyService';
+import { deleteCard, isDefinitiveRejection, isNotFoundError, listCards } from './rampClient';
+
+export async function removeLinkedCard(cardId: string): Promise<void> {
+  try {
+    await deleteCard(cardId);
+  } catch (error) {
+    // 404 is also a definitive rejection, so it has to be read as "already gone" first.
+    if (isNotFoundError(error)) return;
+    // A cancelled sign-in fails before the request is sent, so there is nothing to reconcile.
+    if (isPasskeyCancellation(error) || isDefinitiveRejection(error)) throw error;
+    if (await isCardGone(cardId)) return;
+    throw error;
+  }
+}
+
+async function isCardGone(cardId: string): Promise<boolean> {
+  try {
+    return !(await listCards()).some(card => card.id === cardId);
+  } catch {
+    return false;
+  }
+}

--- a/src/features/cash/services/rampClient.ts
+++ b/src/features/cash/services/rampClient.ts
@@ -188,6 +188,12 @@ export async function listCards(abortController?: AbortController | null): Promi
   return (data.cards ?? []).map(toLinkedCard);
 }
 
+export async function deleteCard(cardId: string, abortController?: AbortController | null): Promise<void> {
+  await authorizedRequest('addCash', headers =>
+    getCashPlatformClient().delete(`/ramp/payment-methods/${encodeURIComponent(cardId)}`, { abortController, headers })
+  );
+}
+
 // ---- Wallet link -----------------------------------------------------------
 
 export type RampWallet = { id: string; address: string };

--- a/src/features/cash/stores/cardRemovalFlowStore.test.ts
+++ b/src/features/cash/stores/cardRemovalFlowStore.test.ts
@@ -1,0 +1,145 @@
+import { RainbowFetchError } from '@/framework/data/http/rainbowFetch';
+
+import { isPasskeyCancellation } from '../services/cashPasskeyService';
+import { deleteCard, listCards } from '../services/rampClient';
+import { useCardRemovalFlowStore } from './cardRemovalFlowStore';
+import { useCashPaymentMethodStore, type LinkedCard } from './cashPaymentMethodStore';
+
+jest.mock('@/logger', () => ({
+  logger: { debug: jest.fn(), error: jest.fn(), warn: jest.fn() },
+  RainbowError: class RainbowError extends Error {},
+}));
+
+jest.mock('../services/rampClient', () => ({
+  ...jest.requireActual('../services/rampClient'),
+  deleteCard: jest.fn(),
+  listCards: jest.fn(),
+}));
+
+jest.mock('../services/cashPasskeyService', () => ({
+  isPasskeyCancellation: jest.fn(),
+}));
+
+const mockDeleteCard = deleteCard as jest.Mock;
+const mockListCards = listCards as jest.Mock;
+const mockIsPasskeyCancellation = isPasskeyCancellation as jest.Mock;
+
+const CARD: LinkedCard = { id: 'card_1', brand: 'Visa Debit', last4: '8990' };
+const REPLACEMENT_CARD: LinkedCard = { id: 'card_2', brand: 'Visa Debit', last4: '1234' };
+
+const flow = () => useCardRemovalFlowStore.getState();
+const linkedCard = () => useCashPaymentMethodStore.getState().linkedCard;
+
+function fetchError(status: number): RainbowFetchError {
+  return new RainbowFetchError({ message: 'request failed', response: { status } as Response });
+}
+
+function deferDelete() {
+  let settle!: (error?: unknown) => void;
+  const pending = new Promise<unknown>(resolve => {
+    settle = resolve;
+  });
+  mockDeleteCard.mockImplementation(async () => {
+    const error = await pending;
+    if (error) throw error;
+  });
+  return settle;
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  useCardRemovalFlowStore.setState({ state: 'idle' });
+  useCashPaymentMethodStore.getState().setLinkedCard(CARD);
+  mockDeleteCard.mockResolvedValue(undefined);
+  mockListCards.mockResolvedValue([CARD]);
+  mockIsPasskeyCancellation.mockReturnValue(false);
+});
+
+describe('cardRemovalFlowStore', () => {
+  it('drops the card after the platform deletes it', async () => {
+    expect(await flow().remove(CARD)).toBe('removed');
+
+    expect(mockDeleteCard).toHaveBeenCalledWith(CARD.id);
+    expect(linkedCard()).toBeNull();
+    expect(flow().state).toBe('idle');
+  });
+
+  it('keeps the card without reconciling when the sign-in prompt is cancelled', async () => {
+    mockDeleteCard.mockRejectedValue(new Error('user cancelled'));
+    mockIsPasskeyCancellation.mockReturnValue(true);
+
+    expect(await flow().remove(CARD)).toBe('cancelled');
+
+    expect(mockListCards).not.toHaveBeenCalled();
+    expect(linkedCard()).toEqual(CARD);
+    expect(flow().state).toBe('idle');
+  });
+
+  it('keeps the card after a definitive failure and allows an immediate retry', async () => {
+    mockDeleteCard.mockRejectedValueOnce(fetchError(422));
+
+    expect(await flow().remove(CARD)).toBe('failed');
+    expect(linkedCard()).toEqual(CARD);
+    expect(mockListCards).not.toHaveBeenCalled();
+
+    expect(await flow().remove(CARD)).toBe('removed');
+    expect(linkedCard()).toBeNull();
+  });
+
+  it('ignores a second removal while the first is in flight', async () => {
+    const settle = deferDelete();
+
+    const first = flow().remove(CARD);
+    expect(await flow().remove(CARD)).toBe('skipped');
+
+    expect(mockDeleteCard).toHaveBeenCalledTimes(1);
+    settle();
+    await first;
+  });
+
+  it('treats a missing card as already removed', async () => {
+    mockDeleteCard.mockRejectedValue(fetchError(404));
+
+    expect(await flow().remove(CARD)).toBe('removed');
+
+    expect(linkedCard()).toBeNull();
+    expect(mockListCards).not.toHaveBeenCalled();
+  });
+
+  it('clears the card when reconciliation confirms an ambiguous delete succeeded', async () => {
+    mockDeleteCard.mockRejectedValue(new Error('connection lost'));
+    mockListCards.mockResolvedValue([]);
+
+    expect(await flow().remove(CARD)).toBe('removed');
+
+    expect(mockListCards).toHaveBeenCalledTimes(1);
+    expect(linkedCard()).toBeNull();
+  });
+
+  it('retains the card when reconciliation confirms an ambiguous delete failed', async () => {
+    mockDeleteCard.mockRejectedValue(new Error('connection lost'));
+
+    expect(await flow().remove(CARD)).toBe('failed');
+    expect(linkedCard()).toEqual(CARD);
+  });
+
+  it('retains the card when an ambiguous delete cannot be reconciled', async () => {
+    mockDeleteCard.mockRejectedValue(new Error('connection lost'));
+    mockListCards.mockRejectedValue(new Error('still offline'));
+
+    expect(await flow().remove(CARD)).toBe('failed');
+    expect(linkedCard()).toEqual(CARD);
+  });
+
+  it('does not overwrite a replacement card when an old request settles', async () => {
+    const settle = deferDelete();
+
+    const removal = flow().remove(CARD);
+    useCashPaymentMethodStore.getState().setLinkedCard(REPLACEMENT_CARD);
+    settle();
+    await removal;
+
+    expect(linkedCard()).toEqual(REPLACEMENT_CARD);
+    expect(flow().state).toBe('idle');
+  });
+});

--- a/src/features/cash/stores/cardRemovalFlowStore.ts
+++ b/src/features/cash/stores/cardRemovalFlowStore.ts
@@ -1,0 +1,40 @@
+import { createBaseStore } from '@storesjs/stores';
+
+import { logger, RainbowError } from '@/logger';
+
+import { removeLinkedCard } from '../services/cardRemovalService';
+import { isPasskeyCancellation } from '../services/cashPasskeyService';
+import { useCashPaymentMethodStore, type LinkedCard } from './cashPaymentMethodStore';
+
+type CardRemovalResult = 'removed' | 'cancelled' | 'failed' | 'skipped';
+
+type CardRemovalFlowStore = {
+  state: 'idle' | 'removing';
+  remove: (card: LinkedCard) => Promise<CardRemovalResult>;
+};
+
+export const useCardRemovalFlowStore = createBaseStore<CardRemovalFlowStore>((set, get) => ({
+  state: 'idle',
+
+  remove: async card => {
+    if (get().state === 'removing') return 'skipped';
+    if (useCashPaymentMethodStore.getState().linkedCard?.id !== card.id) return 'skipped';
+
+    set({ state: 'removing' });
+    try {
+      await removeLinkedCard(card.id);
+      // The card can be replaced while the delete is in flight, so only drop the one that was removed.
+      if (useCashPaymentMethodStore.getState().linkedCard?.id === card.id) {
+        useCashPaymentMethodStore.getState().clearLinkedCard();
+      }
+      return 'removed';
+    } catch (error) {
+      // A cancelled sign-in is a deliberate dismissal, not a failure.
+      if (isPasskeyCancellation(error)) return 'cancelled';
+      logger.error(new RainbowError('[cardRemovalFlowStore]: Failed to remove card', error));
+      return 'failed';
+    } finally {
+      set({ state: 'idle' });
+    }
+  },
+}));

--- a/src/languages/en_US.json
+++ b/src/languages/en_US.json
@@ -1545,6 +1545,7 @@
       "add_cash_screen": {
         "add_from": "Add From",
         "add_credit_card": "Add Credit Card",
+        "add_a_card_to_continue": "Add a card to continue",
         "hold_to_add": "Hold to Add",
         "enter_amount": "Enter Amount",
         "money_is_added_in": "Money is added in",
@@ -1558,6 +1559,15 @@
         "payment_rejected": "Your card declined this payment",
         "wallet_check_error_title": "Couldn’t Continue",
         "wallet_check_error_generic": "We couldn’t check your wallet. Try again"
+      },
+      "payment_methods": {
+        "title": "Add From",
+        "remove_card": "Remove Card",
+        "remove_title": "Remove Card?",
+        "remove_description": "Are you sure you want to remove %{card}? This can’t be undone.",
+        "keep_card": "Keep Card",
+        "remove_error_title": "Couldn’t Remove Card",
+        "remove_error_description": "Something went wrong. Try again"
       },
       "add_wallet": {
         "title": "Connect new wallet",

--- a/src/navigation/Routes.android.tsx
+++ b/src/navigation/Routes.android.tsx
@@ -13,6 +13,7 @@ import { AddWalletSheet } from '@/features/cash/screens/add-wallet-sheet/AddWall
 import { CashDepositIntroPanel } from '@/features/cash/screens/cash-deposit-intro-panel/CashDepositIntroPanel';
 import { CashDepositSetupScreen } from '@/features/cash/screens/cash-deposit-setup/CashDepositSetupScreen';
 import { CashSignInScreen } from '@/features/cash/screens/cash-sign-in/CashSignInScreen';
+import { PaymentMethodsSheet } from '@/features/cash/screens/payment-methods-sheet/PaymentMethodsSheet';
 import { PROFILES } from '@/features/config/constants/experimental';
 import { useExperimentalFlag } from '@/features/config/hooks/experimentalHooks';
 import { ControlPanel } from '@/features/dapp-browser/screens/ControlPanel';
@@ -293,6 +294,7 @@ function BSNavigator() {
       <BSStack.Screen component={CashSignInScreen} name={Routes.CASH_SIGN_IN_SCREEN} options={cashDepositSetupSheetPreset} />
       <BSStack.Screen component={AddCashSheet} name={Routes.ADD_CASH_SHEET} />
       <BSStack.Screen component={AddWalletSheet} name={Routes.CASH_ADD_WALLET_SHEET} />
+      <BSStack.Screen component={PaymentMethodsSheet} name={Routes.CASH_PAYMENT_METHODS_SHEET} />
       <BSStack.Screen component={PerpsTradeDetailsSheet} name={Routes.PERPS_TRADE_DETAILS_SHEET} />
       <BSStack.Screen component={PolymarketEventScreen} name={Routes.POLYMARKET_EVENT_SCREEN} />
       <BSStack.Screen component={PolymarketRedeemPositionSheet} name={Routes.POLYMARKET_MANAGE_POSITION_SHEET} />

--- a/src/navigation/Routes.ios.tsx
+++ b/src/navigation/Routes.ios.tsx
@@ -13,6 +13,7 @@ import { AddWalletSheet } from '@/features/cash/screens/add-wallet-sheet/AddWall
 import { CashDepositIntroPanel } from '@/features/cash/screens/cash-deposit-intro-panel/CashDepositIntroPanel';
 import { CashDepositSetupScreen } from '@/features/cash/screens/cash-deposit-setup/CashDepositSetupScreen';
 import { CashSignInScreen } from '@/features/cash/screens/cash-sign-in/CashSignInScreen';
+import { PaymentMethodsSheet } from '@/features/cash/screens/payment-methods-sheet/PaymentMethodsSheet';
 import { PROFILES } from '@/features/config/constants/experimental';
 import { useExperimentalFlag } from '@/features/config/hooks/experimentalHooks';
 import { ControlPanel } from '@/features/dapp-browser/screens/ControlPanel';
@@ -318,6 +319,7 @@ function NativeStackNavigator() {
       <NativeStack.Screen component={CashSignInScreen} name={Routes.CASH_SIGN_IN_SCREEN} {...cashDepositSetupConfig} />
       <NativeStack.Screen component={AddCashSheet} name={Routes.ADD_CASH_SHEET} {...panelConfig} />
       <NativeStack.Screen component={AddWalletSheet} name={Routes.CASH_ADD_WALLET_SHEET} {...panelConfig} />
+      <NativeStack.Screen component={PaymentMethodsSheet} name={Routes.CASH_PAYMENT_METHODS_SHEET} {...panelConfig} />
       <NativeStack.Screen
         component={PerpsTradeDetailsSheet}
         name={Routes.PERPS_TRADE_DETAILS_SHEET}

--- a/src/navigation/routesNames.ts
+++ b/src/navigation/routesNames.ts
@@ -75,6 +75,7 @@ const Routes = {
   CASH_SETUP_CARD_DETAILS: 'CashSetupCardDetails',
   CASH_SETUP_CARD_ADDED: 'CashSetupCardAdded',
   CASH_ADD_WALLET_SHEET: 'CashAddWalletSheet',
+  CASH_PAYMENT_METHODS_SHEET: 'CashPaymentMethodsSheet',
   RECEIVE_MODAL: 'ReceiveModal',
   REGISTER_ENS_NAVIGATOR: 'RegisterEnsNavigator',
   CHOOSE_BACKUP_SHEET: 'ChooseBackupSheet',

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -664,6 +664,7 @@ type RouteParams = {
     /** Fiat amount as a decimal string, e.g. "50". */
     depositAmount: string;
   };
+  [Routes.CASH_PAYMENT_METHODS_SHEET]: undefined;
   [Routes.PERPS_ACCOUNT_SCREEN]:
     | {
         scrollToTop?: boolean;


### PR DESCRIPTION
Fixed: APP-3955

## Why?

A linked card is currently permanent. Once a member adds one there is no way to detach it, so a lost, expired, or simply wrong card stays on the Cash account for good — not something we can ship in the first App Store release.

## Approach

The "Add From" row now opens a payment methods sheet where the card can be removed from its context menu, behind a destructive confirmation. The card is only dropped locally once the platform confirms the delete, so a failed removal can't leave the app disagreeing with the backend, and the confirm button stays busy through dismissal so the same card can't be deleted twice.

## Visuals

https://github.com/user-attachments/assets/fb8a4338-7439-4e38-8098-2957625924b9



## Testing

1. With a card linked, open Add Cash and tap the **Add From** row — the payment methods sheet lists the card.
2. Open the row's **•••** menu → **Remove Card** → confirm. The sheet dismisses and Add Cash now shows the "Add a card to continue" hint in place of the card row.
3. Confirm removal with the device offline. The card stays linked, a "Couldn't Remove Card" alert appears, and retrying once back online succeeds.
4. While a removal is in flight, the confirm button shows a spinner and stays disabled until the sheet dismisses — repeated taps must not fire a second removal.
5. With no card linked, both the preset-amount and keypad views show the "Add a card to continue" hint.
