### PR TITLE
fix(CASH): missing TX when purshase is immediately completed

### DIFF
--- a/src/features/cash/utils/buildCashPurchaseTransaction.ts
+++ b/src/features/cash/utils/buildCashPurchaseTransaction.ts
@@ -60,6 +60,9 @@ export function buildCashPurchaseTransaction({
     network,
     nonce: null,
     status,
+    // Stands in for `minedAt` until history indexes the transaction; without one the activity list
+    // drops the row the moment it settles.
+    timestamp: Date.now(),
     title: buildTransactionTitle('purchase', status),
     to: walletAddress,
     type: 'purchase',


### PR DESCRIPTION
Fixed: APP-3992

## Description

A completed card deposit could disappear from Activity. The "Purchased" toast fires and the USDC arrives, but no row shows up — which reads to the user as a lost deposit.

Activity groups settled transactions by mined time and silently skips any without one. A cash purchase is tracked locally from the moment the order completes and carried no timestamp of its own, so it was visible only while pending: if it settled before the backend had indexed a mined time, the row was dropped the instant it flipped to confirmed. Every other locally tracked transaction is stamped with a creation time on the way in — this does the same for purchases, and the real mined time still takes over once history indexes it.

## Testing

1. Add cash with a linked card and hold to confirm.
2. When the sheet closes and the "Purchased" toast appears, open Activity.
3. The deposit is listed under Today, and stays listed once the transaction is indexed.

Most likely to reproduce on a fast settle, where the order already reads as complete the first time its status is checked.
