### PR TITLE
test(CASH): cover immediate purchase transaction timestamps

### DIFF
--- a/src/features/cash/utils/buildCashPurchaseTransaction.test.ts
+++ b/src/features/cash/utils/buildCashPurchaseTransaction.test.ts
@@ -1,0 +1,35 @@
+import { OrderStatus, RampCryptoAsset, RampNetwork, type BuyOrder } from '../services/rampClient';
+import { buildCashPurchaseTransaction } from './buildCashPurchaseTransaction';
+
+jest.mock('@/utils/ethereumUtils', () => ({ getUniqueId: (address: string, chainId: number) => `${address}_${chainId}` }));
+jest.mock('@/utils/getUrlForTrustIconFallback', () => ({ __esModule: true, default: () => 'icon-url' }));
+
+const WALLET_ADDRESS = '0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed';
+const COMPLETED_ORDER: Extract<BuyOrder, { status: OrderStatus.Completed }> = {
+  id: 'order-1',
+  status: OrderStatus.Completed,
+  cryptoAmount: { amount: '50', asset: { asset: RampCryptoAsset.USDC, network: RampNetwork.Base } },
+  fiatAmount: { amount: '50', currency: 'USD' },
+  createdTime: '2026-06-24T18:31:25.000Z',
+  completedTime: '2026-06-24T18:31:31.000Z',
+  transactionHash: '0xtx',
+  walletAddress: WALLET_ADDRESS.toLowerCase(),
+};
+
+describe('buildCashPurchaseTransaction', () => {
+  afterEach(() => jest.restoreAllMocks());
+
+  it('timestamps an immediately completed purchase before history indexing', () => {
+    const now = 1750789891000;
+    jest.spyOn(Date, 'now').mockReturnValue(now);
+
+    const transaction = buildCashPurchaseTransaction({ order: COMPLETED_ORDER, walletAddress: WALLET_ADDRESS });
+
+    expect(transaction).toMatchObject({
+      hash: COMPLETED_ORDER.transactionHash,
+      status: 'pending',
+      timestamp: now,
+      type: 'purchase',
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- add direct regression coverage for the timestamp attached to an immediately completed CASH purchase
- keep the test focused on the behavior introduced by #7730: the activity row must remain visible before history indexing supplies `minedAt`

## Why

`buildCashPurchaseTransaction` now supplies a timestamp for a completed purchase, but the existing `cashBuyOrderStore` tests mock that builder and cannot catch a regression in the builder itself. This test fixes that coverage gap without changing production behavior.

## Validation

- `./node_modules/.bin/jest src/features/cash/utils/buildCashPurchaseTransaction.test.ts src/features/cash/stores/cashBuyOrderStore.test.ts --runInBand`
- `./node_modules/.bin/prettier --check src/features/cash/utils/buildCashPurchaseTransaction.test.ts`
- `./node_modules/.bin/eslint src/features/cash/utils/buildCashPurchaseTransaction.test.ts --quiet`

All focused checks pass locally.
