### PR TITLE
Refactor `SmoothPager` to support more complex navigation structures

### DIFF
--- a/.deps-check-baseline.android.json
+++ b/.deps-check-baseline.android.json
@@ -2106,7 +2106,27 @@
         ]
       },
       {
-        "name": "src/components/SmoothPager/SmoothPager.tsx",
+        "name": "src/features/perps/screens/perps-account-screen/PerpsAccountScreen.tsx",
+        "dependencyTypes": [
+          "aliased",
+          "aliased-tsconfig",
+          "aliased-tsconfig-paths",
+          "local",
+          "import"
+        ]
+      },
+      {
+        "name": "src/features/perps/screens/perps-account-screen/OpenPositionsSection.tsx",
+        "dependencyTypes": [
+          "aliased",
+          "aliased-tsconfig",
+          "aliased-tsconfig-paths",
+          "local",
+          "import"
+        ]
+      },
+      {
+        "name": "src/features/perps/components/PerpPositionCard.tsx",
         "dependencyTypes": [
           "aliased",
           "aliased-tsconfig",
@@ -57045,274 +57065,6 @@
   {
     "type": "cycle",
     "from": "src/features/perps/screens/PerpsNavigator.tsx",
-    "to": "src/components/SmoothPager/SmoothPager.tsx",
-    "unresolvedTo": "@/components/SmoothPager/SmoothPager",
-    "dependencyTypes": [
-      "aliased",
-      "aliased-tsconfig",
-      "aliased-tsconfig-paths",
-      "local",
-      "import"
-    ],
-    "rule": {
-      "severity": "error",
-      "name": "no-circular"
-    },
-    "cycle": [
-      {
-        "name": "src/components/SmoothPager/SmoothPager.tsx",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/__swaps__/utils/swaps.ts",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/design-system/index.ts",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/design-system/components/MarkdownText/MarkdownText.tsx",
-        "dependencyTypes": [
-          "local",
-          "export"
-        ]
-      },
-      {
-        "name": "src/design-system/components/TextLink/TextLink.tsx",
-        "dependencyTypes": [
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/utils/openInBrowser.ts",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/navigation/Navigation.tsx",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/navigation/prefetchRegistry.ts",
-        "dependencyTypes": [
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/features/charts/stores/candlestickStore.ts",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/state/assets/userAssetsStoreManager.ts",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/redux/store.ts",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/redux/reducers.ts",
-        "dependencyTypes": [
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/redux/settings.ts",
-        "dependencyTypes": [
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/handlers/web3.ts",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/utils/ethereumUtils.ts",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/state/assets/userAssets.ts",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/state/wallets/walletsStore.ts",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/features/backup/backup.ts",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/model/wallet.ts",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/features/hardware-wallet/navigation/HardwareWalletTxNavigator.tsx",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/features/hardware-wallet/screens/PairHardwareWalletAgainSheet.tsx",
-        "dependencyTypes": [
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/features/hardware-wallet/components/NanoXDeviceAnimation.tsx",
-        "dependencyTypes": [
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/theme/ThemeContext.tsx",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/navigation/onNavigationStateChange.js",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/state/navigation/navigationStore.ts",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/navigation/virtualNavigators.ts",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/features/perps/screens/PerpsNavigator.tsx",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "import"
-        ]
-      }
-    ]
-  },
-  {
-    "type": "cycle",
-    "from": "src/features/perps/screens/PerpsNavigator.tsx",
     "to": "src/features/perps/components/SheetHandle.tsx",
     "unresolvedTo": "@/features/perps/components/SheetHandle",
     "dependencyTypes": [
@@ -65647,26 +65399,6 @@
         ]
       },
       {
-        "name": "src/components/SmoothPager/SmoothPager.tsx",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/__swaps__/utils/swaps.ts",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "import"
-        ]
-      },
-      {
         "name": "src/design-system/index.ts",
         "dependencyTypes": [
           "aliased",
@@ -66233,26 +65965,6 @@
       },
       {
         "name": "src/features/perps/screens/PerpsNavigator.tsx",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/components/SmoothPager/SmoothPager.tsx",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/__swaps__/utils/swaps.ts",
         "dependencyTypes": [
           "aliased",
           "aliased-tsconfig",
@@ -85665,274 +85377,6 @@
       },
       {
         "name": "src/features/polymarket/screens/polymarket-navigator/PolymarketNavbar.tsx",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "import"
-        ]
-      }
-    ]
-  },
-  {
-    "type": "cycle",
-    "from": "src/features/polymarket/screens/polymarket-navigator/PolymarketNavigator.tsx",
-    "to": "src/components/SmoothPager/SmoothPager.tsx",
-    "unresolvedTo": "@/components/SmoothPager/SmoothPager",
-    "dependencyTypes": [
-      "aliased",
-      "aliased-tsconfig",
-      "aliased-tsconfig-paths",
-      "local",
-      "import"
-    ],
-    "rule": {
-      "severity": "error",
-      "name": "no-circular"
-    },
-    "cycle": [
-      {
-        "name": "src/components/SmoothPager/SmoothPager.tsx",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/__swaps__/utils/swaps.ts",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/design-system/index.ts",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/design-system/components/MarkdownText/MarkdownText.tsx",
-        "dependencyTypes": [
-          "local",
-          "export"
-        ]
-      },
-      {
-        "name": "src/design-system/components/TextLink/TextLink.tsx",
-        "dependencyTypes": [
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/utils/openInBrowser.ts",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/navigation/Navigation.tsx",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/navigation/prefetchRegistry.ts",
-        "dependencyTypes": [
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/features/charts/stores/candlestickStore.ts",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/state/assets/userAssetsStoreManager.ts",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/redux/store.ts",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/redux/reducers.ts",
-        "dependencyTypes": [
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/redux/settings.ts",
-        "dependencyTypes": [
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/handlers/web3.ts",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/utils/ethereumUtils.ts",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/state/assets/userAssets.ts",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/state/wallets/walletsStore.ts",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/features/backup/backup.ts",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/model/wallet.ts",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/features/hardware-wallet/navigation/HardwareWalletTxNavigator.tsx",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/features/hardware-wallet/screens/PairHardwareWalletAgainSheet.tsx",
-        "dependencyTypes": [
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/features/hardware-wallet/components/NanoXDeviceAnimation.tsx",
-        "dependencyTypes": [
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/theme/ThemeContext.tsx",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/navigation/onNavigationStateChange.js",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/state/navigation/navigationStore.ts",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/navigation/virtualNavigators.ts",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/features/polymarket/screens/polymarket-navigator/PolymarketNavigator.tsx",
         "dependencyTypes": [
           "aliased",
           "aliased-tsconfig",
@@ -106518,26 +105962,6 @@
         ]
       },
       {
-        "name": "src/components/SmoothPager/SmoothPager.tsx",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/__swaps__/utils/swaps.ts",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "import"
-        ]
-      },
-      {
         "name": "src/design-system/index.ts",
         "dependencyTypes": [
           "aliased",
@@ -106631,7 +106055,7 @@
         ]
       },
       {
-        "name": "src/components/SmoothPager/SmoothPager.tsx",
+        "name": "src/design-system/index.ts",
         "dependencyTypes": [
           "aliased",
           "aliased-tsconfig",
@@ -106641,7 +106065,80 @@
         ]
       },
       {
-        "name": "src/__swaps__/utils/swaps.ts",
+        "name": "src/design-system/components/MarkdownText/MarkdownText.tsx",
+        "dependencyTypes": [
+          "local",
+          "export"
+        ]
+      },
+      {
+        "name": "src/design-system/components/TextLink/TextLink.tsx",
+        "dependencyTypes": [
+          "local",
+          "import"
+        ]
+      },
+      {
+        "name": "src/utils/openInBrowser.ts",
+        "dependencyTypes": [
+          "aliased",
+          "aliased-tsconfig",
+          "aliased-tsconfig-paths",
+          "local",
+          "import"
+        ]
+      },
+      {
+        "name": "src/navigation/Navigation.tsx",
+        "dependencyTypes": [
+          "aliased",
+          "aliased-tsconfig",
+          "aliased-tsconfig-paths",
+          "local",
+          "import"
+        ]
+      }
+    ]
+  },
+  {
+    "type": "cycle",
+    "from": "src/navigation/onNavigationStateChange.js",
+    "to": "src/state/navigation/navigationStore.ts",
+    "unresolvedTo": "@/state/navigation/navigationStore",
+    "dependencyTypes": [
+      "aliased",
+      "aliased-tsconfig",
+      "aliased-tsconfig-paths",
+      "local",
+      "import"
+    ],
+    "rule": {
+      "severity": "error",
+      "name": "no-circular"
+    },
+    "cycle": [
+      {
+        "name": "src/state/navigation/navigationStore.ts",
+        "dependencyTypes": [
+          "aliased",
+          "aliased-tsconfig",
+          "aliased-tsconfig-paths",
+          "local",
+          "import"
+        ]
+      },
+      {
+        "name": "src/navigation/virtualNavigators.ts",
+        "dependencyTypes": [
+          "aliased",
+          "aliased-tsconfig",
+          "aliased-tsconfig-paths",
+          "local",
+          "import"
+        ]
+      },
+      {
+        "name": "src/features/perps/screens/PerpsNavigator.tsx",
         "dependencyTypes": [
           "aliased",
           "aliased-tsconfig",
@@ -106693,6 +106190,161 @@
           "local",
           "import"
         ]
+      },
+      {
+        "name": "src/navigation/prefetchRegistry.ts",
+        "dependencyTypes": [
+          "local",
+          "import"
+        ]
+      },
+      {
+        "name": "src/features/charts/stores/candlestickStore.ts",
+        "dependencyTypes": [
+          "aliased",
+          "aliased-tsconfig",
+          "aliased-tsconfig-paths",
+          "local",
+          "import"
+        ]
+      },
+      {
+        "name": "src/state/assets/userAssetsStoreManager.ts",
+        "dependencyTypes": [
+          "aliased",
+          "aliased-tsconfig",
+          "aliased-tsconfig-paths",
+          "local",
+          "import"
+        ]
+      },
+      {
+        "name": "src/redux/store.ts",
+        "dependencyTypes": [
+          "aliased",
+          "aliased-tsconfig",
+          "aliased-tsconfig-paths",
+          "local",
+          "import"
+        ]
+      },
+      {
+        "name": "src/redux/reducers.ts",
+        "dependencyTypes": [
+          "local",
+          "import"
+        ]
+      },
+      {
+        "name": "src/redux/settings.ts",
+        "dependencyTypes": [
+          "local",
+          "import"
+        ]
+      },
+      {
+        "name": "src/handlers/web3.ts",
+        "dependencyTypes": [
+          "aliased",
+          "aliased-tsconfig",
+          "aliased-tsconfig-paths",
+          "local",
+          "import"
+        ]
+      },
+      {
+        "name": "src/utils/ethereumUtils.ts",
+        "dependencyTypes": [
+          "aliased",
+          "aliased-tsconfig",
+          "aliased-tsconfig-paths",
+          "local",
+          "import"
+        ]
+      },
+      {
+        "name": "src/state/assets/userAssets.ts",
+        "dependencyTypes": [
+          "aliased",
+          "aliased-tsconfig",
+          "aliased-tsconfig-paths",
+          "local",
+          "import"
+        ]
+      },
+      {
+        "name": "src/state/wallets/walletsStore.ts",
+        "dependencyTypes": [
+          "aliased",
+          "aliased-tsconfig",
+          "aliased-tsconfig-paths",
+          "local",
+          "import"
+        ]
+      },
+      {
+        "name": "src/features/backup/backup.ts",
+        "dependencyTypes": [
+          "aliased",
+          "aliased-tsconfig",
+          "aliased-tsconfig-paths",
+          "local",
+          "import"
+        ]
+      },
+      {
+        "name": "src/model/wallet.ts",
+        "dependencyTypes": [
+          "aliased",
+          "aliased-tsconfig",
+          "aliased-tsconfig-paths",
+          "local",
+          "import"
+        ]
+      },
+      {
+        "name": "src/features/hardware-wallet/navigation/HardwareWalletTxNavigator.tsx",
+        "dependencyTypes": [
+          "aliased",
+          "aliased-tsconfig",
+          "aliased-tsconfig-paths",
+          "local",
+          "import"
+        ]
+      },
+      {
+        "name": "src/features/hardware-wallet/screens/PairHardwareWalletAgainSheet.tsx",
+        "dependencyTypes": [
+          "local",
+          "import"
+        ]
+      },
+      {
+        "name": "src/features/hardware-wallet/components/NanoXDeviceAnimation.tsx",
+        "dependencyTypes": [
+          "local",
+          "import"
+        ]
+      },
+      {
+        "name": "src/theme/ThemeContext.tsx",
+        "dependencyTypes": [
+          "aliased",
+          "aliased-tsconfig",
+          "aliased-tsconfig-paths",
+          "local",
+          "import"
+        ]
+      },
+      {
+        "name": "src/navigation/onNavigationStateChange.js",
+        "dependencyTypes": [
+          "aliased",
+          "aliased-tsconfig",
+          "aliased-tsconfig-paths",
+          "local",
+          "import"
+        ]
       }
     ]
   },
@@ -106715,26 +106367,6 @@
     "cycle": [
       {
         "name": "src/features/polymarket/screens/polymarket-navigator/PolymarketNavigator.tsx",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/components/SmoothPager/SmoothPager.tsx",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/__swaps__/utils/swaps.ts",
         "dependencyTypes": [
           "aliased",
           "aliased-tsconfig",
@@ -108243,17 +107875,7 @@
         ]
       },
       {
-        "name": "src/components/SmoothPager/SmoothPager.tsx",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/__swaps__/utils/swaps.ts",
+        "name": "src/features/perps/components/PerpsNavigatorFooter.tsx",
         "dependencyTypes": [
           "aliased",
           "aliased-tsconfig",
@@ -108493,17 +108115,7 @@
         ]
       },
       {
-        "name": "src/components/SmoothPager/SmoothPager.tsx",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/__swaps__/utils/swaps.ts",
+        "name": "src/features/perps/components/PerpsNavigatorFooter.tsx",
         "dependencyTypes": [
           "aliased",
           "aliased-tsconfig",

--- a/.deps-check-baseline.ios.json
+++ b/.deps-check-baseline.ios.json
@@ -2106,7 +2106,27 @@
         ]
       },
       {
-        "name": "src/components/SmoothPager/SmoothPager.tsx",
+        "name": "src/features/perps/screens/perps-account-screen/PerpsAccountScreen.tsx",
+        "dependencyTypes": [
+          "aliased",
+          "aliased-tsconfig",
+          "aliased-tsconfig-paths",
+          "local",
+          "import"
+        ]
+      },
+      {
+        "name": "src/features/perps/screens/perps-account-screen/OpenPositionsSection.tsx",
+        "dependencyTypes": [
+          "aliased",
+          "aliased-tsconfig",
+          "aliased-tsconfig-paths",
+          "local",
+          "import"
+        ]
+      },
+      {
+        "name": "src/features/perps/components/PerpPositionCard.tsx",
         "dependencyTypes": [
           "aliased",
           "aliased-tsconfig",
@@ -57045,274 +57065,6 @@
   {
     "type": "cycle",
     "from": "src/features/perps/screens/PerpsNavigator.tsx",
-    "to": "src/components/SmoothPager/SmoothPager.tsx",
-    "unresolvedTo": "@/components/SmoothPager/SmoothPager",
-    "dependencyTypes": [
-      "aliased",
-      "aliased-tsconfig",
-      "aliased-tsconfig-paths",
-      "local",
-      "import"
-    ],
-    "rule": {
-      "severity": "error",
-      "name": "no-circular"
-    },
-    "cycle": [
-      {
-        "name": "src/components/SmoothPager/SmoothPager.tsx",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/__swaps__/utils/swaps.ts",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/design-system/index.ts",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/design-system/components/MarkdownText/MarkdownText.tsx",
-        "dependencyTypes": [
-          "local",
-          "export"
-        ]
-      },
-      {
-        "name": "src/design-system/components/TextLink/TextLink.tsx",
-        "dependencyTypes": [
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/utils/openInBrowser.ts",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/navigation/Navigation.tsx",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/navigation/prefetchRegistry.ts",
-        "dependencyTypes": [
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/features/charts/stores/candlestickStore.ts",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/state/assets/userAssetsStoreManager.ts",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/redux/store.ts",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/redux/reducers.ts",
-        "dependencyTypes": [
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/redux/settings.ts",
-        "dependencyTypes": [
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/handlers/web3.ts",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/utils/ethereumUtils.ts",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/state/assets/userAssets.ts",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/state/wallets/walletsStore.ts",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/features/backup/backup.ts",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/model/wallet.ts",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/features/hardware-wallet/navigation/HardwareWalletTxNavigator.tsx",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/features/hardware-wallet/screens/PairHardwareWalletAgainSheet.tsx",
-        "dependencyTypes": [
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/features/hardware-wallet/components/NanoXDeviceAnimation.tsx",
-        "dependencyTypes": [
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/theme/ThemeContext.tsx",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/navigation/onNavigationStateChange.js",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/state/navigation/navigationStore.ts",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/navigation/virtualNavigators.ts",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/features/perps/screens/PerpsNavigator.tsx",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "import"
-        ]
-      }
-    ]
-  },
-  {
-    "type": "cycle",
-    "from": "src/features/perps/screens/PerpsNavigator.tsx",
     "to": "src/features/perps/components/SheetHandle.tsx",
     "unresolvedTo": "@/features/perps/components/SheetHandle",
     "dependencyTypes": [
@@ -65647,26 +65399,6 @@
         ]
       },
       {
-        "name": "src/components/SmoothPager/SmoothPager.tsx",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/__swaps__/utils/swaps.ts",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "import"
-        ]
-      },
-      {
         "name": "src/design-system/index.ts",
         "dependencyTypes": [
           "aliased",
@@ -66233,26 +65965,6 @@
       },
       {
         "name": "src/features/perps/screens/PerpsNavigator.tsx",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/components/SmoothPager/SmoothPager.tsx",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/__swaps__/utils/swaps.ts",
         "dependencyTypes": [
           "aliased",
           "aliased-tsconfig",
@@ -85665,274 +85377,6 @@
       },
       {
         "name": "src/features/polymarket/screens/polymarket-navigator/PolymarketNavbar.tsx",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "import"
-        ]
-      }
-    ]
-  },
-  {
-    "type": "cycle",
-    "from": "src/features/polymarket/screens/polymarket-navigator/PolymarketNavigator.tsx",
-    "to": "src/components/SmoothPager/SmoothPager.tsx",
-    "unresolvedTo": "@/components/SmoothPager/SmoothPager",
-    "dependencyTypes": [
-      "aliased",
-      "aliased-tsconfig",
-      "aliased-tsconfig-paths",
-      "local",
-      "import"
-    ],
-    "rule": {
-      "severity": "error",
-      "name": "no-circular"
-    },
-    "cycle": [
-      {
-        "name": "src/components/SmoothPager/SmoothPager.tsx",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/__swaps__/utils/swaps.ts",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/design-system/index.ts",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/design-system/components/MarkdownText/MarkdownText.tsx",
-        "dependencyTypes": [
-          "local",
-          "export"
-        ]
-      },
-      {
-        "name": "src/design-system/components/TextLink/TextLink.tsx",
-        "dependencyTypes": [
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/utils/openInBrowser.ts",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/navigation/Navigation.tsx",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/navigation/prefetchRegistry.ts",
-        "dependencyTypes": [
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/features/charts/stores/candlestickStore.ts",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/state/assets/userAssetsStoreManager.ts",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/redux/store.ts",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/redux/reducers.ts",
-        "dependencyTypes": [
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/redux/settings.ts",
-        "dependencyTypes": [
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/handlers/web3.ts",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/utils/ethereumUtils.ts",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/state/assets/userAssets.ts",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/state/wallets/walletsStore.ts",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/features/backup/backup.ts",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/model/wallet.ts",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/features/hardware-wallet/navigation/HardwareWalletTxNavigator.tsx",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/features/hardware-wallet/screens/PairHardwareWalletAgainSheet.tsx",
-        "dependencyTypes": [
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/features/hardware-wallet/components/NanoXDeviceAnimation.tsx",
-        "dependencyTypes": [
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/theme/ThemeContext.tsx",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/navigation/onNavigationStateChange.js",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/state/navigation/navigationStore.ts",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/navigation/virtualNavigators.ts",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/features/polymarket/screens/polymarket-navigator/PolymarketNavigator.tsx",
         "dependencyTypes": [
           "aliased",
           "aliased-tsconfig",
@@ -106518,26 +105962,6 @@
         ]
       },
       {
-        "name": "src/components/SmoothPager/SmoothPager.tsx",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/__swaps__/utils/swaps.ts",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "import"
-        ]
-      },
-      {
         "name": "src/design-system/index.ts",
         "dependencyTypes": [
           "aliased",
@@ -106631,7 +106055,7 @@
         ]
       },
       {
-        "name": "src/components/SmoothPager/SmoothPager.tsx",
+        "name": "src/design-system/index.ts",
         "dependencyTypes": [
           "aliased",
           "aliased-tsconfig",
@@ -106641,7 +106065,80 @@
         ]
       },
       {
-        "name": "src/__swaps__/utils/swaps.ts",
+        "name": "src/design-system/components/MarkdownText/MarkdownText.tsx",
+        "dependencyTypes": [
+          "local",
+          "export"
+        ]
+      },
+      {
+        "name": "src/design-system/components/TextLink/TextLink.tsx",
+        "dependencyTypes": [
+          "local",
+          "import"
+        ]
+      },
+      {
+        "name": "src/utils/openInBrowser.ts",
+        "dependencyTypes": [
+          "aliased",
+          "aliased-tsconfig",
+          "aliased-tsconfig-paths",
+          "local",
+          "import"
+        ]
+      },
+      {
+        "name": "src/navigation/Navigation.tsx",
+        "dependencyTypes": [
+          "aliased",
+          "aliased-tsconfig",
+          "aliased-tsconfig-paths",
+          "local",
+          "import"
+        ]
+      }
+    ]
+  },
+  {
+    "type": "cycle",
+    "from": "src/navigation/onNavigationStateChange.js",
+    "to": "src/state/navigation/navigationStore.ts",
+    "unresolvedTo": "@/state/navigation/navigationStore",
+    "dependencyTypes": [
+      "aliased",
+      "aliased-tsconfig",
+      "aliased-tsconfig-paths",
+      "local",
+      "import"
+    ],
+    "rule": {
+      "severity": "error",
+      "name": "no-circular"
+    },
+    "cycle": [
+      {
+        "name": "src/state/navigation/navigationStore.ts",
+        "dependencyTypes": [
+          "aliased",
+          "aliased-tsconfig",
+          "aliased-tsconfig-paths",
+          "local",
+          "import"
+        ]
+      },
+      {
+        "name": "src/navigation/virtualNavigators.ts",
+        "dependencyTypes": [
+          "aliased",
+          "aliased-tsconfig",
+          "aliased-tsconfig-paths",
+          "local",
+          "import"
+        ]
+      },
+      {
+        "name": "src/features/perps/screens/PerpsNavigator.tsx",
         "dependencyTypes": [
           "aliased",
           "aliased-tsconfig",
@@ -106693,6 +106190,161 @@
           "local",
           "import"
         ]
+      },
+      {
+        "name": "src/navigation/prefetchRegistry.ts",
+        "dependencyTypes": [
+          "local",
+          "import"
+        ]
+      },
+      {
+        "name": "src/features/charts/stores/candlestickStore.ts",
+        "dependencyTypes": [
+          "aliased",
+          "aliased-tsconfig",
+          "aliased-tsconfig-paths",
+          "local",
+          "import"
+        ]
+      },
+      {
+        "name": "src/state/assets/userAssetsStoreManager.ts",
+        "dependencyTypes": [
+          "aliased",
+          "aliased-tsconfig",
+          "aliased-tsconfig-paths",
+          "local",
+          "import"
+        ]
+      },
+      {
+        "name": "src/redux/store.ts",
+        "dependencyTypes": [
+          "aliased",
+          "aliased-tsconfig",
+          "aliased-tsconfig-paths",
+          "local",
+          "import"
+        ]
+      },
+      {
+        "name": "src/redux/reducers.ts",
+        "dependencyTypes": [
+          "local",
+          "import"
+        ]
+      },
+      {
+        "name": "src/redux/settings.ts",
+        "dependencyTypes": [
+          "local",
+          "import"
+        ]
+      },
+      {
+        "name": "src/handlers/web3.ts",
+        "dependencyTypes": [
+          "aliased",
+          "aliased-tsconfig",
+          "aliased-tsconfig-paths",
+          "local",
+          "import"
+        ]
+      },
+      {
+        "name": "src/utils/ethereumUtils.ts",
+        "dependencyTypes": [
+          "aliased",
+          "aliased-tsconfig",
+          "aliased-tsconfig-paths",
+          "local",
+          "import"
+        ]
+      },
+      {
+        "name": "src/state/assets/userAssets.ts",
+        "dependencyTypes": [
+          "aliased",
+          "aliased-tsconfig",
+          "aliased-tsconfig-paths",
+          "local",
+          "import"
+        ]
+      },
+      {
+        "name": "src/state/wallets/walletsStore.ts",
+        "dependencyTypes": [
+          "aliased",
+          "aliased-tsconfig",
+          "aliased-tsconfig-paths",
+          "local",
+          "import"
+        ]
+      },
+      {
+        "name": "src/features/backup/backup.ts",
+        "dependencyTypes": [
+          "aliased",
+          "aliased-tsconfig",
+          "aliased-tsconfig-paths",
+          "local",
+          "import"
+        ]
+      },
+      {
+        "name": "src/model/wallet.ts",
+        "dependencyTypes": [
+          "aliased",
+          "aliased-tsconfig",
+          "aliased-tsconfig-paths",
+          "local",
+          "import"
+        ]
+      },
+      {
+        "name": "src/features/hardware-wallet/navigation/HardwareWalletTxNavigator.tsx",
+        "dependencyTypes": [
+          "aliased",
+          "aliased-tsconfig",
+          "aliased-tsconfig-paths",
+          "local",
+          "import"
+        ]
+      },
+      {
+        "name": "src/features/hardware-wallet/screens/PairHardwareWalletAgainSheet.tsx",
+        "dependencyTypes": [
+          "local",
+          "import"
+        ]
+      },
+      {
+        "name": "src/features/hardware-wallet/components/NanoXDeviceAnimation.tsx",
+        "dependencyTypes": [
+          "local",
+          "import"
+        ]
+      },
+      {
+        "name": "src/theme/ThemeContext.tsx",
+        "dependencyTypes": [
+          "aliased",
+          "aliased-tsconfig",
+          "aliased-tsconfig-paths",
+          "local",
+          "import"
+        ]
+      },
+      {
+        "name": "src/navigation/onNavigationStateChange.js",
+        "dependencyTypes": [
+          "aliased",
+          "aliased-tsconfig",
+          "aliased-tsconfig-paths",
+          "local",
+          "import"
+        ]
       }
     ]
   },
@@ -106715,26 +106367,6 @@
     "cycle": [
       {
         "name": "src/features/polymarket/screens/polymarket-navigator/PolymarketNavigator.tsx",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/components/SmoothPager/SmoothPager.tsx",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/__swaps__/utils/swaps.ts",
         "dependencyTypes": [
           "aliased",
           "aliased-tsconfig",
@@ -108243,17 +107875,7 @@
         ]
       },
       {
-        "name": "src/components/SmoothPager/SmoothPager.tsx",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/__swaps__/utils/swaps.ts",
+        "name": "src/features/perps/components/PerpsNavigatorFooter.tsx",
         "dependencyTypes": [
           "aliased",
           "aliased-tsconfig",
@@ -108493,17 +108115,7 @@
         ]
       },
       {
-        "name": "src/components/SmoothPager/SmoothPager.tsx",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/__swaps__/utils/swaps.ts",
+        "name": "src/features/perps/components/PerpsNavigatorFooter.tsx",
         "dependencyTypes": [
           "aliased",
           "aliased-tsconfig",

--- a/src/components/SmoothPager/SmoothPager.tsx
+++ b/src/components/SmoothPager/SmoothPager.tsx
@@ -444,7 +444,8 @@ const SmoothPagerComponent = <Page extends string>({
     if (navigation) {
       unsubscribe = navigation.subscribe(handleNavigationState);
 
-      const initialState = navigation.getState();
+      const navigationState = navigation.getState();
+      const initialState = registry.indexById.has(navigationState.page) ? navigationState : registry.navigationState;
       const initialStateIndex = registry.indexById.get(initialState.page);
 
       if (initialStateIndex === registry.initialIndex) {

--- a/src/components/SmoothPager/SmoothPager.tsx
+++ b/src/components/SmoothPager/SmoothPager.tsx
@@ -1,714 +1,925 @@
-import React, { forwardRef, useCallback, useImperativeHandle, useMemo, useRef, useState, type ForwardedRef } from 'react';
-import { StyleSheet } from 'react-native';
+import React, { useCallback, useLayoutEffect, useMemo, useState } from 'react';
+import { StyleSheet, View } from 'react-native';
 
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import Animated, {
-  interpolate,
+  makeMutable,
   runOnJS,
   runOnUI,
-  useAnimatedReaction,
-  useAnimatedRef,
   useAnimatedStyle,
-  useDerivedValue,
-  useSharedValue,
-  withSpring,
-  withTiming,
-  type DerivedValue,
   type SharedValue,
   type WithSpringConfig,
   type WithTimingConfig,
 } from 'react-native-reanimated';
 
-import { clamp } from '@/__swaps__/utils/swaps';
 import { TIMING_CONFIGS } from '@/components/animations/animationConfigs';
-import { Box } from '@/design-system';
 import { alignVerticalToFlexAlign, type AlignVertical } from '@/design-system/layout/alignment';
+import { IS_DEV } from '@/env';
 import { useStableValue } from '@/hooks/useStableValue';
+import { type PagerNavigation, type PagerNavigationState } from '@/navigation/pagerNavigation';
 import deviceUtils from '@/utils/deviceUtils';
+
+import {
+  beginPagerGesture,
+  cancelPagerAnimations,
+  createPagerGestureState,
+  downscalePagerIndex,
+  finishPagerGesture,
+  NO_PAGER_GESTURE_TARGETS,
+  PAGER_REST_DISABLED,
+  PAGER_REST_IDLE,
+  requestPagerRest,
+  setPagerGestureTargets,
+  shouldCommitPagerGesture,
+  transitionToPage,
+  updatePagerGesture,
+  upscalePagerIndex,
+  type PagerAnimation,
+  type PagerGestureState,
+  type PagerGestureTargets,
+  type PagerPosition,
+  type PagerRestState,
+  type PagerSide,
+} from './pagerWorklets';
+
+export { downscalePagerIndex, upscalePagerIndex } from './pagerWorklets';
 
 // ============ Constants ====================================================== //
 
 const DEVICE_WIDTH = deviceUtils.dimensions.width;
-const PAGE_ANIMATION_CONFIG = TIMING_CONFIGS.slowerFadeConfig;
-
-const PagerGroup: React.FC<GroupProps> = ({ children }) => <>{children}</>;
-const PagerPage: React.FC<PageProps> = ({ component }) => <>{component}</>;
+const DEFAULT_ANIMATION_CONFIG = TIMING_CONFIGS.slowerFadeConfig;
+const HORIZONTAL_ACTIVATION_DISTANCE = 5;
+const VERTICAL_FAILURE_DISTANCE = 12;
+const SWIPE_VELOCITY_THRESHOLD = 300;
 
 // ============ Types ========================================================== //
 
-type PageId = string;
-type ActiveSubPageIds = Record<number, string | null>;
-
-type GroupProps = {
-  children: React.ReactElement<PageProps>[];
-};
-
-type PageProps = {
-  component: React.ReactElement;
-  id: PageId;
+type PageProps<Page extends string = string> = {
+  children: React.ReactElement;
+  id: Page;
   lazy?: boolean;
 };
 
-type SmoothPagerRef = {
-  currentPageIndex: SharedValue<number>;
+type PagerHistory<Page extends string> = PagerNavigation<Page> & {
   goBack: () => void;
   goForward: () => void;
-  goToPage: (id: PageId) => void;
+};
+
+type PagerGestureCandidates = readonly [
+  historyBackIndex: number,
+  declarationPreviousIndex: number,
+  declarationNextIndex: number,
+  historyForwardIndex: number,
+];
+
+type ExternalGesture = Parameters<ReturnType<typeof Gesture.Pan>['requireExternalGestureToFail']>[0];
+
+type SmoothPagerProps<Page extends string = string> = {
+  children: React.ReactElement<PageProps<Page>> | React.ReactElement<PageProps<Page>>[];
+  enableSwipeToGoBack?: boolean;
+  /** `true` allows swiping to a previously reached forward page; `'always'` also allows the next declared page. */
+  enableSwipeToGoForward?: boolean | 'always';
+  fillHeight?: boolean;
+  lazy?: boolean;
+  /** Called when the destination page becomes interactive, before its transition finishes. */
+  onPageActivated?: (page: Page) => void;
+  pageGap?: number;
+  /**
+   * Optional shared value that follows pager motion.
+   * Initialize it with `upscalePagerIndex`; use `downscalePagerIndex` to read page units.
+   */
+  pageIndex?: SharedValue<number>;
+  scaleTo?: number;
+  verticalPageAlignment?: AlignVertical;
+  /** Waits for these gestures to fail before recognizing a pager swipe. */
+  waitFor?: ExternalGesture | ExternalGesture[];
+} & (
+  | { fallbackPage?: never; initialPage: Page; navigation?: undefined }
+  | {
+      /** Initial page to use when the navigation state points to a page that is not declared here. */
+      fallbackPage?: Page;
+      initialPage?: never;
+      /** Controls the active page and its back and forward history. */
+      navigation: PagerNavigation<Page>;
+    }
+) &
+  ({ springConfig?: WithSpringConfig; timingConfig?: undefined } | { springConfig?: undefined; timingConfig?: WithTimingConfig });
+
+type LazyContentRegistration = {
+  mount?: () => void;
+  mountRequested: boolean;
+  mounted: boolean;
+  onMounted?: () => void;
+};
+
+type PageRegistry<Page extends string = string> = {
+  activeIndex: SharedValue<number>;
+  afterContentMounts?: () => void;
+  afterRest?: () => void;
+  fallbackPage?: Page;
+  forwardGestureMode: NonNullable<SmoothPagerProps['enableSwipeToGoForward']>;
+  furthestIndex?: number;
+  gestureCommitPage?: Page;
+  gestureState?: PagerGestureState;
+  ids: readonly Page[];
+  indexById: ReadonlyMap<Page, number>;
+  initialIndex: number;
+  lazyContent: readonly (LazyContentRegistration | undefined)[];
+  mounted: boolean;
+  navigation?: PagerNavigation<Page>;
+  navigationState: PagerNavigationState<Page>;
+  pageIndex?: SharedValue<number>;
+  pendingContentMounts: number;
+  positions: readonly PagerPosition[];
+  restState?: SharedValue<PagerRestState>;
+  supportsBackGesture: boolean;
 };
 
 // ============ Hooks ========================================================== //
 
-export function usePagerNavigation<T extends string = PageId>() {
-  const ref = useRef<SmoothPagerRef>(null);
-  return useMemo(
-    () => ({
-      ref,
-      goBack: () => ref.current?.goBack(),
-      goForward: () => ref.current?.goForward(),
-      goToPage: (id: T) => ref.current?.goToPage(id),
-    }),
-    [ref]
-  );
-}
-
-// ============ Animation Utils ================================================ //
-
-const SCALE_FACTOR = 200;
-
 /**
- * Converts a scaled page index back to its original value.
+ * Creates a stable navigation controller whose back and forward actions follow the pages actually visited.
+ * Navigating to a new page records the current page and clears the forward history.
  */
-export function downscalePagerIndex(scaledIndex: number): number {
-  'worklet';
-  return scaledIndex / SCALE_FACTOR;
-}
+export function usePagerHistory<Page extends string>(initialPage: Page): PagerHistory<Page> {
+  return useStableValue(() => {
+    const back: Page[] = [];
+    const forward: Page[] = [];
+    const listeners = new Set<(nextState: PagerNavigationState<Page>) => void>();
 
-/**
- * Upscales a page index for use in animation.
- */
-export function upscalePagerIndex(index: number): number {
-  'worklet';
-  return index * SCALE_FACTOR;
+    let state: PagerNavigationState<Page> = { page: initialPage };
+
+    function publish(page: Page): void {
+      state = { back: back.at(-1), forward: forward.at(-1), page };
+      listeners.forEach(listener => listener(state));
+    }
+
+    return {
+      getState: () => state,
+      goBack: () => {
+        const page = back.pop();
+        if (page === undefined) return;
+        forward.push(state.page);
+        publish(page);
+      },
+      goForward: () => {
+        const page = forward.pop();
+        if (page === undefined) return;
+        back.push(state.page);
+        publish(page);
+      },
+      navigate: page => {
+        if (page === state.page) return;
+        back.push(state.page);
+        forward.length = 0;
+        publish(page);
+      },
+      subscribe: listener => {
+        listeners.add(listener);
+        return () => listeners.delete(listener);
+      },
+    };
+  });
 }
 
 // ============ SmoothPager ==================================================== //
 
-type SmoothPagerProps = {
-  children: React.ReactElement<PageProps | GroupProps>[];
-  enableSwipeToGoBack?: boolean;
-  enableSwipeToGoForward?: boolean | 'always';
-  fillHeight?: boolean;
-  initialPage: PageId;
-  lazy?: boolean;
-  onNewIndex?: (index: number) => void;
-  pageGap?: number;
-  scaleTo?: number;
-  verticalPageAlignment?: AlignVertical;
-  waitFor?: React.RefObject<unknown> | React.RefObject<unknown>[];
-} & (
-  | { springConfig?: WithSpringConfig; springVelocityFactor?: number; timingConfig?: undefined }
-  | { springConfig?: undefined; springVelocityFactor?: undefined; timingConfig?: WithTimingConfig }
-);
+const PagerPage = <Page extends string>({ children }: PageProps<Page>) => children;
 
-const SmoothPagerComponent = (
-  {
-    children,
-    enableSwipeToGoBack = true,
-    enableSwipeToGoForward = true,
-    fillHeight = false,
-    initialPage,
-    lazy = false,
-    onNewIndex,
-    pageGap = 0,
-    scaleTo = 0.8,
-    springConfig,
-    springVelocityFactor = 1,
-    timingConfig,
-    verticalPageAlignment = 'bottom',
-    waitFor,
-  }: SmoothPagerProps,
-  ref: ForwardedRef<SmoothPagerRef>
-) => {
-  const { initialIndex, initialSubpageIds, pageIdToIndex } = useStableValue(() => getInitialPagerState(children, initialPage));
+const SmoothPagerComponent = <Page extends string>({
+  children,
+  enableSwipeToGoBack = true,
+  enableSwipeToGoForward = true,
+  fallbackPage,
+  fillHeight = false,
+  initialPage,
+  lazy = false,
+  navigation,
+  onPageActivated,
+  pageGap = 0,
+  pageIndex,
+  scaleTo = 0.8,
+  springConfig,
+  timingConfig,
+  verticalPageAlignment = 'bottom',
+  waitFor,
+}: SmoothPagerProps<Page>) => {
+  const pageElements = getPageElements(children);
+  const registry = useStableValue(() =>
+    createPageRegistry(pageElements, initialPage, fallbackPage, lazy, enableSwipeToGoBack, enableSwipeToGoForward, navigation, pageIndex)
+  );
 
-  const activeSubPageIds = useSharedValue(initialSubpageIds);
-  const currentPageId = useSharedValue(initialPage);
-  const currentPageIndex = useSharedValue(upscalePagerIndex(initialIndex));
-  const deepestReachedPageIndex = useSharedValue(initialIndex);
-  const lastTargetIndex = useSharedValue(initialIndex);
+  if (IS_DEV) {
+    validateStablePagerConfiguration(
+      pageElements,
+      initialPage,
+      fallbackPage,
+      lazy,
+      enableSwipeToGoBack,
+      enableSwipeToGoForward,
+      navigation,
+      pageIndex,
+      registry
+    );
+  }
 
-  // This represents the number of page slots in the pager (treating page groups as a single page)
-  const numberOfPages = children.length;
+  const { activeIndex, gestureState, pageIndex: animatedPageIndex, positions, restState } = registry;
+  const animation = useMemo<PagerAnimation>(
+    () => (springConfig ? { type: 'spring', config: springConfig } : { type: 'timing', config: timingConfig ?? DEFAULT_ANIMATION_CONFIG }),
+    [springConfig, timingConfig]
+  );
 
-  const animateIndex = useCallback(
-    (target: number, velocity?: number) => {
-      'worklet';
-      lastTargetIndex.value = target;
-      if (springConfig) {
-        currentPageIndex.value = withSpring(
-          upscalePagerIndex(target),
-          velocity ? { ...springConfig, velocity: velocity * springVelocityFactor } : springConfig
+  const scheduleGestureTargets = useMemo(() => {
+    if (!gestureState) return undefined;
+    return runOnUI((expectedActiveIndex: number, targets: PagerGestureTargets) => {
+      setPagerGestureTargets(activeIndex, gestureState, expectedActiveIndex, targets);
+    });
+  }, [activeIndex, gestureState]);
+
+  const publishGestureTargets = useCallback(() => {
+    if (!scheduleGestureTargets || !registry.mounted) return;
+
+    const state = registry.navigationState;
+    const currentIndex = registry.indexById.get(state.page);
+    if (currentIndex === undefined) return;
+
+    const candidates = getGestureCandidates(registry, state, currentIndex);
+    const readyTargets = resolveReadyGestureTargets(registry, candidates, currentIndex);
+
+    scheduleGestureTargets(currentIndex, readyTargets);
+  }, [registry, scheduleGestureTargets]);
+
+  const preparePageLifecycle = useCallback(
+    (expectedActiveIndex: number) => {
+      if (!registry.mounted || registry.indexById.get(registry.navigationState.page) !== expectedActiveIndex) return;
+
+      const candidates = getGestureCandidates(registry, registry.navigationState, expectedActiveIndex);
+      const publishWhenPrepared = () => {
+        if (registry.indexById.get(registry.navigationState.page) !== expectedActiveIndex) return;
+        disableCompletedLazyLifecycle(registry);
+        publishGestureTargets();
+      };
+
+      for (const index of getPreparationTargets(registry, expectedActiveIndex, candidates)) requestContentMount(registry, index);
+
+      runAfterContentMounts(registry, publishWhenPrepared);
+    },
+    [publishGestureTargets, registry]
+  );
+
+  const handlePagerSettled = useCallback(
+    (settledIndex: number) => {
+      const afterRest = registry.afterRest;
+      registry.afterRest = undefined;
+      if (afterRest) afterRest();
+      else preparePageLifecycle(settledIndex);
+    },
+    [preparePageLifecycle, registry]
+  );
+
+  const onPagerSettled = restState ? handlePagerSettled : undefined;
+
+  const notifyPageActivated = useMemo(
+    () =>
+      onPageActivated
+        ? (targetIndex: number) => {
+            const page = registry.ids[targetIndex];
+            if (registry.mounted && page !== undefined && registry.navigationState.page === page) onPageActivated(page);
+          }
+        : undefined,
+    [onPageActivated, registry]
+  );
+
+  const schedulePageTransition = useMemo(
+    () =>
+      runOnUI((targetIndex: number, nextTargets: PagerGestureTargets) => {
+        transitionToPage(
+          positions,
+          activeIndex,
+          gestureState,
+          animatedPageIndex,
+          restState,
+          targetIndex,
+          nextTargets,
+          animation,
+          onPagerSettled
         );
+
+        if (notifyPageActivated) runOnJS(notifyPageActivated)(targetIndex);
+      }),
+    [activeIndex, animation, animatedPageIndex, gestureState, notifyPageActivated, onPagerSettled, positions, restState]
+  );
+
+  const requestPage = useCallback(
+    (targetIndex: number) => {
+      const targetId = registry.ids[targetIndex];
+      if (targetId === undefined || registry.navigationState.page !== targetId) return;
+
+      requestContentMount(registry, targetIndex);
+
+      runAfterContentMounts(registry, () => {
+        if (!registry.mounted || registry.navigationState.page !== targetId) return;
+        disableCompletedLazyLifecycle(registry);
+        const candidates = getGestureCandidates(registry, registry.navigationState, targetIndex);
+        const readyTargets = resolveReadyGestureTargets(registry, candidates, targetIndex);
+        schedulePageTransition(targetIndex, readyTargets);
+      });
+    },
+    [registry, schedulePageTransition]
+  );
+
+  const schedulePagerRest = useMemo(() => {
+    if (!onPagerSettled || !restState) return undefined;
+    return runOnUI(() => {
+      requestPagerRest(positions, activeIndex, gestureState, animatedPageIndex, restState, animation, onPagerSettled);
+    });
+  }, [activeIndex, animatedPageIndex, animation, gestureState, onPagerSettled, positions, restState]);
+
+  const handleNavigationState = useCallback(
+    (nextState: PagerNavigationState<Page>) => {
+      const targetIndex = registry.indexById.get(nextState.page);
+      if (targetIndex === undefined || !registry.mounted) return;
+
+      const previousState = registry.navigationState;
+      const sourceIndex = registry.indexById.get(previousState.page) ?? registry.initialIndex;
+      const confirmsGesture = registry.gestureCommitPage === nextState.page;
+      registry.navigationState = nextState;
+
+      if (confirmsGesture) {
+        registry.gestureCommitPage = undefined;
+        publishGestureTargets();
+        return;
+      }
+
+      registry.afterRest = undefined;
+
+      const targetReady = isPageReady(registry, targetIndex);
+
+      if (!targetReady && registry.pendingContentMounts === 0) {
+        registry.afterRest = () => requestPage(targetIndex);
+        schedulePagerRest?.();
       } else {
-        currentPageIndex.value = withTiming(upscalePagerIndex(target), timingConfig ?? PAGE_ANIMATION_CONFIG);
+        const transitionIsDeferred = !targetReady || registry.pendingContentMounts !== 0;
+        if (sourceIndex !== targetIndex && transitionIsDeferred) scheduleGestureTargets?.(sourceIndex, NO_PAGER_GESTURE_TARGETS);
+        requestPage(targetIndex);
       }
     },
-    [currentPageIndex, lastTargetIndex, springConfig, springVelocityFactor, timingConfig]
+    [publishGestureTargets, registry, requestPage, scheduleGestureTargets, schedulePagerRest]
   );
 
-  useImperativeHandle(
-    ref,
-    () => ({
-      currentPageIndex,
+  const commitGestureNavigation = useCallback(
+    (expectedIndex: number, targetIndex: number) => {
+      const state = registry.navigationState;
+      const targetId = registry.ids[targetIndex];
+      if (registry.indexById.get(state.page) !== expectedIndex || !targetId) return;
 
-      goBack() {
-        runOnUI(() => {
-          const currentPageIndexValue = Math.round(downscalePagerIndex(currentPageIndex.value));
-          if (currentPageIndexValue > 0) {
-            const targetIndex = currentPageIndexValue - 1;
-            animateIndex(targetIndex);
-            if (!onNewIndex || lastTargetIndex.value === targetIndex) return;
-            runOnJS(onNewIndex)(targetIndex);
-          }
-        })();
-      },
-
-      goForward() {
-        runOnUI(() => {
-          const currentPageIndexValue = Math.round(downscalePagerIndex(currentPageIndex.value));
-          if (currentPageIndexValue < numberOfPages - 1) {
-            const targetIndex = currentPageIndexValue + 1;
-            animateIndex(targetIndex);
-            if (!onNewIndex || lastTargetIndex.value === targetIndex) return;
-            runOnJS(onNewIndex)(targetIndex);
-          }
-        })();
-      },
-
-      goToPage(id: PageId) {
-        runOnUI(() => {
-          const targetIndex = pageIdToIndex[id];
-          if (targetIndex !== undefined) {
-            animateIndex(targetIndex);
-            currentPageId.value = id;
-            if (!onNewIndex || lastTargetIndex.value === targetIndex) return;
-            runOnJS(onNewIndex)(targetIndex);
-          }
-        })();
-      },
-    }),
-    [animateIndex, currentPageId, currentPageIndex, lastTargetIndex, numberOfPages, onNewIndex, pageIdToIndex]
-  );
-
-  // This handles making the correct subpage active when navigating to pages that exist within page groups. It also
-  // manages the setting and resetting of the deepest reached page, which is used to control whether forward swipe
-  // gestures are allowed (if forward swipe gestures are enabled on the pager).
-  useAnimatedReaction(
-    () => ({ currentPageId: currentPageId.value }),
-    (current, previous) => {
-      const didPageIdChange = previous?.currentPageId && current.currentPageId !== previous.currentPageId;
-
-      if (didPageIdChange) {
-        const previousPageIndex = pageIdToIndex[previous.currentPageId];
-        const pageIndex = pageIdToIndex[current.currentPageId];
-        const currentActiveSubPageId = activeSubPageIds.value[pageIndex];
-
-        // If currentActiveSubPageId is not null here, the current page is in a page group
-        if (currentActiveSubPageId !== null) {
-          if (currentActiveSubPageId === '') {
-            // This page group has not been reached since the last navigation path reset
-            activeSubPageIds.modify(value => {
-              // Set the active subpage ID to the current page ID
-              value[pageIndex] = current.currentPageId;
-              return value;
-            });
-            // Because this page group has not yet been reached, it is now the deepest reached page
-            deepestReachedPageIndex.value = pageIndex;
-          } else if (currentActiveSubPageId !== current.currentPageId) {
-            // Reset the navigation path because the current path deviated from the last taken path
-            activeSubPageIds.modify(value => {
-              value[pageIndex] = current.currentPageId;
-              Object.keys(value).forEach(key => {
-                const index = parseInt(key, 10);
-                if (index > pageIndex && value[index] !== null) {
-                  value[index] = '';
-                }
-              });
-              return value;
-            });
-            // This is now the deepest reached page
-            deepestReachedPageIndex.value = pageIndex;
-          }
-        } else {
-          // The current page is not in a page group
-          if (pageIndex > previousPageIndex && pageIndex > deepestReachedPageIndex.value) {
-            // Update the deepest reached page if this page is deeper than the previous deepest reached page
-            deepestReachedPageIndex.value = pageIndex;
-          }
-        }
+      if (navigation) {
+        registry.gestureCommitPage = targetId;
+        if (state.back === targetId && navigation.goBack) navigation.goBack();
+        else if (state.forward === targetId && navigation.goForward) navigation.goForward();
+        else navigation.navigate(targetId);
+        if (registry.gestureCommitPage === targetId) registry.gestureCommitPage = undefined;
+        notifyPageActivated?.(targetIndex);
+        return;
       }
+
+      if (registry.furthestIndex !== undefined) registry.furthestIndex = Math.max(registry.furthestIndex, targetIndex);
+      registry.navigationState = { page: targetId };
+
+      publishGestureTargets();
+      notifyPageActivated?.(targetIndex);
     },
-    []
+    [navigation, notifyPageActivated, publishGestureTargets, registry]
   );
-
-  const pagerWrapperStyle = useAnimatedStyle(() => {
-    const totalWidth = numberOfPages * DEVICE_WIDTH + (numberOfPages - 1) * pageGap;
-    const translateX = interpolate(downscalePagerIndex(currentPageIndex.value), [0, numberOfPages - 1], [0, -totalWidth + DEVICE_WIDTH]);
-    return { transform: [{ translateX }] };
-  });
-
-  const startPage = useSharedValue<number | null>(null);
-  const startX = useSharedValue<number | null>(null);
-  const maxForwardIndex = useSharedValue<number | null>(null);
-  const canSwipeForward = useSharedValue<boolean | null>(null);
 
   const swipeGesture = useMemo(() => {
-    const gesture = Gesture.Pan()
-      .activeOffsetX([-5, 5])
-      .failOffsetY([-12, 12])
-      .enabled(enableSwipeToGoBack || enableSwipeToGoForward !== false)
-      .onBegin(() => {
-        startPage.value = null;
-        startX.value = null;
-        maxForwardIndex.value = null;
-        canSwipeForward.value = null;
-      })
-      .onUpdate(event => {
-        if (startPage.value === null) {
-          startPage.value = downscalePagerIndex(currentPageIndex.value);
+    if (!gestureState) return undefined;
 
-          if (enableSwipeToGoForward === 'always') {
-            canSwipeForward.value = true;
-            maxForwardIndex.value = numberOfPages - 1;
-          } else if (enableSwipeToGoForward) {
-            canSwipeForward.value = deepestReachedPageIndex.value > startPage.value;
-            maxForwardIndex.value = deepestReachedPageIndex.value;
-          } else {
-            canSwipeForward.value = false;
-            maxForwardIndex.value = startPage.value;
-          }
-        }
-
-        if (startX.value === null) startX.value = event.translationX;
-
-        const dragDistance = event.translationX - (startX.value ?? 0);
-        const dragPages = dragDistance / (DEVICE_WIDTH + pageGap);
-        let newPageIndex = (startPage.value ?? 0) - dragPages;
-
-        const minIndex = enableSwipeToGoBack ? 0 : (startPage.value ?? 0);
-        const maxIndex = maxForwardIndex.value ?? numberOfPages - 1;
-
-        newPageIndex = clamp(newPageIndex, minIndex, maxIndex);
-        currentPageIndex.value = upscalePagerIndex(newPageIndex);
-      })
-      .onEnd(event => {
-        if (startPage.value === null) return;
-
-        const swipeVelocityThreshold = 300;
-        const velocity = event.velocityX;
-        let targetIndex = downscalePagerIndex(currentPageIndex.value);
-
-        if (velocity < -swipeVelocityThreshold && canSwipeForward.value) {
-          targetIndex = Math.ceil(targetIndex);
-        } else if (velocity > swipeVelocityThreshold && enableSwipeToGoBack) {
-          targetIndex = Math.floor(targetIndex);
-        } else {
-          targetIndex = Math.round(targetIndex);
-        }
-
-        const minIndex = enableSwipeToGoBack ? 0 : startPage.value;
-        const maxIndex = maxForwardIndex.value ?? numberOfPages - 1;
-
-        targetIndex = clamp(targetIndex, minIndex ?? 0, maxIndex);
-
-        animateIndex(targetIndex, -velocity);
-        if (onNewIndex) runOnJS(onNewIndex)(targetIndex);
+    const gestureFor = (targetSide: PagerSide) =>
+      createSwipeGesture({
+        activeIndex,
+        animation,
+        gestureState,
+        onCommit: commitGestureNavigation,
+        onSettled: onPagerSettled,
+        pageWidth: DEVICE_WIDTH + pageGap,
+        pageIndex: animatedPageIndex,
+        positions,
+        restState,
+        targetSide,
+        waitFor,
       });
 
-    if (waitFor) {
-      const refs = Array.isArray(waitFor) ? waitFor : [waitFor];
-      refs.forEach(ref => {
-        gesture.requireExternalGestureToFail(ref as never);
-      });
-    }
+    const backGesture = enableSwipeToGoBack ? gestureFor(-1) : undefined;
+    const forwardGesture = enableSwipeToGoForward !== false ? gestureFor(1) : undefined;
 
-    return gesture;
+    return backGesture && forwardGesture ? Gesture.Race(backGesture, forwardGesture) : (backGesture ?? forwardGesture);
   }, [
-    animateIndex,
-    canSwipeForward,
-    currentPageIndex,
-    deepestReachedPageIndex,
+    activeIndex,
+    animation,
+    animatedPageIndex,
+    commitGestureNavigation,
     enableSwipeToGoBack,
     enableSwipeToGoForward,
-    maxForwardIndex,
-    numberOfPages,
-    onNewIndex,
+    gestureState,
+    onPagerSettled,
     pageGap,
-    startPage,
-    startX,
+    positions,
+    restState,
     waitFor,
   ]);
 
-  return (
-    <GestureDetector gesture={swipeGesture}>
-      <Animated.View style={styles.pagerContainer}>
-        <Animated.View
-          style={[
-            styles.pagerWrapper,
-            fillHeight && styles.fillHeight,
-            pagerWrapperStyle,
-            {
-              gap: pageGap,
-              justifyContent: verticalPageAlignment ? alignVerticalToFlexAlign[verticalPageAlignment] : undefined,
-              width: numberOfPages * DEVICE_WIDTH + (numberOfPages - 1) * pageGap,
-            },
-          ]}
-        >
-          {children.map((child, index) => {
-            if ('component' in child.props) {
-              // Handle top-level Page components
-              const { component, id, lazy: lazyProp } = child.props;
-              return (
-                <Page
-                  activeSubPageIds={undefined}
-                  child={component}
-                  currentPageId={currentPageId}
-                  currentPageIndex={currentPageIndex}
-                  id={id}
-                  index={index}
-                  initialPage={initialPage}
-                  key={id}
-                  lazy={lazyProp ?? lazy}
-                  isSubPage={undefined}
-                  scaleTo={scaleTo}
-                  verticalPageAlignment={verticalPageAlignment}
-                />
-              );
-            } else if ('children' in child.props) {
-              // Handle page groups with subpages (Page components) within
-              const subPages = child.props.children;
-              const pageGroupKey = subPages.map(subPage => subPage.props.id).join('-');
-              return (
-                <PageGroup
-                  activeSubPageIds={activeSubPageIds}
-                  currentPageId={currentPageId}
-                  currentPageIndex={currentPageIndex}
-                  index={index}
-                  initialPage={initialPage}
-                  key={pageGroupKey}
-                  lazy={lazy}
-                  scaleTo={scaleTo}
-                  subPages={subPages}
-                  verticalPageAlignment={verticalPageAlignment}
-                />
-              );
-            }
-          })}
-        </Animated.View>
-      </Animated.View>
-    </GestureDetector>
+  const cancelAnimations = useMemo(
+    () =>
+      runOnUI(() => {
+        cancelPagerAnimations(positions, animatedPageIndex);
+      }),
+    [animatedPageIndex, positions]
   );
+
+  useLayoutEffect(() => {
+    registry.mounted = true;
+    let unsubscribe: (() => void) | undefined;
+
+    if (navigation) {
+      unsubscribe = navigation.subscribe(handleNavigationState);
+
+      const initialState = navigation.getState();
+      const initialStateIndex = registry.indexById.get(initialState.page);
+
+      if (initialStateIndex === registry.initialIndex) {
+        registry.navigationState = initialState;
+        preparePageLifecycle(initialStateIndex);
+        notifyPageActivated?.(initialStateIndex);
+      } else {
+        handleNavigationState(initialState);
+      }
+    } else {
+      preparePageLifecycle(registry.initialIndex);
+      notifyPageActivated?.(registry.initialIndex);
+    }
+
+    return () => {
+      unsubscribe?.();
+      registry.mounted = false;
+      registry.afterContentMounts = undefined;
+      registry.afterRest = undefined;
+      cancelAnimations();
+    };
+  }, [cancelAnimations, handleNavigationState, navigation, notifyPageActivated, preparePageLifecycle, registry]);
+
+  const content = (
+    <View pointerEvents={swipeGesture ? 'auto' : 'box-none'} style={[styles.pagerContainer, fillHeight && styles.fillHeight]}>
+      {pageElements.map((page, index) => {
+        const id = registry.ids[index];
+        const contentRegistration = registry.lazyContent[index];
+        return (
+          <PageFrame
+            activeIndex={activeIndex}
+            index={index}
+            key={id}
+            layoutAnchor={index === registry.initialIndex}
+            pageGap={pageGap}
+            position={positions[index]}
+            scaleTo={scaleTo}
+            verticalPageAlignment={verticalPageAlignment}
+          >
+            {contentRegistration ? (
+              <LazyPageContent registration={contentRegistration}>{page.props.children}</LazyPageContent>
+            ) : (
+              page.props.children
+            )}
+          </PageFrame>
+        );
+      })}
+    </View>
+  );
+
+  return swipeGesture ? <GestureDetector gesture={swipeGesture}>{content}</GestureDetector> : content;
 };
 
 /**
  * ### `🫧 SmoothPager 🫧`
  *
- * Enables horizontal navigation between multiple pages with smooth, animated transitions and built-in swipe gestures.
- * It supports individual pages and grouped pages, and allows programmatic navigation via the `usePagerNavigation` hook.
+ * Displays one page at a time with horizontal animated transitions and optional swipe navigation.
+ * Declare every page as a direct `SmoothPager.Page` child. Use `initialPage` for a pager navigated only by swipes,
+ * or pass `navigation` to change pages programmatically and follow its back and forward history.
  *
- * - `enableSwipeToGoBack: boolean` and `enableSwipeToGoForward: boolean | 'always'` allow control over swipe behaviors.
- * - `enableSwipeToGoForward: 'always'` allows forward swipe gestures to be enabled even when the current page is the
- * deepest reached page.
- * - `initialPage: string` allows setting the initially active page by specifying its `id`.
- * - `pageGap: number` defines the spacing between consecutive pages.
- * - `verticalPageAlignment: 'top' | 'center' | 'bottom'` specifies how pages should align vertically in the event the
- * heights of the pages are inconsistent.
+ * Page order determines where pages sit horizontally, and lazy content mounts before its page is shown. The declared
+ * page structure and navigation setup are fixed while mounted; remount the pager to change them.
  *
  * @example
- * ```jsx
- * const { goBack, goToPage, ref } = usePagerNavigation();
+ * ```tsx
+ * const navigation = usePagerHistory<'home' | 'details'>('home');
  *
  * return (
- *   <SmoothPager initialPage="home" ref={ref}>
- *     <SmoothPager.Page component={<Home goToPage={goToPage} />} id="home" />
- *     <SmoothPager.Group>
- *       <SmoothPager.Page component={<About goBack={goBack} />} id="about" />
- *       <SmoothPager.Page component={<Contact goBack={goBack} />} id="contact" />
- *     </SmoothPager.Group>
+ *   <SmoothPager navigation={navigation}>
+ *     <SmoothPager.Page id="home">
+ *       <Home onNext={() => navigation.navigate('details')} />
+ *     </SmoothPager.Page>
+ *     <SmoothPager.Page id="details">
+ *       <Details onBack={navigation.goBack} />
+ *     </SmoothPager.Page>
  *   </SmoothPager>
  * );
  * ```
  */
-export const SmoothPager = Object.assign(React.memo(forwardRef<SmoothPagerRef, SmoothPagerProps>(SmoothPagerComponent)), {
+export const SmoothPager = Object.assign(SmoothPagerComponent, {
   /**
-   * `SmoothPager.Page` defines an individual page within the `SmoothPager`, and must be given the following props:
-   *
-   * - `id`: The unique identifier for the page, used when navigating via `goToPage(id)`.
-   * - `component`: The React component to render within the page.
-   *
-   * Each page must also be a direct child of either `SmoothPager` or `SmoothPager.Group`.
+   * Declares a page within a `SmoothPager`.
+   * It must be a direct child with a unique `id`; `lazy` overrides the pager's default for this page.
    */
   Page: PagerPage,
-
-  /**
-   * `SmoothPager.Group` allows multiple pages to share the same physical slot in the pager, and can be used to create
-   * conditional navigation paths within the pager. This is particularly useful for scenarios where multiple pages are
-   * potential candidates for being the next visible page, based on the action taken by the user on the preceding page.
-   *
-   * - Must be a direct child of `SmoothPager`.
-   * - Houses multiple `SmoothPager.Page` components as children, one of which will become active based on the
-   * navigation path taken.
-   */
-  Group: PagerGroup,
 });
 
-// ============ Page Group Component =========================================== //
+// ============ Swipe Gesture ================================================== //
 
-type PageGroupComponentProps = {
-  activeSubPageIds: SharedValue<ActiveSubPageIds>;
-  currentPageId: SharedValue<string>;
-  currentPageIndex: SharedValue<number>;
-  index: number;
-  initialPage: PageId;
-  lazy: boolean;
-  scaleTo: number;
-  subPages: React.ReactElement<PageProps>[];
-  verticalPageAlignment: AlignVertical;
+type SwipeGestureConfig = {
+  activeIndex: SharedValue<number>;
+  animation: PagerAnimation;
+  gestureState: PagerGestureState;
+  onCommit: (expectedIndex: number, targetIndex: number) => void;
+  onSettled: ((index: number) => void) | undefined;
+  pageIndex: SharedValue<number> | undefined;
+  pageWidth: number;
+  positions: readonly PagerPosition[];
+  restState: SharedValue<PagerRestState> | undefined;
+  targetSide: PagerSide;
+  waitFor: SmoothPagerProps['waitFor'];
 };
 
-const PageGroup = React.memo(function PageGroup({
-  activeSubPageIds,
-  currentPageId,
-  currentPageIndex,
+function createSwipeGesture({
+  activeIndex,
+  animation,
+  gestureState,
+  onCommit,
+  onSettled,
+  pageIndex,
+  pageWidth,
+  positions,
+  restState,
+  targetSide,
+  waitFor,
+}: SwipeGestureConfig) {
+  const gesture = Gesture.Pan()
+    .maxPointers(1)
+    .activeOffsetX(-targetSide * HORIZONTAL_ACTIVATION_DISTANCE)
+    .failOffsetX(targetSide * HORIZONTAL_ACTIVATION_DISTANCE)
+    .failOffsetY([-VERTICAL_FAILURE_DISTANCE, VERTICAL_FAILURE_DISTANCE])
+    .onStart(() => {
+      beginPagerGesture(positions, activeIndex, gestureState, pageIndex, targetSide);
+    })
+    .onChange(event => {
+      updatePagerGesture(positions, gestureState, pageIndex, targetSide, event.changeX, pageWidth);
+    })
+    .onEnd((event, success) => {
+      const encodedTarget = gestureState.gestureTarget;
+      if (encodedTarget === 0) return;
+
+      const expectedIndex = activeIndex.value;
+      const nextIndex = encodedTarget - 1;
+      const commit = success && shouldCommitPagerGesture(positions[nextIndex].value, event.velocityX, targetSide, SWIPE_VELOCITY_THRESHOLD);
+      const settledIndex = finishPagerGesture(
+        positions,
+        activeIndex,
+        gestureState,
+        pageIndex,
+        restState,
+        targetSide,
+        commit,
+        success ? event.velocityX : 0,
+        pageWidth,
+        animation,
+        onSettled
+      );
+
+      if (settledIndex !== -1 && settledIndex !== expectedIndex) runOnJS(onCommit)(expectedIndex, settledIndex);
+    });
+
+  if (waitFor) {
+    if (!Array.isArray(waitFor)) gesture.requireExternalGestureToFail(waitFor);
+    else for (const externalGesture of waitFor) gesture.requireExternalGestureToFail(externalGesture);
+  }
+
+  return gesture;
+}
+
+// ============ Page Components ================================================ //
+
+const PageFrame = React.memo(function PageFrame({
+  activeIndex,
+  children,
   index,
-  initialPage,
-  lazy,
+  layoutAnchor,
+  pageGap,
+  position,
   scaleTo,
-  subPages,
   verticalPageAlignment,
-}: PageGroupComponentProps) {
-  return (
-    <Box style={styles.pageStyle}>
-      {subPages.map(subPage => (
-        <Page
-          activeSubPageIds={activeSubPageIds}
-          child={subPage.props.component}
-          currentPageId={currentPageId}
-          currentPageIndex={currentPageIndex}
-          id={subPage.props.id}
-          index={index}
-          initialPage={initialPage}
-          isSubPage={true}
-          key={subPage.props.id}
-          lazy={lazy}
-          scaleTo={scaleTo}
-          verticalPageAlignment={verticalPageAlignment}
-        />
-      ))}
-    </Box>
-  );
-});
-
-// ============ Page Component ================================================= //
-
-type PageComponentProps = {
-  activeSubPageIds: SharedValue<ActiveSubPageIds> | undefined;
-  child: React.ReactElement;
-  currentPageId: SharedValue<string>;
-  currentPageIndex: SharedValue<number>;
-  id: PageId;
+}: {
+  activeIndex: SharedValue<number>;
+  children: React.ReactElement;
   index: number;
-  initialPage: PageId;
-  isSubPage: boolean | undefined;
-  lazy: boolean;
+  layoutAnchor: boolean;
+  pageGap: number;
+  position: SharedValue<number>;
   scaleTo: number;
   verticalPageAlignment: AlignVertical;
-};
-
-const Page = React.memo(function Page({
-  activeSubPageIds,
-  child,
-  currentPageId,
-  currentPageIndex,
-  id,
-  index,
-  initialPage,
-  isSubPage,
-  lazy,
-  scaleTo,
-  verticalPageAlignment,
-}: PageComponentProps) {
-  const pageRef = useAnimatedRef();
-
-  const shouldDisplay = useDerivedValue(() => (isSubPage ? activeSubPageIds?.value[index] === id || currentPageId.value === id : true));
-  const opacity = useDerivedValue(() =>
-    interpolate(
-      downscalePagerIndex(currentPageIndex.value),
-      [index - 1, index - 0.9, index, index + 0.9, index + 1],
-      [0, 1, 1, 1, 0],
-      'clamp'
-    )
-  );
+}) {
+  const pageWidth = DEVICE_WIDTH + pageGap;
+  const scaleRange = scaleTo - 1;
 
   const pageStyle = useAnimatedStyle(() => {
-    const currentOpacity = opacity.value;
-    const display = shouldDisplay.value ? 'flex' : 'none';
-    const scale = interpolate(downscalePagerIndex(currentPageIndex.value), [index - 1, index, index + 1], [scaleTo, 1, scaleTo], 'clamp');
+    const pagePosition = downscalePagerIndex(position.value);
+    const distance = Math.min(Math.abs(pagePosition), 1);
+    const opacity = distance <= 0.9 ? 1 : (1 - distance) * 10;
+    const translateX = pagePosition * pageWidth;
 
     return {
-      display,
-      opacity: currentOpacity,
-      transform: scaleTo === 1 ? undefined : [{ scale: currentOpacity === 0 ? 0 : scale }],
+      opacity,
+      pointerEvents: activeIndex.value === index || distance < 1 ? ('box-none' as const) : ('none' as const),
+      transform: scaleTo === 1 ? [{ translateX }] : [{ translateX }, { scale: opacity === 0 ? 0 : 1 + distance * scaleRange }],
     };
   });
 
   return (
     <Animated.View
-      ref={pageRef}
       style={[
-        styles.pageStyle,
+        styles.page,
+        layoutAnchor && styles.layoutAnchor,
         pageStyle,
         { justifyContent: alignVerticalToFlexAlign[verticalPageAlignment] },
-        isSubPage && styles.subPageStyle,
       ]}
     >
-      {lazy ? (
-        <MountIfActive id={id} initialPage={initialPage} opacity={opacity} shouldDisplay={shouldDisplay}>
-          {child}
-        </MountIfActive>
-      ) : (
-        child
-      )}
+      {children}
     </Animated.View>
   );
 });
 
-const MountIfActive = ({
-  children,
-  id,
-  initialPage,
-  opacity,
-  shouldDisplay,
-}: {
-  children: React.ReactElement;
-  id: PageId;
-  initialPage: PageId;
-  opacity: DerivedValue<number>;
-  shouldDisplay: SharedValue<boolean>;
-}) => {
-  const [shouldMount, setShouldMount] = useState(() => initialPage === id);
+function LazyPageContent({ children, registration }: { children: React.ReactElement; registration: LazyContentRegistration }) {
+  const [mounted, setMounted] = useState(registration.mounted);
 
-  useAnimatedReaction(
-    () => shouldDisplay.value && opacity.value > 0,
-    (isActive, previous) => {
-      if (!isActive || isActive === previous) return;
-      if (!shouldMount) runOnJS(setShouldMount)(isActive);
-    },
-    []
-  );
+  useLayoutEffect(() => {
+    const mount = () => setMounted(true);
+    registration.mount = mount;
+    if (registration.mountRequested && !registration.mounted) setMounted(true);
 
-  return shouldMount ? children : null;
-};
+    return () => {
+      if (registration.mount === mount) registration.mount = undefined;
+    };
+  }, [registration]);
 
-// ============ Helper Functions =============================================== //
+  useLayoutEffect(() => {
+    if (!mounted) return;
 
-type InitialPagerState = {
-  initialIndex: number;
-  initialSubpageIds: ActiveSubPageIds;
-  pageIdToIndex: Record<PageId, number>;
-};
+    registration.mounted = true;
+    registration.mountRequested = false;
+    const onMounted = registration.onMounted;
+    registration.onMounted = undefined;
 
-function getInitialPagerState(children: SmoothPagerProps['children'], initialPage: PageId): InitialPagerState {
-  const pageIdToIndex = getPageIdToIndexMap(children);
+    onMounted?.();
+  }, [mounted, registration]);
+
+  return mounted ? children : null;
+}
+
+// ============ Page Registry ================================================== //
+
+function getPageElements<Page extends string>(children: SmoothPagerProps<Page>['children']): React.ReactElement<PageProps<Page>>[] {
+  const pageElements: React.ReactElement<PageProps<Page>>[] = [];
+
+  React.Children.forEach(children, child => {
+    if (child === null) return;
+    if (!React.isValidElement<PageProps<Page>>(child) || child.type !== PagerPage || typeof child.props.id !== 'string') {
+      throw new Error('SmoothPager children must be SmoothPager.Page elements with string IDs.');
+    }
+    pageElements.push(child);
+  });
+
+  return pageElements;
+}
+
+function createPageRegistry<Page extends string>(
+  pageElements: React.ReactElement<PageProps<Page>>[],
+  initialPage: Page | undefined,
+  fallbackPage: Page | undefined,
+  defaultLazy: boolean,
+  supportsBackGesture: boolean,
+  forwardGestureMode: NonNullable<SmoothPagerProps['enableSwipeToGoForward']>,
+  navigation: PagerNavigation<Page> | undefined,
+  pageIndex: SharedValue<number> | undefined
+): PageRegistry<Page> {
+  const pageCount = pageElements.length;
+  const ids = new Array<Page>(pageCount);
+  const indexById = new Map<Page, number>();
+
+  for (let index = 0; index < pageCount; index += 1) {
+    const id = pageElements[index].props.id;
+    if (indexById.has(id)) throw new Error(`SmoothPager page ID "${id}" is registered more than once.`);
+    ids[index] = id;
+    indexById.set(id, index);
+  }
+
+  const navigationState = navigation?.beginPath?.() ?? navigation?.getState();
+  const initialNavigationState = navigationState && indexById.has(navigationState.page) ? navigationState : undefined;
+  const resolvedInitialPage = initialNavigationState?.page ?? fallbackPage ?? initialPage;
+
+  if (resolvedInitialPage === undefined) {
+    throw new Error('SmoothPager requires an initial page.');
+  }
+
+  const initialIndex = indexById.get(resolvedInitialPage);
+
+  if (initialIndex === undefined) {
+    const page = navigationState?.page ?? resolvedInitialPage;
+    throw new Error(`SmoothPager initial page "${String(page)}" is not registered.`);
+  }
+
+  const lazyContent = new Array<LazyContentRegistration | undefined>(pageCount);
+  const positions = new Array<PagerPosition>(pageCount);
+  let needsLifecyclePreparation = false;
+
+  for (let index = 0; index < pageCount; index += 1) {
+    const isLazy = pageElements[index].props.lazy ?? defaultLazy;
+    const mounted = index === initialIndex || index === initialIndex + 1 || (supportsBackGesture && index === initialIndex - 1);
+    const content = isLazy ? { mountRequested: false, mounted } : undefined;
+
+    lazyContent[index] = content;
+    positions[index] = makeMutable(index === initialIndex ? 0 : upscalePagerIndex(index < initialIndex ? -1 : 1));
+    if (content && !mounted) needsLifecyclePreparation = true;
+  }
+
+  const hasGestures = supportsBackGesture || forwardGestureMode !== false;
+
   return {
-    initialIndex: pageIdToIndex[initialPage] ?? 0,
-    initialSubpageIds: initializeActiveSubPageIds(pageIdToIndex, initialPage),
-    pageIdToIndex,
+    activeIndex: makeMutable(initialIndex),
+    fallbackPage,
+    forwardGestureMode,
+    furthestIndex: !navigation && forwardGestureMode === true ? initialIndex : undefined,
+    gestureState: hasGestures ? createPagerGestureState() : undefined,
+    ids,
+    indexById,
+    initialIndex,
+    lazyContent,
+    mounted: false,
+    navigation,
+    navigationState: initialNavigationState ?? { page: resolvedInitialPage },
+    pageIndex,
+    pendingContentMounts: 0,
+    positions,
+    restState: needsLifecyclePreparation ? makeMutable(PAGER_REST_IDLE) : undefined,
+    supportsBackGesture,
   };
 }
 
-/**
- * Used to initialize the shared value that keeps track of the active subpage ID for each page group.
- */
-function initializeActiveSubPageIds(pageIdToIndex: Record<PageId, number>, initialPage?: PageId): ActiveSubPageIds {
-  const pageIndices = Object.values(pageIdToIndex);
-  const maxPageIndex = Math.max(...pageIndices);
-  // Initialize the active subpage IDs array with null starting values for each page index
-  const initialSubPageIds: (string | null)[] = new Array(maxPageIndex + 1).fill(null);
-  const pageIndexCounts: Record<number, number> = {};
-  Object.values(pageIdToIndex).forEach(index => {
-    pageIndexCounts[index] = (pageIndexCounts[index] || 0) + 1;
-  });
+function validateStablePagerConfiguration<Page extends string>(
+  pageElements: React.ReactElement<PageProps<Page>>[],
+  initialPage: Page | undefined,
+  fallbackPage: Page | undefined,
+  defaultLazy: boolean,
+  enableSwipeToGoBack: boolean,
+  enableSwipeToGoForward: SmoothPagerProps['enableSwipeToGoForward'],
+  navigation: PagerNavigation<Page> | undefined,
+  pageIndex: SharedValue<number> | undefined,
+  registry: PageRegistry<Page>
+): void {
+  const initialSourceChanged = navigation ? fallbackPage !== registry.fallbackPage : initialPage !== registry.ids[registry.initialIndex];
+  const registrationChanged =
+    pageElements.length !== registry.ids.length ||
+    initialSourceChanged ||
+    pageElements.some(
+      (page, index) =>
+        page.props.id !== registry.ids[index] || Boolean(page.props.lazy ?? defaultLazy) !== Boolean(registry.lazyContent[index])
+    );
 
-  // If a page group exists at a given index, set the active subpage ID to an empty string
-  Object.entries(pageIndexCounts).forEach(([index, count]) => {
-    if (count > 1) {
-      initialSubPageIds[Number(index)] = '';
-    }
-  });
+  const gestureConfigurationChanged =
+    enableSwipeToGoBack !== registry.supportsBackGesture ||
+    enableSwipeToGoForward !== registry.forwardGestureMode ||
+    navigation !== registry.navigation;
 
-  // If the initial page ID matches a subpage, make that subpage active within the page group
-  if (initialPage && pageIdToIndex[initialPage] !== undefined && initialSubPageIds[pageIdToIndex[initialPage]] === '') {
-    initialSubPageIds[pageIdToIndex[initialPage]] = initialPage;
+  if (registrationChanged || gestureConfigurationChanged || pageIndex !== registry.pageIndex) {
+    throw new Error('SmoothPager configuration cannot change while mounted. Remount the pager to change it.');
   }
-
-  // Any top-level Page components will have their active subpage ID set to null
-  return initialSubPageIds;
 }
 
-/**
- * Used to generate a map of page IDs to their indices in the pager.
- */
-function getPageIdToIndexMap(children: React.ReactElement<PageProps | GroupProps>[]): Record<PageId, number> {
-  const obj: Record<PageId, number> = {};
-  let pageIndex = 0;
-  children.forEach(child => {
-    if ('id' in child.props && 'component' in child.props) {
-      obj[child.props.id] = pageIndex;
-      pageIndex += 1;
-    } else if ('children' in child.props) {
-      child.props.children.forEach(page => {
-        if ('id' in page.props && 'component' in page.props) {
-          obj[page.props.id] = pageIndex;
-        }
-      });
-      pageIndex += 1;
-    }
-  });
-  return obj;
+// ============ Lazy Content Lifecycle ========================================= //
+
+function requestContentMount<Page extends string>(registry: PageRegistry<Page>, index: number): void {
+  const content = registry.lazyContent[index];
+  if (!content || content.mounted || content.mountRequested) return;
+
+  content.mountRequested = true;
+  registry.pendingContentMounts += 1;
+
+  content.onMounted = () => {
+    registry.pendingContentMounts -= 1;
+    if (registry.pendingContentMounts !== 0) return;
+
+    const afterContentMounts = registry.afterContentMounts;
+    registry.afterContentMounts = undefined;
+    afterContentMounts?.();
+  };
+  content.mount?.();
+}
+
+function runAfterContentMounts<Page extends string>(registry: PageRegistry<Page>, callback: () => void): void {
+  registry.afterContentMounts = callback;
+
+  if (registry.pendingContentMounts === 0) {
+    registry.afterContentMounts = undefined;
+    callback();
+  }
+}
+
+function disableCompletedLazyLifecycle<Page extends string>(registry: PageRegistry<Page>): void {
+  // Once all lazy content is mounted, settling no longer needs to notify React.
+  if (registry.restState && registry.lazyContent.every(content => !content || content.mounted)) {
+    registry.restState.value = PAGER_REST_DISABLED;
+  }
+}
+
+// ============ Swipe Targets ================================================== //
+
+function resolvePageIndex<Page extends string>(
+  page: Page | undefined,
+  fallbackIndex: number,
+  activeIndex: number,
+  registry: PageRegistry<Page>
+): number {
+  const index = page === undefined ? fallbackIndex : registry.indexById.get(page);
+  return index === undefined || index < 0 || index >= registry.ids.length || index === activeIndex ? -1 : index;
+}
+
+function getGestureCandidates<Page extends string>(
+  registry: PageRegistry<Page>,
+  state: PagerNavigationState<Page>,
+  activeIndex: number
+): PagerGestureCandidates {
+  const historyBackIndex = registry.supportsBackGesture ? resolvePageIndex(state.back, -1, activeIndex, registry) : -1;
+  const declarationPreviousIndex = registry.supportsBackGesture ? resolvePageIndex(undefined, activeIndex - 1, activeIndex, registry) : -1;
+  const canUseLinearForward =
+    registry.forwardGestureMode === 'always' || (registry.furthestIndex !== undefined && activeIndex < registry.furthestIndex);
+
+  const declarationNextIndex = canUseLinearForward ? resolvePageIndex(undefined, activeIndex + 1, activeIndex, registry) : -1;
+  const historyForwardIndex = registry.forwardGestureMode !== false ? resolvePageIndex(state.forward, -1, activeIndex, registry) : -1;
+
+  // Prefer the page the user came from; otherwise use an adjacent page before replaying forward history.
+  return [historyBackIndex, declarationPreviousIndex, declarationNextIndex, historyForwardIndex];
+}
+
+function resolveReadyGestureTargets<Page extends string>(
+  registry: PageRegistry<Page>,
+  candidates: PagerGestureCandidates,
+  activeIndex: number
+): PagerGestureTargets {
+  let leftIndex = -1;
+  let rightIndex = -1;
+
+  for (const index of candidates) {
+    if (!isPageReady(registry, index)) continue;
+
+    if (index < activeIndex && leftIndex === -1) leftIndex = index;
+    else if (index > activeIndex && rightIndex === -1) rightIndex = index;
+
+    if (leftIndex !== -1 && rightIndex !== -1) break;
+  }
+
+  return [leftIndex, rightIndex];
+}
+
+function getPreparationTargets<Page extends string>(
+  registry: PageRegistry<Page>,
+  activeIndex: number,
+  candidates: PagerGestureCandidates
+): number[] {
+  const nextIndex = activeIndex + 1 < registry.ids.length ? activeIndex + 1 : -1;
+  const indices = [nextIndex, ...candidates];
+  return indices.filter((index, offset) => index !== -1 && indices.indexOf(index) === offset);
+}
+
+function isPageReady<Page extends string>(registry: PageRegistry<Page>, index: number): boolean {
+  if (index === -1) return false;
+  return registry.lazyContent[index]?.mounted ?? true;
 }
 
 // ============ Styles ========================================================= //
 
 const styles = StyleSheet.create({
-  pageStyle: {
+  fillHeight: {
+    height: '100%',
+  },
+  layoutAnchor: {
+    position: 'relative',
+  },
+  page: {
     alignItems: 'center',
     height: '100%',
-    pointerEvents: 'box-none',
+    left: 0,
+    position: 'absolute',
+    top: 0,
     width: DEVICE_WIDTH,
   },
   pagerContainer: {
     flex: 1,
-    pointerEvents: 'box-none',
     width: DEVICE_WIDTH,
-  },
-  pagerWrapper: {
-    flexDirection: 'row',
-    pointerEvents: 'box-none',
-  },
-  fillHeight: {
-    height: '100%',
-    pointerEvents: 'auto',
-  },
-  subPageStyle: {
-    alignItems: 'center',
-    bottom: 0,
-    height: '100%',
-    left: 0,
-    position: 'absolute',
-    width: DEVICE_WIDTH,
-  },
-  subPageWrapperStyle: {
-    position: 'absolute',
   },
 });

--- a/src/components/SmoothPager/pagerWorklets.ts
+++ b/src/components/SmoothPager/pagerWorklets.ts
@@ -86,7 +86,7 @@ export function cancelPagerAnimations(positions: readonly PagerPosition[], pageI
 }
 
 function animateValue(
-  value: SharedValue<number>,
+  sharedValue: SharedValue<number>,
   destination: number,
   animation: PagerAnimation,
   velocity?: number,
@@ -95,9 +95,9 @@ function animateValue(
   'worklet';
   if (animation.type === 'spring') {
     const config = velocity === undefined ? animation.config : { ...animation.config, velocity };
-    value.value = withSpring(destination, config, callback);
+    sharedValue.value = withSpring(destination, config, callback);
   } else {
-    value.value = withTiming(destination, animation.config, callback);
+    sharedValue.value = withTiming(destination, animation.config, callback);
   }
 }
 
@@ -164,8 +164,8 @@ function settlePages(
             gestureState.motionPeerIndex = -1;
           }
 
-          const isPageIndexStale = pageIndex && pageIndex.value !== upscalePagerIndex(settledIndex);
-          const skipSettlement = !isPageIndexStale || !tracksRest || !restState || !onSettled || restState.value !== PAGER_REST_REQUESTED;
+          const isPageIndexSettled = pageIndex === undefined || pageIndex.value === upscalePagerIndex(settledIndex);
+          const skipSettlement = !isPageIndexSettled || !tracksRest || !restState || !onSettled || restState.value !== PAGER_REST_REQUESTED;
           if (skipSettlement) return;
 
           completePagerRest(gestureState, restState, settledIndex, onSettled);

--- a/src/components/SmoothPager/pagerWorklets.ts
+++ b/src/components/SmoothPager/pagerWorklets.ts
@@ -62,7 +62,7 @@ export function createPagerGestureState(): PagerGestureState {
 
 // ============ Animation Coordinates ========================================== //
 
-// Reanimated produces smoother motion on device when page positions span this larger range.
+/** Reanimated produces smoother motion on device when page positions span this larger range. */
 const SCALE_FACTOR = 200;
 
 /** Converts an animated pager index back to page units. */
@@ -390,22 +390,30 @@ export function beginPagerGesture(
   'worklet';
   const activePageIndex = activeIndex.value;
   const motionPeer = gestureState.motionPeerIndex;
-  const interruptsMotion = motionPeer !== -1 && motionPeer !== activePageIndex;
+  const hasMotionPeer = motionPeer !== -1 && motionPeer !== activePageIndex;
 
+  let usesMotionPair = false;
   let sourceIndex = activePageIndex;
   let targetIndex = getPagerTargetIndex(targetSide === -1 ? gestureState.leftTarget : gestureState.rightTarget);
 
-  if (interruptsMotion) {
-    const peerIsTarget = (positions[motionPeer].value - positions[activePageIndex].value) * targetSide > 0;
-    sourceIndex = peerIsTarget ? activePageIndex : motionPeer;
-    targetIndex = peerIsTarget ? motionPeer : activePageIndex;
+  if (hasMotionPeer) {
+    const activePosition = positions[activePageIndex].value;
+    const peerPosition = positions[motionPeer].value;
+    const peerIsTarget = (peerPosition - activePosition) * targetSide > 0;
+    const peerIsVisualSource = Math.abs(peerPosition) < Math.abs(activePosition);
+
+    if (peerIsTarget || peerIsVisualSource) {
+      usesMotionPair = true;
+      sourceIndex = peerIsTarget ? activePageIndex : motionPeer;
+      targetIndex = peerIsTarget ? motionPeer : activePageIndex;
+    }
   }
 
   if (targetIndex < 0 || targetIndex === sourceIndex) return;
   cancelPagerAnimations(positions, pageIndex);
 
   const sourcePosition = positions[sourceIndex];
-  if (!interruptsMotion) placePagerTarget(positions, sourceIndex, targetIndex, targetSide);
+  if (!usesMotionPair) placePagerTarget(positions, sourceIndex, targetIndex, targetSide);
 
   let trailingIndex = -1;
   let trailingDistance = SCALE_FACTOR;

--- a/src/components/SmoothPager/pagerWorklets.ts
+++ b/src/components/SmoothPager/pagerWorklets.ts
@@ -1,0 +1,540 @@
+import {
+  cancelAnimation,
+  runOnJS,
+  withSpring,
+  withTiming,
+  type makeMutable,
+  type SharedValue,
+  type WithSpringConfig,
+  type WithTimingConfig,
+} from 'react-native-reanimated';
+
+// ============ Types ========================================================== //
+
+export type PagerAnimation = { type: 'spring'; config: WithSpringConfig } | { type: 'timing'; config: WithTimingConfig };
+export type PagerRestState = -1 | 0 | 1;
+export type PagerSide = -1 | 1;
+
+/** A page position whose current spring velocity can be carried into an interrupted transition. */
+export type PagerPosition = MutablePosition & {
+  readonly _animation?: (NonNullable<MutablePosition['_animation']> & { readonly velocity?: number }) | null;
+};
+
+/** Page indices available on the left and right; `-1` means no page is available on that side. */
+export type PagerGestureTargets = readonly [leftIndex: number, rightIndex: number];
+
+/**
+ * Mutable gesture and transition state stored on the UI thread.
+ * `gestureTarget`, `leftTarget`, and `rightTarget` store a page index plus one so that zero can mean “no page.”
+ */
+export type PagerGestureState = {
+  readonly __workletContextObject: true;
+  gestureOrigin: number;
+  gestureTarget: number;
+  gestureTrailingIndex: number;
+  leftTarget: number;
+  motionPeerIndex: number;
+  rightTarget: number;
+};
+
+type AnimationCallback = (finished?: boolean) => void;
+type MutablePosition = ReturnType<typeof makeMutable<number>>;
+type PageSettledCallback = (index: number) => void;
+
+// ============ Constants and Gesture State ==================================== //
+
+export const PAGER_REST_DISABLED: PagerRestState = -1;
+export const PAGER_REST_IDLE: PagerRestState = 0;
+export const PAGER_REST_REQUESTED: PagerRestState = 1;
+export const NO_PAGER_GESTURE_TARGETS: PagerGestureTargets = [-1, -1];
+
+export function createPagerGestureState(): PagerGestureState {
+  return {
+    __workletContextObject: true,
+    gestureOrigin: 0,
+    gestureTarget: 0,
+    gestureTrailingIndex: -1,
+    leftTarget: 0,
+    motionPeerIndex: -1,
+    rightTarget: 0,
+  };
+}
+
+// ============ Animation Coordinates ========================================== //
+
+// Reanimated produces smoother motion on device when page positions span this larger range.
+const SCALE_FACTOR = 200;
+
+/** Converts an animated pager index back to page units. */
+export function downscalePagerIndex(scaledIndex: number): number {
+  'worklet';
+  return scaledIndex / SCALE_FACTOR;
+}
+
+/** Converts a page index to the scaled value used for animation. */
+export function upscalePagerIndex(index: number): number {
+  'worklet';
+  return index * SCALE_FACTOR;
+}
+
+// ============ Animation and Settlement ======================================= //
+
+export function cancelPagerAnimations(positions: readonly PagerPosition[], pageIndex: SharedValue<number> | undefined): void {
+  'worklet';
+  for (const position of positions) cancelAnimation(position);
+  if (pageIndex) cancelAnimation(pageIndex);
+}
+
+function animateValue(
+  value: SharedValue<number>,
+  destination: number,
+  animation: PagerAnimation,
+  velocity?: number,
+  callback?: AnimationCallback
+): void {
+  'worklet';
+  if (animation.type === 'spring') {
+    const config = velocity === undefined ? animation.config : { ...animation.config, velocity };
+    value.value = withSpring(destination, config, callback);
+  } else {
+    value.value = withTiming(destination, animation.config, callback);
+  }
+}
+
+function getRestingPagePosition(pageIndex: number, activeIndex: number): number {
+  'worklet';
+  return pageIndex === activeIndex ? 0 : pageIndex < activeIndex ? -SCALE_FACTOR : SCALE_FACTOR;
+}
+
+function arePagerPagesSettled(positions: readonly PagerPosition[], activeIndex: number): boolean {
+  'worklet';
+  for (let index = 0; index < positions.length; index += 1) {
+    if (positions[index].value !== getRestingPagePosition(index, activeIndex)) return false;
+  }
+  return true;
+}
+
+function completePagerRest(
+  gestureState: PagerGestureState | undefined,
+  restState: SharedValue<PagerRestState>,
+  settledIndex: number,
+  onSettled: PageSettledCallback
+): void {
+  'worklet';
+  restState.value = PAGER_REST_IDLE;
+
+  if (gestureState) {
+    gestureState.leftTarget = 0;
+    gestureState.rightTarget = 0;
+  }
+  runOnJS(onSettled)(settledIndex);
+}
+
+function settlePages(
+  positions: readonly PagerPosition[],
+  activeIndex: SharedValue<number>,
+  gestureState: PagerGestureState | undefined,
+  pageIndex: SharedValue<number> | undefined,
+  restState: SharedValue<PagerRestState> | undefined,
+  settledIndex: number,
+  positionVelocity: number | undefined,
+  pageIndexVelocity: number | undefined,
+  animation: PagerAnimation,
+  notifyWhenSettled: boolean,
+  onSettled: PageSettledCallback | undefined
+): void {
+  'worklet';
+  const tracksRest = restState !== undefined && restState.value !== PAGER_REST_DISABLED && onSettled !== undefined;
+  const expectedMotionPeerIndex = gestureState?.motionPeerIndex ?? -1;
+  const tracksMotion = expectedMotionPeerIndex !== -1;
+
+  if (tracksRest) restState.value = notifyWhenSettled ? PAGER_REST_REQUESTED : PAGER_REST_IDLE;
+
+  const transitionDistance = -positions[settledIndex].value;
+  let animationCount = 0;
+
+  const onAnimationComplete: AnimationCallback | undefined =
+    tracksMotion || tracksRest
+      ? finished => {
+          if (!finished || activeIndex.value !== settledIndex || !arePagerPagesSettled(positions, settledIndex)) {
+            return;
+          }
+
+          if (tracksMotion && gestureState?.motionPeerIndex === expectedMotionPeerIndex) {
+            gestureState.motionPeerIndex = -1;
+          }
+
+          const isPageIndexStale = pageIndex && pageIndex.value !== upscalePagerIndex(settledIndex);
+          const skipSettlement = !isPageIndexStale || !tracksRest || !restState || !onSettled || restState.value !== PAGER_REST_REQUESTED;
+          if (skipSettlement) return;
+
+          completePagerRest(gestureState, restState, settledIndex, onSettled);
+        }
+      : undefined;
+
+  for (let index = 0; index < positions.length; index += 1) {
+    const position = positions[index];
+    const currentPosition = position.value;
+    const restingPosition = getRestingPagePosition(index, settledIndex);
+
+    let destination: number;
+    let normalizeWhenFinished = false;
+
+    if (index === settledIndex) {
+      destination = 0;
+    } else if (Math.abs(currentPosition) < SCALE_FACTOR) {
+      destination = currentPosition + transitionDistance;
+      normalizeWhenFinished = true;
+    } else {
+      // A fully hidden page can move to the side implied by its order without being seen.
+      if (currentPosition !== restingPosition) position.value = restingPosition;
+      continue;
+    }
+
+    if (currentPosition === destination) {
+      // Self assignment cancels a spring that happens to be crossing its boundary.
+      position.value = normalizeWhenFinished ? restingPosition : destination;
+      continue;
+    }
+
+    animationCount += 1;
+    if (animation.type === 'spring') cancelAnimation(position);
+
+    animateValue(
+      position,
+      destination,
+      animation,
+      positionVelocity,
+      normalizeWhenFinished
+        ? finished => {
+            if (finished) position.value = restingPosition;
+            onAnimationComplete?.(finished);
+          }
+        : onAnimationComplete
+    );
+  }
+
+  if (pageIndex) {
+    const destination = upscalePagerIndex(settledIndex);
+    if (pageIndex.value === destination) {
+      pageIndex.value = destination;
+    } else {
+      animationCount += 1;
+      if (animation.type === 'spring') cancelAnimation(pageIndex);
+      animateValue(pageIndex, destination, animation, pageIndexVelocity, onAnimationComplete);
+    }
+  }
+
+  if (animationCount === 0) {
+    if (tracksMotion && gestureState?.motionPeerIndex === expectedMotionPeerIndex) gestureState.motionPeerIndex = -1;
+    if (restState?.value === PAGER_REST_REQUESTED && onSettled) completePagerRest(gestureState, restState, settledIndex, onSettled);
+  }
+}
+
+// ============ Page Transitions =============================================== //
+
+function getVisualSourceIndex(positions: readonly PagerPosition[], preferredIndex: number): number {
+  'worklet';
+  let closestIndex = preferredIndex;
+  let closestDistance = Math.abs(positions[preferredIndex].value);
+
+  for (let index = 0; index < positions.length; index += 1) {
+    const distance = Math.abs(positions[index].value);
+    if (distance < closestDistance) {
+      closestDistance = distance;
+      closestIndex = index;
+    }
+  }
+  return closestIndex;
+}
+
+function placePagerTarget(positions: readonly PagerPosition[], sourceIndex: number, targetIndex: number, targetSide: PagerSide): void {
+  'worklet';
+  const target = positions[targetIndex];
+  const targetIsVisible = Math.abs(target.value) < SCALE_FACTOR;
+  const targetPosition = targetIsVisible ? target.value : positions[sourceIndex].value + targetSide * SCALE_FACTOR;
+
+  // Place a hidden page on the correct side before it becomes a swipe target.
+  // If another visible page already occupies that slot, a newer navigation request has replaced it.
+  for (let index = 0; index < positions.length; index += 1) {
+    if (index === sourceIndex || index === targetIndex) continue;
+    const position = positions[index].value;
+
+    if (Math.abs(position) >= SCALE_FACTOR || Math.abs(position - targetPosition) < SCALE_FACTOR / 2) {
+      positions[index].value = getRestingPagePosition(index, targetIndex);
+    }
+  }
+
+  if (!targetIsVisible) target.value = targetPosition;
+}
+
+function getPagerTargetSide(positions: readonly PagerPosition[], sourceIndex: number, targetIndex: number): PagerSide {
+  'worklet';
+  const targetPosition = positions[targetIndex].value;
+  const delta = targetPosition - positions[sourceIndex].value;
+  if (Math.abs(targetPosition) < SCALE_FACTOR && delta !== 0) return delta < 0 ? -1 : 1;
+
+  return targetIndex < sourceIndex ? -1 : 1;
+}
+
+export function setPagerGestureTargets(
+  activeIndex: SharedValue<number>,
+  gestureState: PagerGestureState | undefined,
+  expectedActiveIndex: number,
+  targets: PagerGestureTargets
+): void {
+  'worklet';
+  if (!gestureState || activeIndex.value !== expectedActiveIndex) return;
+
+  gestureState.leftTarget = targets[0] + 1;
+  gestureState.rightTarget = targets[1] + 1;
+}
+
+export function transitionToPage(
+  positions: readonly PagerPosition[],
+  activeIndex: SharedValue<number>,
+  gestureState: PagerGestureState | undefined,
+  pageIndex: SharedValue<number> | undefined,
+  restState: SharedValue<PagerRestState> | undefined,
+  targetIndex: number,
+  nextTargets: PagerGestureTargets,
+  animation: PagerAnimation,
+  onSettled: PageSettledCallback | undefined
+): void {
+  'worklet';
+  const semanticSourceIndex = activeIndex.value;
+  const previousMotionPeerIndex = gestureState?.motionPeerIndex ?? -1;
+  const visualSourceIndex = getVisualSourceIndex(positions, semanticSourceIndex);
+  const targetSide = getPagerTargetSide(positions, visualSourceIndex, targetIndex);
+  const sourcePosition = positions[visualSourceIndex].value;
+
+  const positionVelocity = animation.type === 'spring' ? (positions[visualSourceIndex]._animation?.velocity ?? 0) : undefined;
+  const sourceDestination = visualSourceIndex === targetIndex ? 0 : -targetSide * SCALE_FACTOR;
+  const remainingSourceTravel = sourceDestination - sourcePosition;
+
+  const pageIndexVelocity =
+    pageIndex && positionVelocity !== undefined && remainingSourceTravel !== 0
+      ? positionVelocity * ((upscalePagerIndex(targetIndex) - pageIndex.value) / remainingSourceTravel)
+      : undefined;
+
+  if (gestureState) gestureState.gestureTarget = 0;
+  placePagerTarget(positions, visualSourceIndex, targetIndex, targetSide);
+  activeIndex.value = targetIndex;
+
+  if (gestureState) {
+    // Track the two pages that are actually moving.
+    // A quickly replaced destination may enter history without reaching the screen.
+    let nextMotionPeerIndex = previousMotionPeerIndex === targetIndex ? -1 : previousMotionPeerIndex;
+    if (semanticSourceIndex !== targetIndex) nextMotionPeerIndex = semanticSourceIndex;
+    if (visualSourceIndex !== targetIndex) nextMotionPeerIndex = visualSourceIndex;
+    gestureState.motionPeerIndex = nextMotionPeerIndex;
+  }
+
+  setPagerGestureTargets(activeIndex, gestureState, targetIndex, nextTargets);
+
+  settlePages(
+    positions,
+    activeIndex,
+    gestureState,
+    pageIndex,
+    restState,
+    targetIndex,
+    positionVelocity,
+    pageIndexVelocity,
+    animation,
+    true,
+    onSettled
+  );
+}
+
+export function requestPagerRest(
+  positions: readonly PagerPosition[],
+  activeIndex: SharedValue<number>,
+  gestureState: PagerGestureState | undefined,
+  pageIndex: SharedValue<number> | undefined,
+  restState: SharedValue<PagerRestState>,
+  animation: PagerAnimation,
+  onSettled: PageSettledCallback
+): void {
+  'worklet';
+  if (restState.value === PAGER_REST_DISABLED) return;
+  restState.value = PAGER_REST_REQUESTED;
+
+  if (gestureState) {
+    gestureState.leftTarget = 0;
+    gestureState.rightTarget = 0;
+  }
+
+  if ((gestureState?.gestureTarget ?? 0) !== 0) return;
+
+  const activePage = activeIndex.value;
+  const restPage = getVisualSourceIndex(positions, activePage);
+
+  transitionToPage(positions, activeIndex, gestureState, pageIndex, restState, restPage, NO_PAGER_GESTURE_TARGETS, animation, onSettled);
+}
+
+// ============ Swipe Gestures ================================================= //
+
+function getPagerTargetIndex(target: number): number {
+  'worklet';
+  return target - 1;
+}
+
+export function beginPagerGesture(
+  positions: readonly PagerPosition[],
+  activeIndex: SharedValue<number>,
+  gestureState: PagerGestureState,
+  pageIndex: SharedValue<number> | undefined,
+  targetSide: PagerSide
+): void {
+  'worklet';
+  const activePageIndex = activeIndex.value;
+  const motionPeer = gestureState.motionPeerIndex;
+  const interruptsMotion = motionPeer !== -1 && motionPeer !== activePageIndex;
+
+  let sourceIndex = activePageIndex;
+  let targetIndex = getPagerTargetIndex(targetSide === -1 ? gestureState.leftTarget : gestureState.rightTarget);
+
+  if (interruptsMotion) {
+    const peerIsTarget = (positions[motionPeer].value - positions[activePageIndex].value) * targetSide > 0;
+    sourceIndex = peerIsTarget ? activePageIndex : motionPeer;
+    targetIndex = peerIsTarget ? motionPeer : activePageIndex;
+  }
+
+  if (targetIndex < 0 || targetIndex === sourceIndex) return;
+  cancelPagerAnimations(positions, pageIndex);
+
+  const sourcePosition = positions[sourceIndex];
+  if (!interruptsMotion) placePagerTarget(positions, sourceIndex, targetIndex, targetSide);
+
+  let trailingIndex = -1;
+  let trailingDistance = SCALE_FACTOR;
+
+  for (let index = 0; index < positions.length; index += 1) {
+    if (index === sourceIndex || index === targetIndex) continue;
+    const distance = Math.abs(positions[index].value);
+    if (distance < trailingDistance) {
+      trailingDistance = distance;
+      trailingIndex = index;
+    }
+  }
+
+  gestureState.gestureOrigin = sourcePosition.value;
+  gestureState.gestureTarget = targetIndex + 1;
+  gestureState.motionPeerIndex = sourceIndex;
+  gestureState.gestureTrailingIndex = trailingIndex;
+}
+
+export function updatePagerGesture(
+  positions: readonly PagerPosition[],
+  gestureState: PagerGestureState,
+  pageIndex: SharedValue<number> | undefined,
+  targetSide: PagerSide,
+  changeX: number,
+  pageWidth: number
+): void {
+  'worklet';
+  const encodedTarget = gestureState.gestureTarget;
+  if (encodedTarget === 0) return;
+
+  const sourceIndex = gestureState.motionPeerIndex;
+  if (sourceIndex === -1) return;
+
+  const targetIndex = encodedTarget - 1;
+  const sourcePosition = positions[sourceIndex];
+  const targetPosition = positions[targetIndex];
+  const currentSourcePosition = sourcePosition.value;
+  const origin = gestureState.gestureOrigin;
+  const destination = -targetSide * SCALE_FACTOR;
+  const lowerBound = Math.min(origin, 0, destination);
+  const upperBound = Math.max(origin, 0, destination);
+  const nextSourcePosition = Math.max(lowerBound, Math.min(upperBound, currentSourcePosition + (changeX / pageWidth) * SCALE_FACTOR));
+  const appliedChange = nextSourcePosition - currentSourcePosition;
+
+  sourcePosition.value = nextSourcePosition;
+  targetPosition.value += appliedChange;
+
+  if (gestureState.gestureTrailingIndex !== -1) positions[gestureState.gestureTrailingIndex].value += appliedChange;
+
+  if (pageIndex) {
+    const remainingTravel = destination - currentSourcePosition;
+    if (remainingTravel !== 0) {
+      pageIndex.value += (upscalePagerIndex(targetIndex) - pageIndex.value) * (appliedChange / remainingTravel);
+    }
+  }
+}
+
+export function shouldCommitPagerGesture(
+  targetPosition: number,
+  velocityX: number,
+  targetSide: PagerSide,
+  velocityThreshold: number
+): boolean {
+  'worklet';
+  const velocityTowardsTarget = -velocityX * targetSide;
+  const progress = 1 - Math.min(Math.abs(targetPosition) / SCALE_FACTOR, 1);
+  return velocityTowardsTarget > velocityThreshold || (velocityTowardsTarget >= -velocityThreshold && progress >= 0.5);
+}
+
+export function finishPagerGesture(
+  positions: readonly PagerPosition[],
+  activeIndex: SharedValue<number>,
+  gestureState: PagerGestureState,
+  pageIndex: SharedValue<number> | undefined,
+  restState: SharedValue<PagerRestState> | undefined,
+  targetSide: PagerSide,
+  commit: boolean,
+  velocityX: number,
+  pageWidth: number,
+  animation: PagerAnimation,
+  onSettled: PageSettledCallback | undefined
+): number {
+  'worklet';
+  const encodedTarget = gestureState.gestureTarget;
+  if (encodedTarget === 0) return -1;
+
+  const sourceIndex = gestureState.motionPeerIndex;
+  if (sourceIndex === -1) return -1;
+
+  const targetIndex = encodedTarget - 1;
+  const settledIndex = commit ? targetIndex : sourceIndex;
+  const changesActivePage = settledIndex !== activeIndex.value;
+  const scaledVelocity = (velocityX / pageWidth) * SCALE_FACTOR;
+  const sourceDestination = commit ? -targetSide * SCALE_FACTOR : 0;
+  const remainingSourceTravel = sourceDestination - positions[sourceIndex].value;
+  const notifyWhenSettled =
+    restState !== undefined && restState.value !== PAGER_REST_DISABLED && (commit || restState.value === PAGER_REST_REQUESTED);
+
+  const pageIndexVelocity =
+    pageIndex && remainingSourceTravel !== 0
+      ? scaledVelocity * ((upscalePagerIndex(settledIndex) - pageIndex.value) / remainingSourceTravel)
+      : undefined;
+
+  activeIndex.value = settledIndex;
+  gestureState.gestureTarget = 0;
+  gestureState.motionPeerIndex = commit ? sourceIndex : targetIndex;
+  gestureState.gestureTrailingIndex = -1;
+
+  if (changesActivePage) {
+    const availableSide = commit ? -targetSide : targetSide;
+    const availableTarget = (commit ? sourceIndex : targetIndex) + 1;
+    gestureState.leftTarget = availableSide === -1 ? availableTarget : 0;
+    gestureState.rightTarget = availableSide === 1 ? availableTarget : 0;
+  }
+
+  settlePages(
+    positions,
+    activeIndex,
+    gestureState,
+    pageIndex,
+    restState,
+    settledIndex,
+    scaledVelocity,
+    pageIndexVelocity,
+    animation,
+    notifyWhenSettled,
+    onSettled
+  );
+
+  return settledIndex;
+}

--- a/src/components/explainer-sheet/ExplainerSheet.tsx
+++ b/src/components/explainer-sheet/ExplainerSheet.tsx
@@ -3,13 +3,13 @@ import { StyleSheet, View } from 'react-native';
 
 import { Blur, Canvas, Circle, Group, RadialGradient, LinearGradient as SkiaLinearGradient, vec } from '@shopify/react-native-skia';
 import { LinearGradient, type LinearGradientProps } from 'expo-linear-gradient';
-import { Extrapolation, interpolate, useAnimatedStyle, useDerivedValue, type SharedValue } from 'react-native-reanimated';
+import { Extrapolation, interpolate, useAnimatedStyle, useDerivedValue, useSharedValue, type SharedValue } from 'react-native-reanimated';
 
 import { AnimatedBlurView } from '@/components/AnimatedComponents/AnimatedBlurView';
 import ButtonPressAnimation from '@/components/animations/ButtonPressAnimation';
 import { SheetHandle } from '@/components/sheet';
 import { Panel, PANEL_WIDTH, TapToDismiss } from '@/components/SmoothPager/ListPanel';
-import { downscalePagerIndex, SmoothPager, usePagerNavigation } from '@/components/SmoothPager/SmoothPager';
+import { downscalePagerIndex, SmoothPager, upscalePagerIndex, usePagerHistory } from '@/components/SmoothPager/SmoothPager';
 import { AnimatedText, Box, Separator } from '@/design-system';
 import { foregroundColors, globalColors } from '@/design-system/color/palettes';
 import { getColorForTheme } from '@/design-system/color/useForegroundColor';
@@ -202,12 +202,10 @@ const PanelContent = memo(function PanelContent({
   gradientColors: string[];
   ButtonComponent?: React.ComponentType<ExplainerSheetButtonProps>;
 }) {
-  const { goForward, ref } = usePagerNavigation();
+  const pagerNavigation = usePagerHistory(steps[0].id);
   const { goBack: dismissSheet } = useNavigation();
-
-  const currentPageIndex = useDerivedValue(() => {
-    return downscalePagerIndex(ref.current?.currentPageIndex.value ?? 0);
-  });
+  const animatedPageIndex = useSharedValue(upscalePagerIndex(0));
+  const currentPageIndex = useDerivedValue(() => downscalePagerIndex(animatedPageIndex.value));
 
   const roundedCurrentPageIndex = useDerivedValue(() => {
     return Math.round(currentPageIndex.value);
@@ -222,12 +220,14 @@ const PanelContent = memo(function PanelContent({
   });
 
   const goToNextStepOrDismiss = useCallback(() => {
-    if (roundedCurrentPageIndex.value < steps.length - 1) {
-      goForward();
+    const currentStepIndex = steps.findIndex(step => step.id === pagerNavigation.getState().page);
+    const nextStep = steps[currentStepIndex + 1];
+    if (nextStep) {
+      pagerNavigation.navigate(nextStep.id);
     } else {
       dismissSheet();
     }
-  }, [dismissSheet, goForward, roundedCurrentPageIndex, steps.length]);
+  }, [dismissSheet, pagerNavigation, steps]);
 
   return (
     <Box
@@ -240,21 +240,22 @@ const PanelContent = memo(function PanelContent({
       gap={32}
     >
       <Box gap={20} style={styles.flex}>
-        <SmoothPager enableSwipeToGoBack={true} enableSwipeToGoForward={'always'} initialPage={steps[0].id} ref={ref}>
+        <SmoothPager
+          enableSwipeToGoBack={true}
+          enableSwipeToGoForward={'always'}
+          navigation={pagerNavigation}
+          pageIndex={animatedPageIndex}
+        >
           {steps.map((step, index) => (
-            <SmoothPager.Page
-              key={step.id}
-              component={
-                <Step
-                  step={step}
-                  stepIndex={index}
-                  currentPageIndex={currentPageIndex}
-                  showSunrays={showSunrays}
-                  gradientColors={gradientColors}
-                />
-              }
-              id={step.id}
-            />
+            <SmoothPager.Page key={step.id} id={step.id}>
+              <Step
+                step={step}
+                stepIndex={index}
+                currentPageIndex={currentPageIndex}
+                showSunrays={showSunrays}
+                gradientColors={gradientColors}
+              />
+            </SmoothPager.Page>
           ))}
         </SmoothPager>
         <StepIndicators stepCount={steps.length} currentIndex={currentPageIndex} />

--- a/src/features/cash/screens/cash-deposit-setup/CashDepositSetupScreen.tsx
+++ b/src/features/cash/screens/cash-deposit-setup/CashDepositSetupScreen.tsx
@@ -1,21 +1,17 @@
-import React, { memo, useLayoutEffect } from 'react';
+import React, { memo } from 'react';
 import { StyleSheet } from 'react-native';
-
-import { useRoute, type RouteProp } from '@react-navigation/native';
-import { useListen } from '@storesjs/stores';
 
 import { AbsolutePortalRoot } from '@/components/AbsolutePortal';
 import { SPRING_CONFIGS } from '@/components/animations/animationConfigs';
-import { SmoothPager, usePagerNavigation } from '@/components/SmoothPager/SmoothPager';
+import { SmoothPager } from '@/components/SmoothPager/SmoothPager';
 import { Box } from '@/design-system';
 import { useHardwareBackOnFocus } from '@/framework/ui/hooks/useHardwareBack';
 import { useCleanup } from '@/hooks/useCleanup';
 import { useStableValue } from '@/hooks/useStableValue';
 import Routes from '@/navigation/routesNames';
-import { type CashDepositSetupRoute, type RootStackParamList } from '@/navigation/types';
+import { type CashDepositSetupRoute } from '@/navigation/types';
 
 import { useCardLinkFlowStore } from '../../stores/cardLinkFlowStore';
-import { useCashDepositSetupStatusStore } from '../../stores/cashDepositSetupStore';
 import { getIsCashHalfSheetOpen } from '../../stores/cashHalfSheetVisibilityStore';
 import { useCashSetupSessionStore } from '../../stores/cashSetupSessionStore';
 import { useVerifyPhoneFlowStore } from '../../stores/verifyPhoneFlowStore';
@@ -23,7 +19,7 @@ import { CashDepositSetupNavigation, CashDepositSetupNavigator, useCashDepositSe
 import { SetupCancelSheet } from './components/SetupCancelSheet';
 import { useSetupCancelSheetStore } from './setupCancelSheetStore';
 import { useIsSetupSubmittingStore } from './setupSubmittingStore';
-import { getFirstSetupStep, SETUP_STEP_ORDER } from './steps';
+import { SETUP_STEP_ORDER } from './steps';
 import { AllDoneStep } from './steps/AllDoneStep';
 import { CardAddedStep } from './steps/CardAddedStep';
 import { CardDetailsStep } from './steps/CardDetailsStep';
@@ -51,23 +47,7 @@ const STEP_COMPONENTS: Record<CashDepositSetupRoute, React.ReactElement> = {
 };
 
 export const CashDepositSetupScreen = memo(function CashDepositSetupScreen() {
-  const { params } = useRoute<RouteProp<RootStackParamList, typeof Routes.CASH_DEPOSIT_SETUP_SCREEN>>();
-  const { ref, goToPage } = usePagerNavigation();
   const { next, cancel } = useCashDepositSetupNavigation();
-  const initialPage = useStableValue(
-    () => params?.initialStep ?? getFirstSetupStep(useCashDepositSetupStatusStore.getState()) ?? SETUP_STEP_ORDER[0]
-  );
-
-  // onNewIndex doesn't fire on mount, so seed the navigator with the page the pager opens on.
-  useLayoutEffect(() => {
-    useCashDepositSetupNavigationStore.setState({ activeRoute: initialPage, history: [] });
-  }, [initialPage]);
-
-  useListen(
-    useCashDepositSetupNavigationStore,
-    state => state.activeRoute,
-    route => goToPage(route)
-  );
 
   useHardwareBackOnFocus(
     () => {
@@ -103,19 +83,15 @@ export const CashDepositSetupScreen = memo(function CashDepositSetupScreen() {
         <SmoothPager
           enableSwipeToGoBack={false}
           enableSwipeToGoForward={false}
-          initialPage={initialPage}
           lazy
-          onNewIndex={CashDepositSetupNavigator.handlePagerIndexChange}
-          ref={ref}
+          navigation={CashDepositSetupNavigator.Pager}
           scaleTo={1}
           springConfig={SPRING_CONFIGS.snappyMediumSpringConfig}
         >
           {SETUP_STEP_ORDER.map(route => (
-            <SmoothPager.Page
-              component={<CashDepositSetupNavigator.Route name={route}>{STEP_COMPONENTS[route]}</CashDepositSetupNavigator.Route>}
-              id={route}
-              key={route}
-            />
+            <SmoothPager.Page id={route} key={route}>
+              <CashDepositSetupNavigator.Route name={route}>{STEP_COMPONENTS[route]}</CashDepositSetupNavigator.Route>
+            </SmoothPager.Page>
           ))}
         </SmoothPager>
       ))}

--- a/src/features/cash/screens/cash-deposit-setup/cashDepositSetupNavigator.ts
+++ b/src/features/cash/screens/cash-deposit-setup/cashDepositSetupNavigator.ts
@@ -1,12 +1,14 @@
 import { createVirtualNavigator } from '@/navigation/createVirtualNavigator';
 import { type CashDepositSetupRoute } from '@/navigation/types';
 
-import { SETUP_STEP_GROUP, SETUP_STEP_ORDER } from './steps';
+import { useCashDepositSetupStatusStore } from '../../stores/cashDepositSetupStore';
+import { getFirstSetupStep, SETUP_STEP_GROUP, SETUP_STEP_ORDER } from './steps';
 
 const Navigator = createVirtualNavigator<CashDepositSetupRoute>({
   initialRoute: SETUP_STEP_ORDER[0],
   routes: [...SETUP_STEP_ORDER],
   options: {
+    getEntryRoute: () => getFirstSetupStep(useCashDepositSetupStatusStore.getState()) ?? SETUP_STEP_ORDER[0],
     getRouteGroup: route => SETUP_STEP_GROUP[route],
   },
 });

--- a/src/features/dapp-browser/screens/ControlPanel.tsx
+++ b/src/features/dapp-browser/screens/ControlPanel.tsx
@@ -18,7 +18,7 @@ import { TIMING_CONFIGS } from '@/components/animations/animationConfigs';
 import ButtonPressAnimation from '@/components/animations/ButtonPressAnimation';
 import { GestureHandlerButton } from '@/components/buttons/GestureHandlerButton';
 import { ImgixImage } from '@/components/images';
-import { SmoothPager, usePagerNavigation } from '@/components/SmoothPager/SmoothPager';
+import { SmoothPager, usePagerHistory } from '@/components/SmoothPager/SmoothPager';
 import {
   AnimatedText,
   Bleed,
@@ -81,7 +81,8 @@ const HOME_PANEL_FULL_HEIGHT = 334;
 const HOME_PANEL_DAPP_SECTION = 44 + 24;
 
 export const ControlPanel = () => {
-  const { goBack, goToPage, ref } = usePagerNavigation();
+  const pagerNavigation = usePagerHistory(PAGES.HOME);
+  const { goBack, navigate: goToPage } = pagerNavigation;
   const accountAddress = useAccountAddress();
   const {
     params: { activeTabRef },
@@ -267,48 +268,37 @@ export const ControlPanel = () => {
     <>
       <AccentColorSetter animatedAccentColor={animatedAccentColor} selectedWallet={selectedWallet} />
       <Box style={controlPanelStyles.panelContainer}>
-        <SmoothPager initialPage={PAGES.HOME} ref={ref}>
-          <SmoothPager.Page
-            component={
-              <HomePanel
-                allNetworkItems={allNetworkItems}
-                animatedAccentColor={animatedAccentColor}
-                goToPage={goToPage}
-                isConnected={isConnected}
-                onConnect={handleConnect}
-                onDisconnect={handleDisconnect}
-                selectedChainId={currentChainId}
-                selectedWallet={selectedWallet}
-              />
-            }
-            id={PAGES.HOME}
-          />
-          <SmoothPager.Group>
-            <SmoothPager.Page
-              component={
-                <SwitchWalletPanel
-                  allWalletItems={allWalletItems}
-                  animatedAccentColor={animatedAccentColor}
-                  goBack={goBack}
-                  onWalletSwitch={handleSwitchWallet}
-                  selectedWalletId={selectedWalletId}
-                />
-              }
-              id={PAGES.SWITCH_WALLET}
+        <SmoothPager navigation={pagerNavigation}>
+          <SmoothPager.Page id={PAGES.HOME}>
+            <HomePanel
+              allNetworkItems={allNetworkItems}
+              animatedAccentColor={animatedAccentColor}
+              goToPage={goToPage}
+              isConnected={isConnected}
+              onConnect={handleConnect}
+              onDisconnect={handleDisconnect}
+              selectedChainId={currentChainId}
+              selectedWallet={selectedWallet}
             />
-            <SmoothPager.Page
-              component={
-                <SwitchNetworkPanel
-                  allNetworkItems={allNetworkItems}
-                  animatedAccentColor={animatedAccentColor}
-                  goBack={goBack}
-                  onNetworkSwitch={handleNetworkSwitch}
-                  selectedNetworkId={selectedNetworkId}
-                />
-              }
-              id={PAGES.SWITCH_NETWORK}
+          </SmoothPager.Page>
+          <SmoothPager.Page id={PAGES.SWITCH_WALLET}>
+            <SwitchWalletPanel
+              allWalletItems={allWalletItems}
+              animatedAccentColor={animatedAccentColor}
+              goBack={goBack}
+              onWalletSwitch={handleSwitchWallet}
+              selectedWalletId={selectedWalletId}
             />
-          </SmoothPager.Group>
+          </SmoothPager.Page>
+          <SmoothPager.Page id={PAGES.SWITCH_NETWORK}>
+            <SwitchNetworkPanel
+              allNetworkItems={allNetworkItems}
+              animatedAccentColor={animatedAccentColor}
+              goBack={goBack}
+              onNetworkSwitch={handleNetworkSwitch}
+              selectedNetworkId={selectedNetworkId}
+            />
+          </SmoothPager.Page>
         </SmoothPager>
       </Box>
       <TapToDismiss />

--- a/src/features/discover/components/DiscoverSectionsPager.tsx
+++ b/src/features/discover/components/DiscoverSectionsPager.tsx
@@ -8,11 +8,12 @@ import { SPRING_CONFIGS } from '@/components/animations/animationConfigs';
 import { useDiscoverScreenContext, type DiscoverSectionScrollViewRef } from '@/components/Discover/DiscoverScreenContext';
 import { DEFAULT_SCROLL_FADE_DISTANCE } from '@/components/scroll-header-fade/ScrollHeaderFade';
 import { Skeleton } from '@/components/Skeleton';
-import { SmoothPager, usePagerNavigation } from '@/components/SmoothPager/SmoothPager';
+import { SmoothPager } from '@/components/SmoothPager/SmoothPager';
 import { Box } from '@/design-system';
 import { DiscoverRefreshControl } from '@/features/discover/components/DiscoverRefreshControl';
 import { DiscoverSections } from '@/features/discover/components/DiscoverSection';
 import {
+  DiscoverPagerNavigation,
   DiscoverSectionNavigation,
   useDiscoverNavigationStore,
   type DiscoverSection,
@@ -36,8 +37,6 @@ export const DiscoverSectionsPager = memo(function DiscoverSectionsPager({ scrol
   const surface = useDiscoverSurface();
   const tabs = useMemo(() => surface?.tabs ?? [], [surface]);
   const activeSectionId = useDiscoverNavigationStore(state => state.activeSection);
-  const { ref, goToPage } = usePagerNavigation<DiscoverSection>();
-  const initialSection = getInitialSection(tabs, activeSectionId);
   const sectionScrollOffsets = useRef<SectionScrollOffsets>({});
   const pagerKey = tabs.map(tab => tab.id).join('|');
 
@@ -46,16 +45,7 @@ export const DiscoverSectionsPager = memo(function DiscoverSectionsPager({ scrol
     state => state.activeSection,
     section => {
       scrollOffset.value = sectionScrollOffsets.current[section] ?? 0;
-      goToPage(section);
     }
-  );
-
-  const handlePagerIndexChange = useCallback(
-    (index: number) => {
-      const section = tabs[index]?.id;
-      if (section) DiscoverSectionNavigation.navigate(section);
-    },
-    [tabs]
   );
 
   useEffect(() => {
@@ -78,31 +68,25 @@ export const DiscoverSectionsPager = memo(function DiscoverSectionsPager({ scrol
       <SmoothPager
         enableSwipeToGoBack={false}
         enableSwipeToGoForward={false}
+        fallbackPage={tabs[0].id}
         fillHeight
-        initialPage={initialSection}
         key={pagerKey}
-        onNewIndex={handlePagerIndexChange}
-        ref={ref}
+        navigation={DiscoverPagerNavigation}
         scaleTo={1}
         springConfig={SPRING_CONFIGS.snappyMediumSpringConfig}
         verticalPageAlignment="top"
       >
         {tabs.map((section, index) => (
-          <SmoothPager.Page
-            component={
-              <DiscoverSectionScrollView
-                isActive={section.id === activeSectionId}
-                scrollOffset={scrollOffset}
-                section={section}
-                sectionIndex={index}
-                sectionScrollOffsets={sectionScrollOffsets}
-                surfaceId={surface.id}
-              />
-            }
-            id={section.id}
-            key={section.id}
-            lazy
-          />
+          <SmoothPager.Page id={section.id} key={section.id} lazy>
+            <DiscoverSectionScrollView
+              isActive={section.id === activeSectionId}
+              scrollOffset={scrollOffset}
+              section={section}
+              sectionIndex={index}
+              sectionScrollOffsets={sectionScrollOffsets}
+              surfaceId={surface.id}
+            />
+          </SmoothPager.Page>
         ))}
       </SmoothPager>
     </Box>
@@ -223,10 +207,6 @@ const DiscoverSectionScrollView = memo(function DiscoverSectionScrollView({
     </SectionScrollView>
   );
 });
-
-function getInitialSection(tabs: DiscoverTab[], activeSectionId: string): string {
-  return tabs.some(tab => tab.id === activeSectionId) ? activeSectionId : (tabs[0]?.id ?? activeSectionId);
-}
 
 const styles = StyleSheet.create({
   container: {

--- a/src/features/discover/stores/discoverNavigationStore.ts
+++ b/src/features/discover/stores/discoverNavigationStore.ts
@@ -23,3 +23,13 @@ export const useDiscoverNavigationStore = createBaseStore<DiscoverNavigationStor
 }));
 
 export const DiscoverSectionNavigation = createStoreActions(useDiscoverNavigationStore);
+
+export const DiscoverPagerNavigation = {
+  getState: () => ({ page: useDiscoverNavigationStore.getState().activeSection }),
+  navigate: DiscoverSectionNavigation.navigate,
+  subscribe: (listener: (state: { page: DiscoverSection }) => void) =>
+    useDiscoverNavigationStore.subscribe(
+      state => state.activeSection,
+      page => listener({ page })
+    ),
+};

--- a/src/features/perps/components/PerpsNavigatorFooter.tsx
+++ b/src/features/perps/components/PerpsNavigatorFooter.tsx
@@ -81,7 +81,7 @@ const PerpsSearchScreenFooter = () => {
   return (
     <Box flexDirection={'row'} gap={12} width="full" alignItems={'center'} justifyContent={'space-between'}>
       <BackButton
-        onPress={() => PerpsNavigation.navigate(Routes.PERPS_ACCOUNT_SCREEN)}
+        onPress={() => PerpsNavigation.goBack(Routes.PERPS_ACCOUNT_SCREEN)}
         backgroundColor={accentColors.opacity12}
         borderColor={accentColors.opacity6}
         textColor={accentColors.opacity100}
@@ -295,7 +295,7 @@ const PerpsNewPositionScreenFooter = memo(function PerpsNewPositionScreenFooter(
       )}
       <Box flexDirection={'row'} gap={12} width="full" alignItems={'center'} justifyContent={'space-between'}>
         <BackButton
-          onPress={() => PerpsNavigation.navigate(Routes.PERPS_SEARCH_SCREEN, { type: 'newPosition' })}
+          onPress={() => PerpsNavigation.goBack(Routes.PERPS_SEARCH_SCREEN, { type: 'newPosition' })}
           backgroundColor={button.backgroundColor}
           borderColor={button.borderColor}
           textColor={button.backTextColor}

--- a/src/features/perps/screens/PerpsNavigator.tsx
+++ b/src/features/perps/screens/PerpsNavigator.tsx
@@ -1,12 +1,10 @@
 import { memo } from 'react';
 import { StyleSheet } from 'react-native';
 
-import { useRoute, type RouteProp } from '@react-navigation/native';
-import { useListen } from '@storesjs/stores';
 import { KeyboardProvider } from 'react-native-keyboard-controller';
 
 import { SPRING_CONFIGS } from '@/components/animations/animationConfigs';
-import { SmoothPager, usePagerNavigation } from '@/components/SmoothPager/SmoothPager';
+import { SmoothPager } from '@/components/SmoothPager/SmoothPager';
 import { Box, useColorMode } from '@/design-system';
 import { PerpsNavbar } from '@/features/perps/components/PerpsNavbar';
 import { PerpsNavigatorFooter } from '@/features/perps/components/PerpsNavigatorFooter';
@@ -20,29 +18,18 @@ import { useCleanup } from '@/hooks/useCleanup';
 import { useStableValue } from '@/hooks/useStableValue';
 import { createVirtualNavigator } from '@/navigation/createVirtualNavigator';
 import Routes from '@/navigation/routesNames';
-import { type PerpsRoute, type RootStackParamList } from '@/navigation/types';
+import { type PerpsRoute } from '@/navigation/types';
 
 const Navigator = createVirtualNavigator<PerpsRoute>({
   initialRoute: Routes.PERPS_ACCOUNT_SCREEN,
   routes: [Routes.PERPS_ACCOUNT_SCREEN, Routes.PERPS_SEARCH_SCREEN, Routes.PERPS_NEW_POSITION_SCREEN],
 });
 
-export const PerpsNavigation = Navigator.Navigation;
-export const usePerpsNavigationStore = Navigator.useNavigationStore;
+export const { Navigation: PerpsNavigation, useNavigationStore: usePerpsNavigationStore } = Navigator;
 
 export const PerpsNavigator = memo(function PerpsNavigator() {
-  const { params } = useRoute<RouteProp<RootStackParamList, typeof Routes.PERPS_NAVIGATOR>>();
   const { isDarkMode } = useColorMode();
-  const { ref, goToPage } = usePagerNavigation();
-  const initialPage = useStableValue(() => params?.initialPerpsPage ?? Routes.PERPS_ACCOUNT_SCREEN);
-
   const screenBackgroundColor = isDarkMode ? PERPS_BACKGROUND_DARK : PERPS_BACKGROUND_LIGHT;
-
-  useListen(
-    usePerpsNavigationStore,
-    state => state.activeRoute,
-    route => goToPage(route)
-  );
 
   useCleanup(PerpsNavigation.resetNavigationState);
 
@@ -59,39 +46,27 @@ export const PerpsNavigator = memo(function PerpsNavigator() {
             <SmoothPager
               enableSwipeToGoBack={true}
               enableSwipeToGoForward={true}
-              initialPage={initialPage}
-              onNewIndex={Navigator.handlePagerIndexChange}
-              ref={ref}
+              navigation={Navigator.Pager}
               scaleTo={1}
               springConfig={SPRING_CONFIGS.snappyMediumSpringConfig}
             >
-              <SmoothPager.Page
-                component={
-                  <Navigator.Route name={Routes.PERPS_ACCOUNT_SCREEN}>
-                    <PerpsAccountScreen />
-                  </Navigator.Route>
-                }
-                id={Routes.PERPS_ACCOUNT_SCREEN}
-              />
+              <SmoothPager.Page id={Routes.PERPS_ACCOUNT_SCREEN}>
+                <Navigator.Route name={Routes.PERPS_ACCOUNT_SCREEN}>
+                  <PerpsAccountScreen />
+                </Navigator.Route>
+              </SmoothPager.Page>
 
-              <SmoothPager.Page
-                component={
-                  <Navigator.Route name={Routes.PERPS_SEARCH_SCREEN}>
-                    <PerpsSearchScreen />
-                  </Navigator.Route>
-                }
-                id={Routes.PERPS_SEARCH_SCREEN}
-              />
+              <SmoothPager.Page id={Routes.PERPS_SEARCH_SCREEN}>
+                <Navigator.Route name={Routes.PERPS_SEARCH_SCREEN}>
+                  <PerpsSearchScreen />
+                </Navigator.Route>
+              </SmoothPager.Page>
 
-              <SmoothPager.Page
-                component={
-                  <Navigator.Route name={Routes.PERPS_NEW_POSITION_SCREEN}>
-                    <PerpsNewPositionScreen />
-                  </Navigator.Route>
-                }
-                id={Routes.PERPS_NEW_POSITION_SCREEN}
-                lazy
-              />
+              <SmoothPager.Page id={Routes.PERPS_NEW_POSITION_SCREEN} lazy>
+                <Navigator.Route name={Routes.PERPS_NEW_POSITION_SCREEN}>
+                  <PerpsNewPositionScreen />
+                </Navigator.Route>
+              </SmoothPager.Page>
             </SmoothPager>
           ))}
 

--- a/src/features/perps/screens/perp-detail-screen/SheetFooter.tsx
+++ b/src/features/perps/screens/perp-detail-screen/SheetFooter.tsx
@@ -58,9 +58,7 @@ export function SheetFooter({ backgroundColor, market }: SheetFooterProps) {
         if (isPerpsNavigatorBehindCurrentRoute()) {
           navigation.goBack();
         } else {
-          Navigation.replace(Routes.PERPS_NAVIGATOR, {
-            initialPerpsPage: Routes.PERPS_NEW_POSITION_SCREEN,
-          });
+          Navigation.replace(Routes.PERPS_NAVIGATOR);
         }
       },
       text: i18n.t(i18n.l.perps.actions.open_position),

--- a/src/features/perps/utils/navigateToPerps.ts
+++ b/src/features/perps/utils/navigateToPerps.ts
@@ -1,7 +1,6 @@
 import { PerpsNavigation } from '@/features/perps/screens/PerpsNavigator';
 import Navigation from '@/navigation/Navigation';
 import Routes from '@/navigation/routesNames';
-import { type RootStackParamList } from '@/navigation/types';
 import { device } from '@/storage';
 
 export const HAS_SEEN_PERPS_EXPLAIN_KEY = 'hasSeenPerpsExplainSheet';
@@ -20,11 +19,11 @@ export function maybeNavigateToPerpsExplainSheet(navigationAction: () => void): 
   });
 }
 
-export function navigateToPerps(params?: RootStackParamList[typeof Routes.PERPS_NAVIGATOR]) {
-  maybeNavigateToPerpsExplainSheet(() => Navigation.handleAction(Routes.PERPS_NAVIGATOR, params));
+export function navigateToPerps() {
+  maybeNavigateToPerpsExplainSheet(() => Navigation.handleAction(Routes.PERPS_NAVIGATOR));
 }
 
 export function navigateToPerpsSearch() {
   PerpsNavigation.navigate(Routes.PERPS_SEARCH_SCREEN, { type: 'search' });
-  navigateToPerps({ initialPerpsPage: Routes.PERPS_SEARCH_SCREEN });
+  navigateToPerps();
 }

--- a/src/features/polymarket/screens/polymarket-navigator/PolymarketContext.tsx
+++ b/src/features/polymarket/screens/polymarket-navigator/PolymarketContext.tsx
@@ -1,6 +1,6 @@
 import { createContext, useContext, useMemo, useRef, type ReactNode, type RefObject } from 'react';
-import { type ScrollView } from 'react-native';
 
+import { type ScrollView } from 'react-native-gesture-handler';
 import type Animated from 'react-native-reanimated';
 
 type PolymarketContextType = {

--- a/src/features/polymarket/screens/polymarket-navigator/PolymarketNavigator.tsx
+++ b/src/features/polymarket/screens/polymarket-navigator/PolymarketNavigator.tsx
@@ -1,10 +1,8 @@
 import { memo, useEffect } from 'react';
 import { StyleSheet } from 'react-native';
 
-import { useListen } from '@storesjs/stores';
-
 import { SPRING_CONFIGS } from '@/components/animations/animationConfigs';
-import { SmoothPager, usePagerNavigation } from '@/components/SmoothPager/SmoothPager';
+import { SmoothPager } from '@/components/SmoothPager/SmoothPager';
 import { Box, useColorMode } from '@/design-system';
 import { POLYMARKET_BACKGROUND_DARK, POLYMARKET_BACKGROUND_LIGHT } from '@/features/polymarket/constants';
 import { PolymarketAccountScreen } from '@/features/polymarket/screens/polymarket-account-screen/PolymarketAccountScreen';
@@ -39,16 +37,9 @@ export const PolymarketNavigator = memo(function PolymarketNavigator() {
 
 const PolymarketNavigatorContent = () => {
   const { isDarkMode } = useColorMode();
-  const { ref, goToPage } = usePagerNavigation();
   const { categorySelectorRef, eventsListRef } = usePolymarketContext();
 
   const screenBackgroundColor = isDarkMode ? POLYMARKET_BACKGROUND_DARK : POLYMARKET_BACKGROUND_LIGHT;
-
-  useListen(
-    usePolymarketNavigationStore,
-    state => state.activeRoute,
-    route => goToPage(route)
-  );
 
   useCleanup(PolymarketNavigation.resetNavigationState);
 
@@ -66,7 +57,7 @@ const PolymarketNavigatorContent = () => {
     // Reset list scroll too: a repeated deep link to the same league leaves
     // selectedLeagueId unchanged, so the value-based useListen won't fire.
     eventsListRef.current?.scrollToOffset({ offset: 0, animated: false });
-  }, [requestedRoute, routeRequestKey]);
+  }, [eventsListRef, requestedRoute, routeRequestKey]);
 
   return (
     <>
@@ -80,41 +71,28 @@ const PolymarketNavigatorContent = () => {
           <SmoothPager
             enableSwipeToGoBack
             enableSwipeToGoForward="always"
-            initialPage={usePolymarketNavigationStore.getState().activeRoute}
-            onNewIndex={Navigator.handlePagerIndexChange}
-            ref={ref}
+            navigation={Navigator.Pager}
             scaleTo={1}
             springConfig={SPRING_CONFIGS.snappyMediumSpringConfig}
             waitFor={categorySelectorRef}
           >
-            <SmoothPager.Page
-              component={
-                <Navigator.Route name={Routes.POLYMARKET_BROWSE_EVENTS_SCREEN}>
-                  <PolymarketBrowseEventsScreen />
-                </Navigator.Route>
-              }
-              id={Routes.POLYMARKET_BROWSE_EVENTS_SCREEN}
-            />
+            <SmoothPager.Page id={Routes.POLYMARKET_BROWSE_EVENTS_SCREEN}>
+              <Navigator.Route name={Routes.POLYMARKET_BROWSE_EVENTS_SCREEN}>
+                <PolymarketBrowseEventsScreen />
+              </Navigator.Route>
+            </SmoothPager.Page>
 
-            <SmoothPager.Page
-              component={
-                <Navigator.Route name={Routes.POLYMARKET_ACCOUNT_SCREEN}>
-                  <PolymarketAccountScreen />
-                </Navigator.Route>
-              }
-              id={Routes.POLYMARKET_ACCOUNT_SCREEN}
-              lazy
-            />
+            <SmoothPager.Page id={Routes.POLYMARKET_ACCOUNT_SCREEN} lazy>
+              <Navigator.Route name={Routes.POLYMARKET_ACCOUNT_SCREEN}>
+                <PolymarketAccountScreen />
+              </Navigator.Route>
+            </SmoothPager.Page>
 
-            <SmoothPager.Page
-              component={
-                <Navigator.Route name={Routes.POLYMARKET_SEARCH_SCREEN}>
-                  <PolymarketSearchScreen />
-                </Navigator.Route>
-              }
-              id={Routes.POLYMARKET_SEARCH_SCREEN}
-              lazy
-            />
+            <SmoothPager.Page id={Routes.POLYMARKET_SEARCH_SCREEN} lazy>
+              <Navigator.Route name={Routes.POLYMARKET_SEARCH_SCREEN}>
+                <PolymarketSearchScreen />
+              </Navigator.Route>
+            </SmoothPager.Page>
           </SmoothPager>
         ))}
       </Box>

--- a/src/features/rnbw-membership/screens/rnbw-membership-tiers-sheet/RnbwMembershipTiersSheet.tsx
+++ b/src/features/rnbw-membership/screens/rnbw-membership-tiers-sheet/RnbwMembershipTiersSheet.tsx
@@ -2,11 +2,18 @@ import { memo } from 'react';
 import { StyleSheet } from 'react-native';
 
 import { LinearGradient, type LinearGradientProps } from 'expo-linear-gradient';
-import Animated, { Extrapolation, interpolate, useAnimatedStyle, useDerivedValue, type SharedValue } from 'react-native-reanimated';
+import Animated, {
+  Extrapolation,
+  interpolate,
+  useAnimatedStyle,
+  useDerivedValue,
+  useSharedValue,
+  type SharedValue,
+} from 'react-native-reanimated';
 
 import { StepIndicators } from '@/components/explainer-sheet/components/StepIndicators';
 import { PANEL_WIDTH, PanelSheet } from '@/components/PanelSheet/PanelSheet';
-import { downscalePagerIndex, SmoothPager, usePagerNavigation } from '@/components/SmoothPager/SmoothPager';
+import { downscalePagerIndex, SmoothPager, upscalePagerIndex } from '@/components/SmoothPager/SmoothPager';
 import { Box, globalColors, Separator, Text, useColorMode } from '@/design-system';
 import { getValueForColorMode } from '@/design-system/color/palettes';
 import { TierProgressBar } from '@/features/rnbw-membership/components/TierProgressBar';
@@ -14,6 +21,7 @@ import { RNBW_SYMBOL } from '@/features/rnbw-rewards/constants';
 import { RNBW_DECIMALS } from '@/features/rnbw-staking/constants';
 import { formatNumber } from '@/helpers/strings';
 import { convertRawAmountToDecimalFormat } from '@/helpers/utilities';
+import { useStableValue } from '@/hooks/useStableValue';
 import * as i18n from '@/languages';
 
 import { TierBadge } from '../../components/TierBadge';
@@ -27,10 +35,13 @@ const AnimatedLinearGradient = Animated.createAnimatedComponent(LinearGradient);
 export const RnbwMembershipTiersSheet = memo(function RnbwMembershipTiersSheet() {
   const { isDarkMode, colorMode } = useColorMode();
   const { currentTier, allTiers } = useMembershipTierInfo();
-  const { ref } = usePagerNavigation();
-  const currentPageIndex = useDerivedValue(() => {
-    return downscalePagerIndex(ref.current?.currentPageIndex.value ?? 0);
+  const [initialPage, initialPageIndex] = useStableValue(() => {
+    const currentIndex = allTiers.findIndex(tier => tier.level === currentTier.level);
+    const index = currentIndex === -1 ? 0 : currentIndex;
+    return [allTiers[index].level, index] as const;
   });
+  const animatedPageIndex = useSharedValue(upscalePagerIndex(initialPageIndex));
+  const currentPageIndex = useDerivedValue(() => downscalePagerIndex(animatedPageIndex.value));
 
   return (
     <PanelSheet>
@@ -43,13 +54,11 @@ export const RnbwMembershipTiersSheet = memo(function RnbwMembershipTiersSheet()
             pageIndex={currentPageIndex}
           />
         ))}
-        <SmoothPager enableSwipeToGoBack={true} enableSwipeToGoForward={'always'} initialPage={currentTier.level} ref={ref}>
+        <SmoothPager enableSwipeToGoBack={true} enableSwipeToGoForward={'always'} initialPage={initialPage} pageIndex={animatedPageIndex}>
           {allTiers.map((tier, index) => (
-            <SmoothPager.Page
-              key={tier.level}
-              component={<Tier tier={tier} tierIndex={index} tierCount={allTiers.length} />}
-              id={tier.level}
-            />
+            <SmoothPager.Page key={tier.level} id={tier.level}>
+              <Tier tier={tier} tierIndex={index} tierCount={allTiers.length} />
+            </SmoothPager.Page>
           ))}
         </SmoothPager>
         <StepIndicators

--- a/src/navigation/createVirtualNavigator.test.ts
+++ b/src/navigation/createVirtualNavigator.test.ts
@@ -1,5 +1,5 @@
 import Routes from '@/navigation/routesNames';
-import { type CashDepositSetupRoute } from '@/navigation/types';
+import { type CashDepositSetupRoute, type PerpsRoute } from '@/navigation/types';
 
 import { createVirtualNavigator } from './createVirtualNavigator';
 
@@ -30,6 +30,13 @@ function createNavigator(withGroups: boolean) {
     initialRoute: ROUTES[0],
     routes: ROUTES,
     options: withGroups ? { getRouteGroup: route => GROUPS[route] } : undefined,
+  });
+}
+
+function createPerpsNavigator() {
+  return createVirtualNavigator<PerpsRoute>({
+    initialRoute: Routes.PERPS_ACCOUNT_SCREEN,
+    routes: [Routes.PERPS_ACCOUNT_SCREEN, Routes.PERPS_SEARCH_SCREEN, Routes.PERPS_NEW_POSITION_SCREEN],
   });
 }
 
@@ -77,5 +84,38 @@ describe('createVirtualNavigator getRouteGroup', () => {
     Navigation.navigate(Routes.CASH_SETUP_CONFIRM_PHONE);
     Navigation.navigate(Routes.CASH_SETUP_IDENTITY);
     expect(useNavigationStore.getState().history).toEqual([Routes.CASH_SETUP_PHONE, Routes.CASH_SETUP_CONFIRM_PHONE]);
+  });
+});
+
+describe('createVirtualNavigator goBack', () => {
+  it('uses history before a direct-entry fallback', () => {
+    const { Navigation, useNavigationStore } = createPerpsNavigator();
+    Navigation.navigate(Routes.PERPS_SEARCH_SCREEN, { type: 'newPosition' });
+    Navigation.navigate(Routes.PERPS_NEW_POSITION_SCREEN);
+
+    Navigation.goBack(Routes.PERPS_ACCOUNT_SCREEN);
+
+    expect(useNavigationStore.getState()).toMatchObject({
+      activeRoute: Routes.PERPS_SEARCH_SCREEN,
+      future: [Routes.PERPS_NEW_POSITION_SCREEN],
+      history: [Routes.PERPS_ACCOUNT_SCREEN],
+    });
+  });
+
+  it('starts a fallback path when direct entry has no history', () => {
+    const { Navigation, Pager, useNavigationStore } = createPerpsNavigator();
+    Navigation.navigate(Routes.PERPS_NEW_POSITION_SCREEN);
+    Pager.beginPath?.();
+
+    Navigation.goBack(Routes.PERPS_SEARCH_SCREEN, { type: 'newPosition' });
+
+    expect(useNavigationStore.getState()).toMatchObject({
+      activeRoute: Routes.PERPS_SEARCH_SCREEN,
+      future: [],
+      history: [],
+      params: {
+        [Routes.PERPS_SEARCH_SCREEN]: { type: 'newPosition' },
+      },
+    });
   });
 });

--- a/src/navigation/createVirtualNavigator.ts
+++ b/src/navigation/createVirtualNavigator.ts
@@ -3,6 +3,7 @@ import React from 'react';
 import { createBaseStore, createStoreActions } from '@storesjs/stores';
 
 import { UseRouteProvider, type RouteParams, type UseRouteHook } from '@/navigation/Navigation';
+import { type PagerNavigation, type PagerNavigationState } from '@/navigation/pagerNavigation';
 import { type Route } from '@/navigation/routesNames';
 import { setActiveRoute } from '@/state/navigation/navigationStore';
 import { shallowEqual } from '@/worklets/comparisons';
@@ -14,6 +15,7 @@ export type VirtualNavigator<VirtualRoute extends Route> = {
   getActiveRouteState: () => ActiveRouteState<VirtualRoute>;
   getParams: <R extends VirtualRoute>(route: R) => RouteParams<R> | undefined;
   goBack: () => void;
+  goForward: () => void;
   isRouteActive: (route: VirtualRoute) => boolean;
   navigate: <R extends VirtualRoute>(route: R, params?: RouteParams<R>) => void;
   resetNavigationState: () => void;
@@ -22,7 +24,8 @@ export type VirtualNavigator<VirtualRoute extends Route> = {
 
 type VirtualNavigationState<VirtualRoute extends Route> = {
   activeRoute: VirtualRoute;
-  history: VirtualRoute[];
+  future: readonly VirtualRoute[];
+  history: readonly VirtualRoute[];
   params: { [R in VirtualRoute]?: RouteParams<R> };
 };
 
@@ -40,23 +43,23 @@ export function createVirtualNavigator<VirtualRoute extends Route>({
   initialRoute: VirtualRoute;
   routes: readonly VirtualRoute[];
   options?: {
+    /** Resolves the route at which each new pager binding enters. */
+    getEntryRoute?: () => VirtualRoute;
     /** When the group changes between two routes, `navigate` clears history instead of appending to it. */
     getRouteGroup?: (route: VirtualRoute) => string;
     keyPrefix?: string;
-    onRouteChange?: (route: VirtualRoute) => void;
   };
 }) {
   const routeKeyPrefix = options?.keyPrefix ?? 'virtual';
-  const initialState: Pick<VirtualNavigationState<VirtualRoute>, 'activeRoute' | 'history' | 'params'> = {
+  const initialState: VirtualNavigationState<VirtualRoute> = {
     activeRoute: initialRoute,
+    future: [],
     history: [],
     params: {},
   };
 
   const useNavigationStore = createBaseStore<VirtualNavigationStore<VirtualRoute>>((set, get) => ({
-    activeRoute: initialState.activeRoute,
-    history: initialState.history,
-    params: initialState.params,
+    ...initialState,
 
     getActiveRoute: () => get().activeRoute,
 
@@ -76,7 +79,20 @@ export function createVirtualNavigator<VirtualRoute extends Route>({
         if (!state.history.length) return state;
         return {
           activeRoute: state.history[state.history.length - 1],
+          future: [...state.future, state.activeRoute],
           history: state.history.slice(0, -1),
+        };
+      });
+      setActiveRoute(get().activeRoute);
+    },
+
+    goForward: () => {
+      set(state => {
+        if (!state.future.length) return state;
+        return {
+          activeRoute: state.future[state.future.length - 1],
+          future: state.future.slice(0, -1),
+          history: [...state.history, state.activeRoute],
         };
       });
       setActiveRoute(get().activeRoute);
@@ -91,15 +107,14 @@ export function createVirtualNavigator<VirtualRoute extends Route>({
       set(state => {
         const didParamsChange = didSpecifyParams && !shallowEqual(params, state.params[route]);
         if (state.activeRoute === route) {
-          if (didParamsChange) {
-            return { params: { ...state.params, [route]: params } };
-          }
+          if (didParamsChange) return { params: { ...state.params, [route]: params } };
           return state;
         }
         const getRouteGroup = options?.getRouteGroup;
         const crossesGroupBoundary = getRouteGroup != null && getRouteGroup(route) !== getRouteGroup(state.activeRoute);
         return {
           activeRoute: route,
+          future: [],
           history: crossesGroupBoundary ? [] : [...state.history, state.activeRoute],
           params: didParamsChange ? { ...state.params, [route]: params } : state.params,
         };
@@ -120,27 +135,6 @@ export function createVirtualNavigator<VirtualRoute extends Route>({
 
   const navigationActions = createStoreActions(useNavigationStore);
 
-  const indexToRoute = routes.reduce<Record<number, VirtualRoute>>((map, route, index) => {
-    map[index] = route;
-    return map;
-  }, {});
-
-  function handlePagerIndexChange(index: number): void {
-    const route = indexToRoute[index];
-    const { activeRoute, history } = useNavigationStore.getState();
-
-    if (route === activeRoute) {
-      options?.onRouteChange?.(route);
-      return;
-    }
-
-    if (history.length && history[history.length - 1] === route) {
-      navigationActions.goBack();
-    } else {
-      navigationActions.navigate(route);
-    }
-  }
-
   function createRouteHook(route: VirtualRoute): UseRouteHook {
     const routeInfo = {
       key: `${routeKeyPrefix}:${String(route)}`,
@@ -149,13 +143,52 @@ export function createVirtualNavigator<VirtualRoute extends Route>({
     return () => routeInfo;
   }
 
-  const RouteProvider = ({ children, name }: { children: React.ReactNode; name: VirtualRoute }) =>
-    React.createElement(UseRouteProvider, { value: createRouteHook(name) }, children);
+  const routeHooks = new Map<VirtualRoute, UseRouteHook | undefined>();
+  routes.forEach(route => routeHooks.set(route, undefined));
+
+  function getRouteHook(route: VirtualRoute): UseRouteHook | undefined {
+    if (!routeHooks.has(route)) return;
+    let hook = routeHooks.get(route);
+    if (!hook) routeHooks.set(route, (hook = createRouteHook(route)));
+    return hook;
+  }
+
+  const RouteProvider = ({ children, name }: { children: React.ReactNode; name: VirtualRoute }) => {
+    const useRoute = getRouteHook(name);
+    if (!useRoute) throw new Error(`Virtual route "${name}" is not registered.`);
+    return React.createElement(UseRouteProvider, { value: useRoute }, children);
+  };
+
+  function selectPagerState({ activeRoute, future, history }: VirtualNavigationState<VirtualRoute>): PagerNavigationState<VirtualRoute> {
+    return {
+      back: history.at(-1),
+      forward: future.at(-1),
+      page: activeRoute,
+    };
+  }
+
+  const pagerNavigation: PagerNavigation<VirtualRoute> = {
+    beginPath: () => {
+      const activeRoute = options?.getEntryRoute?.() ?? useNavigationStore.getState().activeRoute;
+      useNavigationStore.setState(state => {
+        if (state.activeRoute === activeRoute && !state.history.length && !state.future.length) return state;
+        return { activeRoute, future: [], history: [] };
+      });
+      return selectPagerState(useNavigationStore.getState());
+    },
+    getState: () => selectPagerState(useNavigationStore.getState()),
+    goBack: navigationActions.goBack,
+    goForward: navigationActions.goForward,
+    navigate: page => {
+      if (routeHooks.has(page)) navigationActions.navigate(page);
+    },
+    subscribe: listener => useNavigationStore.subscribe(selectPagerState, listener, { equalityFn: shallowEqual }),
+  };
 
   return {
     Navigation: navigationActions,
+    Pager: pagerNavigation,
     Route: RouteProvider,
-    handlePagerIndexChange,
     useNavigationStore,
   };
 }

--- a/src/navigation/createVirtualNavigator.ts
+++ b/src/navigation/createVirtualNavigator.ts
@@ -14,7 +14,10 @@ export type VirtualNavigator<VirtualRoute extends Route> = {
   getActiveRoute: () => VirtualRoute;
   getActiveRouteState: () => ActiveRouteState<VirtualRoute>;
   getParams: <R extends VirtualRoute>(route: R) => RouteParams<R> | undefined;
-  goBack: () => void;
+  /**
+   * Returns to the previous route, or starts a new path at the fallback when history is empty.
+   */
+  goBack: <R extends VirtualRoute>(fallbackRoute?: R, fallbackParams?: RouteParams<R>) => void;
   goForward: () => void;
   isRouteActive: (route: VirtualRoute) => boolean;
   navigate: <R extends VirtualRoute>(route: R, params?: RouteParams<R>) => void;
@@ -74,13 +77,29 @@ export function createVirtualNavigator<VirtualRoute extends Route>({
 
     getParams: route => get().params[route],
 
-    goBack: () => {
+    goBack: (...fallback) => {
+      const didSpecifyFallbackParams = fallback.length > 1;
+      const [fallbackRoute, fallbackParams] = fallback;
+
       set(state => {
-        if (!state.history.length) return state;
+        if (state.history.length) {
+          return {
+            activeRoute: state.history[state.history.length - 1],
+            future: [...state.future, state.activeRoute],
+            history: state.history.slice(0, -1),
+          };
+        }
+
+        if (fallbackRoute === undefined) return state;
+
+        const didParamsChange = didSpecifyFallbackParams && !shallowEqual(fallbackParams, state.params[fallbackRoute]);
+        if (state.activeRoute === fallbackRoute && !state.future.length && !didParamsChange) return state;
+
         return {
-          activeRoute: state.history[state.history.length - 1],
-          future: [...state.future, state.activeRoute],
-          history: state.history.slice(0, -1),
+          activeRoute: fallbackRoute,
+          future: [],
+          history: [],
+          params: didParamsChange ? { ...state.params, [fallbackRoute]: fallbackParams } : state.params,
         };
       });
       setActiveRoute(get().activeRoute);

--- a/src/navigation/pagerNavigation.ts
+++ b/src/navigation/pagerNavigation.ts
@@ -1,0 +1,16 @@
+export type PagerNavigationState<Page extends string> = {
+  back?: Page;
+  forward?: Page;
+  page: Page;
+};
+
+/** Navigation actions synchronously publish their resulting state to subscribers. */
+export type PagerNavigation<Page extends string> = {
+  /** Starts a new pager path and returns its authoritative first state. */
+  beginPath?: () => PagerNavigationState<Page>;
+  getState: () => PagerNavigationState<Page>;
+  goBack?: () => void;
+  goForward?: () => void;
+  navigate: (page: Page) => void;
+  subscribe: (listener: (state: PagerNavigationState<Page>) => void) => () => void;
+};

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -648,16 +648,8 @@ type RouteParams = {
   [Routes.CLOSE_POSITION_BOTTOM_SHEET]: {
     symbol: string;
   };
-  [Routes.PERPS_NAVIGATOR]:
-    | {
-        initialPerpsPage?: PerpsRoute;
-      }
-    | undefined;
-  [Routes.CASH_DEPOSIT_SETUP_SCREEN]:
-    | {
-        initialStep?: CashDepositSetupRoute;
-      }
-    | undefined;
+  [Routes.PERPS_NAVIGATOR]: undefined;
+  [Routes.CASH_DEPOSIT_SETUP_SCREEN]: undefined;
   [Routes.CASH_ADD_WALLET_SHEET]: {
     walletAddress: Address;
     cardId: string;


### PR DESCRIPTION
Fixes APP-3978

## What changed (plus any additional context for devs)

- Replaces the old `SmoothPager` imperative ref and page group model with declared page IDs and a navigation controller that owns the current page and back/forward history
- Supports navigation paths where multiple pages share the same parent while preserving the order in which pages were actually visited, and skips over intermediate pages when navigating between non-consecutive pages
- Manages page positions, swipe targets, and interrupted transitions on the UI thread, so rapid navigation and swipe reversals continue from the pages currently on screen and preserve their spring velocity
- Keeps each page frame mounted while mounting lazy content only after movement settles, and prepares navigation targets before the next transition
- Migrates Explainer sheets, Cash setup, the browser Control Panel, Discover, Perps, Polymarket, and the RNBW membership tier sheet to the new pager API

Note: I updated the circular dependency baseline here to avoid mixing with this PR's code changes: #7748

## Screen recordings / screenshots

https://github.com/user-attachments/assets/7003451a-62ef-4349-ba7b-97a9d4f7fe4b

## What to test
