### PR TITLE
chore: fix .gitignore for .claude dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,3 +141,8 @@ anvil.log
 # deps-check output consumed by CI
 deps-report.md
 deps-comment.md
+
+# Agent workspaces
+.claude/*
+!.claude/CLAUDE.md
+!.claude/settings.local.json


### PR DESCRIPTION
`.claude` contains files we DO want checked in today like `CLAUDE.md` and `settings.local.json` but also contains things like subdir `worktrees` auto managed by the Claude harness for epheremeral worktrees, which we do not want to commit.

This change fixes the gitignore to ignore everything in the `.claude` dir EXCEPT the files we know we want. This is both future proof and as a bonus allows keeping personal Claude content per repo like skills being tested, tracking work documents etc without messing with local git exclude.