### PR TITLE
fix(logger): improve client side telemetry redaction around seeds

### DIFF
--- a/src/logger/redactIdentifiers.ts
+++ b/src/logger/redactIdentifiers.ts
@@ -1,12 +1,11 @@
+import { redactSeedPhrases } from '@/logger/redactSeedPhrases';
+
 /**
- * Replaces identifier-shaped values in free text on its way to Sentry. Shape-based rather than a
- * known-value list, because SDKs interpolate their own values into their own messages: e.g an ethers
- * `CALL_EXCEPTION` carries the JSON-RPC request id, so one recurring failure reads as a different
- * string every time. That costs titles and message search rather than grouping, which for these
- * events keys on the stack.
- *
- * Not a secret filter, and must not be relied on as one. Anything below the length floor or
- * containing punctuation passes straight through.
+ * Replaces identifier-shaped and secret values in free text on its way to Sentry. Shape-based rather
+ * than a known-value list, because SDKs interpolate their own values into their own messages: e.g an
+ * ethers `CALL_EXCEPTION` carries the JSON-RPC request id, so one recurring failure reads as a
+ * different string every time. That costs titles and message search rather than grouping, which for
+ * these events keys on the stack.
  */
 const PATTERNS: [RegExp, string][] = [
   // Boundaries are hand-written because `\b` counts `_` as a word character, so it skips the address
@@ -27,5 +26,6 @@ const PATTERNS: [RegExp, string][] = [
 ];
 
 export function redactIdentifiers(text: string): string {
-  return PATTERNS.reduce((redacted, [pattern, placeholder]) => redacted.replace(pattern, placeholder), text);
+  const withoutSeedPhrases = redactSeedPhrases(text);
+  return PATTERNS.reduce((redacted, [pattern, placeholder]) => redacted.replace(pattern, placeholder), withoutSeedPhrases);
 }

--- a/src/logger/redactSeedPhrases.test.ts
+++ b/src/logger/redactSeedPhrases.test.ts
@@ -3,6 +3,8 @@ import { describe, expect, test } from '@jest/globals';
 import { redactIdentifiers } from '@/logger/redactIdentifiers';
 import { redactSeedPhrases } from '@/logger/redactSeedPhrases';
 
+const titleCase = (phrase: string) => phrase.replace(/\b[a-z]/g, letter => letter.toUpperCase());
+
 const TWELVE_WORDS = 'legal winner thank year wave sausage worth useful legal winner thank yellow';
 const TWENTY_FOUR_WORDS =
   'letter advice cage absurd amount doctor acoustic avoid letter advice cage above ' +
@@ -65,6 +67,35 @@ describe('redactSeedPhrases', () => {
     const wrapped = 'legal winner thank year wave\nsausage  worth\tuseful legal winner thank yellow';
 
     expect(redactSeedPhrases(wrapped)).toBe('[seed phrase]');
+  });
+
+  test('catches a mnemonic whatever its casing', () => {
+    // A canonical mnemonic is lowercase, but a phrase that has been through a keyboard, a note app
+    // or a UI that renders it in title case has not stayed canonical. The net assumes nothing.
+    expect(redactSeedPhrases(titleCase(TWELVE_WORDS))).toBe('[seed phrase]');
+    expect(redactSeedPhrases(TWELVE_WORDS.toUpperCase())).toBe('[seed phrase]');
+    expect(redactSeedPhrases(titleCase(TWENTY_FOUR_WORDS))).toBe('[seed phrase]');
+  });
+
+  test('catches a mnemonic whose casing is inconsistent word to word', () => {
+    const mixed = 'Legal WINNER thank Year wave SAUSAGE worth Useful legal WINNER thank Yellow';
+
+    expect(redactSeedPhrases(mixed)).toBe('[seed phrase]');
+  });
+
+  test('redacts the whole phrase when only the first word is capitalized', () => {
+    // The eleven lowercase words after it are a run in their own right, so this case already
+    // redacted to `Legal [seed phrase]`. One word leaves nothing to brute force, but it is a leak.
+    const [first, ...rest] = TWELVE_WORDS.split(' ');
+    const capitalized = [titleCase(first), ...rest].join(' ');
+
+    expect(redactSeedPhrases(capitalized)).toBe('[seed phrase]');
+  });
+
+  test('leaves title-cased prose alone, so folding case did not widen the net', () => {
+    const viem = 'The Total Cost (Gas * Gas Fee + Value) Of Executing This Transaction Exceeds The Balance Of The Account';
+
+    expect(redactSeedPhrases(viem)).toBe(viem);
   });
 
   test('runs as part of redactIdentifiers, so every caller gets it', () => {

--- a/src/logger/redactSeedPhrases.test.ts
+++ b/src/logger/redactSeedPhrases.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, test } from '@jest/globals';
+
+import { redactIdentifiers } from '@/logger/redactIdentifiers';
+import { redactSeedPhrases } from '@/logger/redactSeedPhrases';
+
+const TWELVE_WORDS = 'legal winner thank year wave sausage worth useful legal winner thank yellow';
+const TWENTY_FOUR_WORDS =
+  'letter advice cage absurd amount doctor acoustic avoid letter advice cage above ' +
+  'letter advice cage absurd amount doctor acoustic avoid letter advice cage abstract';
+
+describe('redactSeedPhrases', () => {
+  test('replaces a mnemonic with a placeholder that reads as an alarm', () => {
+    expect(redactSeedPhrases(TWELVE_WORDS)).toBe('[seed phrase]');
+    expect(redactSeedPhrases(TWENTY_FOUR_WORDS)).toBe('[seed phrase]');
+  });
+
+  test('keeps the surrounding message, so the report stays diagnosable', () => {
+    const message = `Failed to import wallet: ${TWELVE_WORDS} is not valid`;
+
+    expect(redactSeedPhrases(message)).toBe('Failed to import wallet: [seed phrase] is not valid');
+  });
+
+  test('catches a mnemonic wherever the words came from, not just the canonical order', () => {
+    const shuffled = 'zebra youth wolf window velvet unique tunnel trophy trigger';
+
+    expect(redactSeedPhrases(shuffled)).toBe('[seed phrase]');
+  });
+
+  test('fires at exactly eight words and not at seven', () => {
+    const words = 'legal winner thank year wave sausage worth useful'.split(' ');
+
+    expect(redactSeedPhrases(words.slice(0, 7).join(' '))).toBe('legal winner thank year wave sausage worth');
+    expect(redactSeedPhrases(words.join(' '))).toBe('[seed phrase]');
+  });
+
+  test('leaves ordinary prose alone, because connectives are not wordlist words', () => {
+    // viem's insufficient-funds message: eleven lowercase words in a row, but the longest run of
+    // wordlist words in it is two. That gap is the whole reason this rule keys on membership rather
+    // than on shape.
+    const viem = 'The total cost (gas * gas fee + value) of executing this transaction exceeds the balance of the account';
+
+    expect(redactSeedPhrases(viem)).toBe(viem);
+  });
+
+  test('leaves error text that happens to contain wordlist words', () => {
+    const messages = [
+      'Error while restoring back up',
+      'missing response for request to the rpc node, will retry once more',
+      'unable to decrypt private data on android, prompting for pin again',
+      'Failed to fetch NFT collections data',
+    ];
+
+    for (const message of messages) {
+      expect(redactSeedPhrases(message)).toBe(message);
+    }
+  });
+
+  test('preserves whitespace in text it does not redact', () => {
+    const spaced = 'first  line\n\tsecond   line with several   ordinary words here';
+
+    expect(redactSeedPhrases(spaced)).toBe(spaced);
+  });
+
+  test('catches a mnemonic split across newlines and irregular spacing', () => {
+    const wrapped = 'legal winner thank year wave\nsausage  worth\tuseful legal winner thank yellow';
+
+    expect(redactSeedPhrases(wrapped)).toBe('[seed phrase]');
+  });
+
+  test('runs as part of redactIdentifiers, so every caller gets it', () => {
+    expect(redactIdentifiers(`restore failed for ${TWELVE_WORDS}`)).toBe('restore failed for [seed phrase]');
+  });
+
+  test('collapses to one message regardless of which mnemonic appeared', () => {
+    const first = redactIdentifiers(`restore failed for ${TWELVE_WORDS}`);
+    const second = redactIdentifiers(`restore failed for ${TWENTY_FOUR_WORDS}`);
+
+    expect(first).toBe(second);
+  });
+});

--- a/src/logger/redactSeedPhrases.ts
+++ b/src/logger/redactSeedPhrases.ts
@@ -5,10 +5,14 @@ const MIN_RUN = 8;
 const PLACEHOLDER = '[seed phrase]';
 
 /**
- * Every BIP-39 English word is 3 to 8 lowercase letters, so this only has to consider runs of those.
- * Narrow enough to skip most text outright, since this runs over every string on every event.
+ * Every BIP-39 English word is 3 to 8 letters, so this only has to consider runs of those. Narrow
+ * enough to skip most text outright, since this runs over every string on every event.
+ *
+ * Case-insensitive to err on the side of caution. A canonical mnemonic is lowercase, but this is a
+ * safety net, so it should not assume the string that reaches it is canonical. Folding case admits
+ * no new words, so the wordlist is still what keeps ordinary prose out.
  */
-const CANDIDATE_RUN = /[a-z]{3,8}(?:\s+[a-z]{3,8})+/g;
+const CANDIDATE_RUN = /[a-z]{3,8}(?:\s+[a-z]{3,8})+/gi;
 
 export function redactSeedPhrases(text: string): string {
   return text.replace(CANDIDATE_RUN, run => {
@@ -21,7 +25,7 @@ export function redactSeedPhrases(text: string): string {
 
     while (index < words.length) {
       let end = index;
-      while (end < words.length && BIP39_WORDS.has(words[end])) end += 1;
+      while (end < words.length && BIP39_WORDS.has(words[end].toLowerCase())) end += 1;
 
       if (end - index >= MIN_RUN) {
         output.push(PLACEHOLDER);

--- a/src/logger/redactSeedPhrases.ts
+++ b/src/logger/redactSeedPhrases.ts
@@ -1,0 +1,40 @@
+import englishWordlist from 'bip39/src/wordlists/english.json';
+
+const BIP39_WORDS = new Set<string>(englishWordlist);
+const MIN_RUN = 8;
+const PLACEHOLDER = '[seed phrase]';
+
+/**
+ * Every BIP-39 English word is 3 to 8 lowercase letters, so this only has to consider runs of those.
+ * Narrow enough to skip most text outright, since this runs over every string on every event.
+ */
+const CANDIDATE_RUN = /[a-z]{3,8}(?:\s+[a-z]{3,8})+/g;
+
+export function redactSeedPhrases(text: string): string {
+  return text.replace(CANDIDATE_RUN, run => {
+    const words = run.split(/\s+/);
+    if (words.length < MIN_RUN) return run;
+
+    const output: string[] = [];
+    let redacted = false;
+    let index = 0;
+
+    while (index < words.length) {
+      let end = index;
+      while (end < words.length && BIP39_WORDS.has(words[end])) end += 1;
+
+      if (end - index >= MIN_RUN) {
+        output.push(PLACEHOLDER);
+        redacted = true;
+        index = end;
+      } else {
+        output.push(words[index]);
+        index += 1;
+      }
+    }
+
+    // Leave the original untouched unless something was actually replaced, so ordinary prose keeps
+    // its own whitespace rather than being collapsed to single spaces by the rejoin below.
+    return redacted ? output.join(' ') : run;
+  });
+}

--- a/src/logger/sentry.ts
+++ b/src/logger/sentry.ts
@@ -80,6 +80,10 @@ function redactValues(container: Record<string, unknown> | unknown[], depth = 0)
 export const defaultOptions: Sentry.ReactNativeOptions = {
   attachStacktrace: true,
 
+  // Both default to false, but we want to explicit about it since these could reveal mnemonics etc.
+  attachScreenshot: false,
+  attachViewHierarchy: false,
+
   beforeBreadcrumb: sanitizeBreadcrumb,
   beforeSend(event, hint) {
     // iOS merges its own network breadcrumbs onto the event after `beforeBreadcrumb` has run, so this


### PR DESCRIPTION
Hardens our telemetry layer to redact bip39-looking phrases from logs. This is defense in depth before we add more sophisticated request logging as we don't have any provable cases of this leaking today.

Note that the redaction is english mnemonics only as we don't support anything else at import right now.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rainbow-me/rainbow/pull/7736?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

