### PR TITLE
fix(CASH): broken e2e - email step

### DIFF
--- a/e2e/flows/cash/Setup.yaml
+++ b/e2e/flows/cash/Setup.yaml
@@ -101,16 +101,8 @@ tags:
     id: cash-setup-next
 - extendedWaitUntil:
     visible:
-      text: 'Enter email'
+      id: cash-setup-success-action
     timeout: 10000
-- repeat:
-    while:
-      notVisible:
-        id: cash-setup-success-action
-    commands:
-      - tapOn:
-          id: cash-setup-next
-      - waitForAnimationToEnd
 - tapOn:
     id: cash-setup-success-action
 - assertVisible:


### PR DESCRIPTION
Fixes broken e2e - Email step was removed from the code, but not from the e2e tests

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rainbow-me/rainbow/pull/7737?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

