### PR TITLE
fix(wallet): preserve caught errors as causes in telemetry

### DIFF
--- a/src/features/backup/backup.ts
+++ b/src/features/backup/backup.ts
@@ -22,6 +22,7 @@ import {
   login,
   logoutFromGoogleDrive,
   normalizeAndroidBackupFilename,
+  parseBackupJson,
 } from '@/handlers/cloudBackup';
 import { WrappedAlert as Alert } from '@/helpers/alert';
 import walletBackupStepTypes from '@/helpers/walletBackupStepTypes';
@@ -487,7 +488,7 @@ async function restoreSpecificBackupIntoKeychain(backedUpData: BackedUpData, use
       }
 
       const valueStr = backedUpData[key];
-      const parsedValue = JSON.parse(valueStr);
+      const parsedValue = parseBackupJson(valueStr);
 
       let secretPhraseOrOldAndroidBackupPrivateKey: string | any; // TODO: Strengthen this type
       /*

--- a/src/features/backup/backup.ts
+++ b/src/features/backup/backup.ts
@@ -534,7 +534,7 @@ async function restoreSpecificBackupIntoKeychain(backedUpData: BackedUpData, use
     }
     return true;
   } catch (e) {
-    logger.error(new RainbowError(`[backup]: Error restoring specific backup into keychain: ${e}`));
+    logger.error(new RainbowError('[backup]: Error restoring specific backup into keychain', e));
     return false;
   }
 }
@@ -612,7 +612,7 @@ export async function fetchBackupPassword(): Promise<null | BackupPassword> {
     }
     return null;
   } catch (e) {
-    logger.error(new RainbowError(`[backup]: Error while fetching backup password: ${e}`));
+    logger.error(new RainbowError('[backup]: Error while fetching backup password', e));
     return null;
   }
 }

--- a/src/handlers/cloudBackup.test.ts
+++ b/src/handlers/cloudBackup.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, jest, test } from '@jest/globals';
+
+import { CLOUD_BACKUP_ERRORS, getDataFromCloud } from './cloudBackup';
+
+jest.mock('react-native-cloud-fs', () => ({
+  getIcloudDocument: jest.fn(() => Promise.resolve('encrypted-blob')),
+  listFiles: jest.fn(() => Promise.resolve({ files: [{ id: 'file-id', name: 'UserData.json' }] })),
+  loginIfNeeded: jest.fn(),
+}));
+
+jest.mock('react-native-fs', () => ({ unlink: jest.fn(), writeFile: jest.fn() }));
+
+jest.mock('./aesEncryption', () => {
+  const state = { plaintext: '' };
+
+  return {
+    __esModule: true,
+    default: class AesEncryptor {
+      decrypt() {
+        return Promise.resolve(state.plaintext);
+      }
+    },
+    state,
+  };
+});
+
+const encryptor = jest.requireMock<{ state: { plaintext: string } }>('./aesEncryption');
+
+// Decryption has already succeeded by the time the parse runs, so what fails to parse here is
+// decrypted backup contents. A phrase is the worst case that can be sitting in it.
+const DECRYPTED_PLAINTEXT = 'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about';
+
+describe('getDataFromCloud', () => {
+  beforeEach(() => {
+    encryptor.state.plaintext = '';
+  });
+
+  test('returns the backup when it parses', async () => {
+    encryptor.state.plaintext = JSON.stringify({ wallets: { id: 'wallet' } });
+
+    await expect(getDataFromCloud('password', 'UserData.json')).resolves.toEqual({ wallets: { id: 'wallet' } });
+  });
+
+  test('reports a malformed backup as its own error, not as a wrong password', async () => {
+    // Reusing ERROR_DECRYPTING_DATA would tell the user their password was wrong and drop the report,
+    // because restoreCloudBackup matches that constant and returns before it reaches logger.error.
+    encryptor.state.plaintext = DECRYPTED_PLAINTEXT;
+
+    const error = await getDataFromCloud('password', 'UserData.json').catch((e: Error) => e);
+
+    expect(error.message).toBe(CLOUD_BACKUP_ERRORS.MALFORMED_BACKUP_DATA);
+    expect(error.message).not.toBe(CLOUD_BACKUP_ERRORS.ERROR_DECRYPTING_DATA);
+  });
+
+  test('keeps the plaintext it failed to parse out of the error it throws', async () => {
+    // JSON.parse quotes its own input back inside the SyntaxError, e.g. `Unexpected token 'a',
+    // "abandon ab"... is not valid JSON`. That error must not be what travels onward.
+    encryptor.state.plaintext = DECRYPTED_PLAINTEXT;
+
+    const error = await getDataFromCloud('password', 'UserData.json').catch((e: Error) => e);
+
+    expect(error.message).toBe(CLOUD_BACKUP_ERRORS.MALFORMED_BACKUP_DATA);
+    expect(error.message).not.toContain('abandon');
+    expect(error.message).not.toContain('is not valid JSON');
+  });
+});
+
+describe('CLOUD_BACKUP_ERRORS', () => {
+  test('appends new errors, because getUserError shows users the index as an error code', () => {
+    // getUserError's default branch reports values(CLOUD_BACKUP_ERRORS).indexOf(message), so
+    // inserting anywhere above the end silently renumbers the codes users are told to quote.
+    const messages = Object.values(CLOUD_BACKUP_ERRORS);
+
+    expect(messages.indexOf(CLOUD_BACKUP_ERRORS.WRONG_PIN)).toBe(10);
+    expect(messages[messages.length - 1]).toBe(CLOUD_BACKUP_ERRORS.MALFORMED_BACKUP_DATA);
+  });
+});

--- a/src/handlers/cloudBackup.test.ts
+++ b/src/handlers/cloudBackup.test.ts
@@ -94,7 +94,6 @@ describe('parseBackupJson', () => {
 
     expect(error.message).toBe(CLOUD_BACKUP_ERRORS.MALFORMED_BACKUP_DATA);
     expect(error.cause).toBeUndefined();
-    expect(JSON.stringify(error)).not.toContain('abandon');
   });
 });
 

--- a/src/handlers/cloudBackup.test.ts
+++ b/src/handlers/cloudBackup.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, jest, test } from '@jest/globals';
 
-import { CLOUD_BACKUP_ERRORS, getDataFromCloud } from './cloudBackup';
+import { CLOUD_BACKUP_ERRORS, getDataFromCloud, parseBackupJson } from './cloudBackup';
 
 jest.mock('react-native-cloud-fs', () => ({
   getIcloudDocument: jest.fn(() => Promise.resolve('encrypted-blob')),
@@ -62,6 +62,39 @@ describe('getDataFromCloud', () => {
     expect(error.message).toBe(CLOUD_BACKUP_ERRORS.MALFORMED_BACKUP_DATA);
     expect(error.message).not.toContain('abandon');
     expect(error.message).not.toContain('is not valid JSON');
+  });
+});
+
+describe('parseBackupJson', () => {
+  test('parses a well-formed entry', () => {
+    expect(parseBackupJson('{"seedphrase":"secret"}')).toEqual({ seedphrase: 'secret' });
+  });
+
+  test('reports malformed data without quoting what it failed to parse', () => {
+    let error!: Error;
+    try {
+      parseBackupJson(DECRYPTED_PLAINTEXT);
+    } catch (e) {
+      error = e as Error;
+    }
+
+    expect(error.message).toBe(CLOUD_BACKUP_ERRORS.MALFORMED_BACKUP_DATA);
+    expect(error.message).not.toContain('abandon');
+  });
+
+  test('carries no cause, so the parse error cannot travel onward as one', () => {
+    // Attaching the SyntaxError as a cause would put the quoted fragment back into telemetry, and
+    // the seed-phrase rule needs eight consecutive wordlist words to catch it.
+    let error!: Error;
+    try {
+      parseBackupJson(DECRYPTED_PLAINTEXT);
+    } catch (e) {
+      error = e as Error;
+    }
+
+    expect(error.message).toBe(CLOUD_BACKUP_ERRORS.MALFORMED_BACKUP_DATA);
+    expect(error.cause).toBeUndefined();
+    expect(JSON.stringify(error)).not.toContain('abandon');
   });
 });
 

--- a/src/handlers/cloudBackup.ts
+++ b/src/handlers/cloudBackup.ts
@@ -30,6 +30,20 @@ export const CLOUD_BACKUP_ERRORS = {
   MALFORMED_BACKUP_DATA: 'Backup data is malformed',
 };
 
+/**
+ * Decryption has already succeeded wherever this runs, so a parse failure means corrupt data rather
+ * than a wrong password, and what failed to parse is backup contents. `JSON.parse` quotes part of its
+ * input back inside the `SyntaxError` it throws, so that error is dropped rather than logged, wrapped
+ * or attached as a cause.
+ */
+export function parseBackupJson(value: string) {
+  try {
+    return JSON.parse(value);
+  } catch {
+    throw new Error(CLOUD_BACKUP_ERRORS.MALFORMED_BACKUP_DATA);
+  }
+}
+
 export function normalizeAndroidBackupFilename(filename: string) {
   return filename.replace(`${REMOTE_BACKUP_WALLET_DIR}/`, '');
 }
@@ -200,14 +214,7 @@ export async function getDataFromCloud(backupPassword: any, filename: string | n
     logger.debug(`[cloudBackup]: Got cloud document ${filename}`);
     const backedUpDataStringified = await encryptor.decrypt(backupPassword, encryptedData);
     if (backedUpDataStringified) {
-      try {
-        return JSON.parse(backedUpDataStringified);
-      } catch {
-        // Decryption already succeeded, so this is a corrupt backup rather than a wrong password, and
-        // what failed to parse is decrypted backup contents. JSON.parse quotes its input back inside
-        // the SyntaxError it throws, so that error is dropped rather than logged or passed as a cause.
-        throw new Error(CLOUD_BACKUP_ERRORS.MALFORMED_BACKUP_DATA);
-      }
+      return parseBackupJson(backedUpDataStringified);
     } else {
       logger.error(new RainbowError('[cloudBackup]: We couldnt decrypt the data'));
       const error = new Error(CLOUD_BACKUP_ERRORS.ERROR_DECRYPTING_DATA);

--- a/src/handlers/cloudBackup.ts
+++ b/src/handlers/cloudBackup.ts
@@ -27,6 +27,7 @@ export const CLOUD_BACKUP_ERRORS = {
   WALLET_BACKUP_STATUS_UPDATE_FAILED: 'Update wallet backup status failed',
   MISSING_PIN: 'The PIN code you entered is invalid',
   WRONG_PIN: 'The PIN code you entered is wrong',
+  MALFORMED_BACKUP_DATA: 'Backup data is malformed',
 };
 
 export function normalizeAndroidBackupFilename(filename: string) {
@@ -199,8 +200,14 @@ export async function getDataFromCloud(backupPassword: any, filename: string | n
     logger.debug(`[cloudBackup]: Got cloud document ${filename}`);
     const backedUpDataStringified = await encryptor.decrypt(backupPassword, encryptedData);
     if (backedUpDataStringified) {
-      const backedUpData = JSON.parse(backedUpDataStringified);
-      return backedUpData;
+      try {
+        return JSON.parse(backedUpDataStringified);
+      } catch {
+        // Decryption already succeeded, so this is a corrupt backup rather than a wrong password, and
+        // what failed to parse is decrypted backup contents. JSON.parse quotes its input back inside
+        // the SyntaxError it throws, so that error is dropped rather than logged or passed as a cause.
+        throw new Error(CLOUD_BACKUP_ERRORS.MALFORMED_BACKUP_DATA);
+      }
     } else {
       logger.error(new RainbowError('[cloudBackup]: We couldnt decrypt the data'));
       const error = new Error(CLOUD_BACKUP_ERRORS.ERROR_DECRYPTING_DATA);

--- a/src/hooks/useImportingWallet.ts
+++ b/src/hooks/useImportingWallet.ts
@@ -368,7 +368,7 @@ export default function useImportingWallet({
           }, 100);
         }
       } catch (error) {
-        logger.error(new RainbowError(`[useImportingWallet]: Error importing wallet: ${error}`));
+        logger.error(new RainbowError('[useImportingWallet]: Error importing wallet', error));
         resetOnFailure();
 
         // Refocus input for retry

--- a/src/hooks/useWalletCloudBackup.ts
+++ b/src/hooks/useWalletCloudBackup.ts
@@ -32,6 +32,8 @@ export function getUserError(e: Error) {
       return i18n.t(i18n.l.back_up.errors.missing_pin);
     case CLOUD_BACKUP_ERRORS.WRONG_PIN:
       return i18n.t(i18n.l.back_up.wrong_pin);
+    case CLOUD_BACKUP_ERRORS.MALFORMED_BACKUP_DATA:
+      return i18n.t(i18n.l.back_up.errors.malformed_backup_data);
     default:
       return i18n.t(i18n.l.back_up.errors.generic, {
         errorCodes: values(CLOUD_BACKUP_ERRORS).indexOf(e.message),

--- a/src/hooks/useWalletCloudBackup.ts
+++ b/src/hooks/useWalletCloudBackup.ts
@@ -150,7 +150,7 @@ export default function useWalletCloudBackup() {
       } catch (e: any) {
         const userError = getUserError(e);
         !!onError && onError(userError);
-        logger.error(new RainbowError(`[useWalletCloudBackup]: error while trying to backup wallet to ${cloudPlatform}: ${e}`));
+        logger.error(new RainbowError(`[useWalletCloudBackup]: error while trying to backup wallet to ${cloudPlatform}`, e));
         analytics.track(
           cloudPlatform === 'Google Drive' ? analytics.event.errorDuringGoogleDriveBackup : analytics.event.errorDuringICloudBackup,
           {
@@ -169,7 +169,7 @@ export default function useWalletCloudBackup() {
         !!onSuccess && onSuccess(password);
         return true;
       } catch (e) {
-        logger.error(new RainbowError(`[useWalletCloudBackup]: error while trying to save wallet backup state: ${e}`));
+        logger.error(new RainbowError('[useWalletCloudBackup]: error while trying to save wallet backup state', e));
         const userError = getUserError(new Error(CLOUD_BACKUP_ERRORS.WALLET_BACKUP_STATUS_UPDATE_FAILED));
         !!onError && onError(userError);
         analytics.track(analytics.event.errorUpdatingBackupStatus, {

--- a/src/languages/en_US.json
+++ b/src/languages/en_US.json
@@ -58,7 +58,8 @@
         "no_keys_found": "No keys found. Please try again.",
         "backup_not_found": "Backup not found. Please try again.",
         "no_account_found": "Unable to retrieve backup files. Make sure you're logged in.",
-        "damaged_wallet": "Unable to backup wallet. Missing keychain data."
+        "damaged_wallet": "Unable to backup wallet. Missing keychain data.",
+        "malformed_backup_data": "Your existing backup appears to be damaged, so we can't add to it."
       },
       "wrong_pin": "The PIN code you entered was incorrect and we can't make a backup. Please try again with the correct code.",
       "wallet_group_title_plural": "Wallet Group %{walletGroupNumber}",


### PR DESCRIPTION
We have multiple callsites aroud the wallet which embedd caught errors as substrings when logging to telemetry instead of passing the sub-error as is. Furthermore, JSON parse errors during cloud backup restore quotes part of what it was parsing back inside its own message, and we don't want to forward the error with that content up the callstack to end up potentially logged to telemetry.

This change fixes both issues, and shows a new dedicated "Your backup is damaged" error to users when the JSON parse fails.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rainbow-me/rainbow/pull/7738?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

