### PR TITLE
[Cash]: Add setup progress indicator

### DIFF
--- a/src/features/cash/screens/cash-deposit-setup/components/SetupProgressIndicator.tsx
+++ b/src/features/cash/screens/cash-deposit-setup/components/SetupProgressIndicator.tsx
@@ -36,7 +36,7 @@ export const SetupProgressIndicator = memo(function SetupProgressIndicator() {
     };
   });
 
-  const progressStyle = useAnimatedStyle(() => {
+  const progressBarStyle = useAnimatedStyle(() => {
     const backgroundColor = fillColor.value;
     return {
       backgroundColor,
@@ -49,22 +49,24 @@ export const SetupProgressIndicator = memo(function SetupProgressIndicator() {
     () => blue,
     (current, previous) => {
       if (previous === null) return;
-      if (exitProgress.value === 0) fillColor.value = current;
+      const isBarStillBlue = progress.value < 1 && exitProgress.value === 0;
+      if (isBarStillBlue) fillColor.value = current;
     },
     [blue]
   );
 
   useAnimatedReaction(
     () => progress.value,
-    (progress, previous) => {
+    (current, previous) => {
       if (previous === null) return;
 
-      if (progress === 1 && previous < 1 && exitProgress.value === 0) {
-        fillColor.value = withTiming(green, TIMING_CONFIGS.slowestFadeConfig, isFinished => {
-          if (isFinished) exitProgress.value = withTiming(1, TIMING_CONFIGS.slowestFadeConfig);
-        });
-        triggerHaptics('notificationSuccess');
-      }
+      const didCompleteSetup = current === 1 && previous < 1 && exitProgress.value === 0;
+      if (!didCompleteSetup) return;
+
+      fillColor.value = withTiming(green, TIMING_CONFIGS.slowestFadeConfig, isFinished => {
+        if (isFinished) exitProgress.value = withTiming(1, TIMING_CONFIGS.slowestFadeConfig);
+      });
+      triggerHaptics('notificationSuccess');
     },
     [green]
   );
@@ -79,7 +81,7 @@ export const SetupProgressIndicator = memo(function SetupProgressIndicator() {
       style={[styles.container, containerStyle]}
       width={INDICATOR_WIDTH}
     >
-      <Animated.View style={[styles.progress, { backgroundColor: blue }, progressStyle]} />
+      <Animated.View style={[styles.progressBar, { backgroundColor: blue }, progressBarStyle]} />
     </Box>
   );
 });
@@ -99,7 +101,7 @@ const styles = StyleSheet.create({
     position: 'absolute',
     top: '50%',
   },
-  progress: {
+  progressBar: {
     borderCurve: 'continuous',
     borderRadius: INDICATOR_HEIGHT / 2,
     height: '100%',

--- a/src/features/cash/screens/cash-deposit-setup/components/SetupProgressIndicator.tsx
+++ b/src/features/cash/screens/cash-deposit-setup/components/SetupProgressIndicator.tsx
@@ -1,7 +1,15 @@
 import { memo } from 'react';
 import { StyleSheet } from 'react-native';
 
-import Animated, { useAnimatedStyle, withSpring, withTiming } from 'react-native-reanimated';
+import Animated, {
+  useAnimatedReaction,
+  useAnimatedStyle,
+  useDerivedValue,
+  useSharedValue,
+  withSpring,
+  withTiming,
+} from 'react-native-reanimated';
+import { triggerHaptics } from 'react-native-turbo-haptics';
 
 import { SPRING_CONFIGS, TIMING_CONFIGS } from '@/components/animations/animationConfigs';
 import { Box, useForegroundColor } from '@/design-system';
@@ -20,19 +28,40 @@ const PROGRESS_STEP_COUNT = FINAL_PROGRESS_STEP_INDEX - FIRST_PROGRESS_STEP_INDE
 
 export const SetupProgressIndicator = memo(function SetupProgressIndicator() {
   const blue = useForegroundColor('blue');
+  const green = useForegroundColor('green');
+  const fillColor = useSharedValue(blue);
+
+  const exitProgress = useSharedValue(0);
   const progress = useStoreSharedValue(useCashDepositSetupNavigationStore, s => getSetupProgress(s.activeRoute));
+  const showProgressBar = useDerivedValue(() => progress.value > 0 && exitProgress.value < 1);
 
   const containerStyle = useAnimatedStyle(() => {
-    const visible = progress.value > 0;
+    const show = showProgressBar.value;
     return {
-      opacity: withTiming(visible ? 1 : 0, TIMING_CONFIGS.buttonPressConfig),
-      transform: [{ scale: withTiming(visible ? 1 : 1.02, TIMING_CONFIGS.buttonPressConfig) }],
+      opacity: withTiming(show ? 1 : 0, TIMING_CONFIGS.slowFadeConfig),
+      transform: [{ scale: withTiming(show ? 1 : 0.925, TIMING_CONFIGS.slowFadeConfig) }],
     };
   });
 
   const progressStyle = useAnimatedStyle(() => ({
+    backgroundColor: fillColor.value,
     width: withSpring(progress.value * INDICATOR_WIDTH, SPRING_CONFIGS.snappyMediumSpringConfig),
   }));
+
+  useAnimatedReaction(
+    () => progress.value,
+    (progress, previous) => {
+      if (previous === null || exitProgress.value !== 0) return;
+
+      if (progress === 1 && previous < 1) {
+        fillColor.value = withTiming(green, TIMING_CONFIGS.slowestFadeConfig, isFinished => {
+          if (isFinished) exitProgress.value = withTiming(1, TIMING_CONFIGS.slowestFadeConfig);
+        });
+        triggerHaptics('notificationSuccess');
+      }
+    },
+    []
+  );
 
   return (
     <Box

--- a/src/features/cash/screens/cash-deposit-setup/components/SetupProgressIndicator.tsx
+++ b/src/features/cash/screens/cash-deposit-setup/components/SetupProgressIndicator.tsx
@@ -38,22 +38,32 @@ export const SetupProgressIndicator = memo(function SetupProgressIndicator() {
 
   const progressStyle = useAnimatedStyle(() => ({
     backgroundColor: fillColor.value,
+    shadowColor: fillColor.value,
     width: withTiming(progress.value * INDICATOR_WIDTH, TIMING_CONFIGS.slowestFadeConfig),
   }));
 
   useAnimatedReaction(
+    () => blue,
+    (current, previous) => {
+      if (previous === null) return;
+      if (exitProgress.value === 0) fillColor.value = current;
+    },
+    [blue]
+  );
+
+  useAnimatedReaction(
     () => progress.value,
     (progress, previous) => {
-      if (previous === null || exitProgress.value !== 0) return;
+      if (previous === null) return;
 
-      if (progress === 1 && previous < 1) {
+      if (progress === 1 && previous < 1 && exitProgress.value === 0) {
         fillColor.value = withTiming(green, TIMING_CONFIGS.slowestFadeConfig, isFinished => {
           if (isFinished) exitProgress.value = withTiming(1, TIMING_CONFIGS.slowestFadeConfig);
         });
         triggerHaptics('notificationSuccess');
       }
     },
-    []
+    [green]
   );
 
   return (
@@ -66,7 +76,7 @@ export const SetupProgressIndicator = memo(function SetupProgressIndicator() {
       style={[styles.container, containerStyle]}
       width={INDICATOR_WIDTH}
     >
-      <Animated.View style={[styles.progress, { backgroundColor: blue, shadowColor: blue }, progressStyle]} />
+      <Animated.View style={[styles.progress, { backgroundColor: blue }, progressStyle]} />
     </Box>
   );
 });
@@ -82,6 +92,7 @@ const styles = StyleSheet.create({
     left: '50%',
     marginLeft: -INDICATOR_WIDTH / 2,
     marginTop: -INDICATOR_HEIGHT / 2,
+    overflow: 'visible',
     position: 'absolute',
     top: '50%',
   },
@@ -89,8 +100,8 @@ const styles = StyleSheet.create({
     borderCurve: 'continuous',
     borderRadius: INDICATOR_HEIGHT / 2,
     height: '100%',
-    shadowOffset: { height: 0, width: 0 },
-    shadowOpacity: 0.4,
-    shadowRadius: 5,
+    shadowOffset: { height: 3, width: 0 },
+    shadowOpacity: 0.24,
+    shadowRadius: 6,
   },
 });

--- a/src/features/cash/screens/cash-deposit-setup/components/SetupProgressIndicator.tsx
+++ b/src/features/cash/screens/cash-deposit-setup/components/SetupProgressIndicator.tsx
@@ -1,0 +1,74 @@
+import { memo } from 'react';
+import { StyleSheet } from 'react-native';
+
+import Animated, { useAnimatedStyle, withSpring, withTiming } from 'react-native-reanimated';
+
+import { SPRING_CONFIGS, TIMING_CONFIGS } from '@/components/animations/animationConfigs';
+import { Box, useForegroundColor } from '@/design-system';
+import Routes from '@/navigation/routesNames';
+import { useStoreSharedValue } from '@/state/internal/hooks/useStoreSharedValue';
+
+import { useCashDepositSetupNavigationStore } from '../cashDepositSetupNavigator';
+import { SETUP_STEP_ORDER } from '../steps';
+
+const INDICATOR_HEIGHT = 8;
+const INDICATOR_WIDTH = 96;
+
+const FIRST_PROGRESS_STEP_INDEX = SETUP_STEP_ORDER.indexOf(Routes.CASH_SETUP_IDENTITY);
+const FINAL_PROGRESS_STEP_INDEX = SETUP_STEP_ORDER.indexOf(Routes.CASH_SETUP_ALL_DONE);
+const PROGRESS_STEP_COUNT = FINAL_PROGRESS_STEP_INDEX - FIRST_PROGRESS_STEP_INDEX + 1;
+
+export const SetupProgressIndicator = memo(function SetupProgressIndicator() {
+  const blue = useForegroundColor('blue');
+  const progress = useStoreSharedValue(useCashDepositSetupNavigationStore, s => getSetupProgress(s.activeRoute));
+
+  const containerStyle = useAnimatedStyle(() => {
+    const visible = progress.value > 0;
+    return {
+      opacity: withTiming(visible ? 1 : 0, TIMING_CONFIGS.buttonPressConfig),
+      transform: [{ scale: withTiming(visible ? 1 : 1.02, TIMING_CONFIGS.buttonPressConfig) }],
+    };
+  });
+
+  const progressStyle = useAnimatedStyle(() => ({
+    width: withSpring(progress.value * INDICATOR_WIDTH, SPRING_CONFIGS.snappyMediumSpringConfig),
+  }));
+
+  return (
+    <Box
+      as={Animated.View}
+      background="fillSecondary"
+      borderRadius={INDICATOR_HEIGHT / 2}
+      height={INDICATOR_HEIGHT}
+      pointerEvents="none"
+      style={[styles.container, containerStyle]}
+      width={INDICATOR_WIDTH}
+    >
+      <Animated.View style={[styles.progress, { backgroundColor: blue, shadowColor: blue }, progressStyle]} />
+    </Box>
+  );
+});
+
+function getSetupProgress(activeRoute: (typeof SETUP_STEP_ORDER)[number]): number {
+  const activeStepIndex = SETUP_STEP_ORDER.indexOf(activeRoute);
+  if (activeStepIndex < FIRST_PROGRESS_STEP_INDEX || activeStepIndex > FINAL_PROGRESS_STEP_INDEX) return 0;
+  return (activeStepIndex - FIRST_PROGRESS_STEP_INDEX + 1) / PROGRESS_STEP_COUNT;
+}
+
+const styles = StyleSheet.create({
+  container: {
+    left: '50%',
+    marginLeft: -INDICATOR_WIDTH / 2,
+    marginTop: -INDICATOR_HEIGHT / 2,
+    position: 'absolute',
+    top: '50%',
+  },
+  progress: {
+    borderCurve: 'continuous',
+    borderRadius: INDICATOR_HEIGHT / 2,
+    height: '100%',
+    shadowOffset: { height: 0, width: 0 },
+    shadowOpacity: 0.4,
+    shadowRadius: 5,
+  },
+});

--- a/src/features/cash/screens/cash-deposit-setup/components/SetupProgressIndicator.tsx
+++ b/src/features/cash/screens/cash-deposit-setup/components/SetupProgressIndicator.tsx
@@ -36,11 +36,14 @@ export const SetupProgressIndicator = memo(function SetupProgressIndicator() {
     };
   });
 
-  const progressStyle = useAnimatedStyle(() => ({
-    backgroundColor: fillColor.value,
-    shadowColor: fillColor.value,
-    width: withTiming(progress.value * INDICATOR_WIDTH, TIMING_CONFIGS.slowestFadeConfig),
-  }));
+  const progressStyle = useAnimatedStyle(() => {
+    const backgroundColor = fillColor.value;
+    return {
+      backgroundColor,
+      shadowColor: backgroundColor,
+      width: withTiming(progress.value * INDICATOR_WIDTH, TIMING_CONFIGS.slowestFadeConfig),
+    };
+  });
 
   useAnimatedReaction(
     () => blue,

--- a/src/features/cash/screens/cash-deposit-setup/components/SetupProgressIndicator.tsx
+++ b/src/features/cash/screens/cash-deposit-setup/components/SetupProgressIndicator.tsx
@@ -1,17 +1,10 @@
 import { memo } from 'react';
 import { StyleSheet } from 'react-native';
 
-import Animated, {
-  useAnimatedReaction,
-  useAnimatedStyle,
-  useDerivedValue,
-  useSharedValue,
-  withSpring,
-  withTiming,
-} from 'react-native-reanimated';
+import Animated, { useAnimatedReaction, useAnimatedStyle, useDerivedValue, useSharedValue, withTiming } from 'react-native-reanimated';
 import { triggerHaptics } from 'react-native-turbo-haptics';
 
-import { SPRING_CONFIGS, TIMING_CONFIGS } from '@/components/animations/animationConfigs';
+import { TIMING_CONFIGS } from '@/components/animations/animationConfigs';
 import { Box, useForegroundColor } from '@/design-system';
 import Routes from '@/navigation/routesNames';
 import { useStoreSharedValue } from '@/state/internal/hooks/useStoreSharedValue';
@@ -45,7 +38,7 @@ export const SetupProgressIndicator = memo(function SetupProgressIndicator() {
 
   const progressStyle = useAnimatedStyle(() => ({
     backgroundColor: fillColor.value,
-    width: withSpring(progress.value * INDICATOR_WIDTH, SPRING_CONFIGS.snappyMediumSpringConfig),
+    width: withTiming(progress.value * INDICATOR_WIDTH, TIMING_CONFIGS.slowestFadeConfig),
   }));
 
   useAnimatedReaction(

--- a/src/features/cash/screens/cash-deposit-setup/components/SetupStepHeader.tsx
+++ b/src/features/cash/screens/cash-deposit-setup/components/SetupStepHeader.tsx
@@ -37,21 +37,16 @@ export const SetupStepHeader = memo(function SetupStepHeader() {
     <Animated.View style={[styles.header, { top: insets.top + 24 }, headerStyle]}>
       <Animated.View style={backStyle}>
         <ButtonPressAnimation disabled={submitting} onPress={goBackInSetup} scaleTo={0.8} testID="cash-setup-back">
-          <Box
-            alignItems="center"
-            background="fillTertiary"
-            borderRadius={18}
-            height={{ custom: 36 }}
-            justifyContent="center"
-            width={{ custom: 36 }}
-          >
+          <Box alignItems="center" background="fillTertiary" borderRadius={18} height={36} justifyContent="center" width={36}>
             <Text align="center" color="label" size="17pt" weight="heavy">
               {'􀆉'}
             </Text>
           </Box>
         </ButtonPressAnimation>
       </Animated.View>
+
       <SetupProgressIndicator />
+
       <SetupCancelButton disabled={submitting} onPress={cancelSetup} />
     </Animated.View>
   );

--- a/src/features/cash/screens/cash-deposit-setup/components/SetupStepHeader.tsx
+++ b/src/features/cash/screens/cash-deposit-setup/components/SetupStepHeader.tsx
@@ -13,6 +13,7 @@ import { useCashDepositSetupNavigationStore } from '../cashDepositSetupNavigator
 import { useSetupContext } from '../setupContext';
 import { cancelSetup, goBackInSetup } from '../setupNavigation';
 import { SetupCancelButton } from './SetupCancelButton';
+import { SetupProgressIndicator } from './SetupProgressIndicator';
 
 export const SetupStepHeader = memo(function SetupStepHeader() {
   const { useActionStore } = useSetupContext();
@@ -20,10 +21,7 @@ export const SetupStepHeader = memo(function SetupStepHeader() {
   const submitting = useActionStore(s => s.loading === true);
 
   const hasHistory = useStoreSharedValue(useCashDepositSetupNavigationStore, s => s.history.length > 0);
-  const visible = useStoreSharedValue(
-    useCashDepositSetupNavigationStore,
-    s => !s.isRouteActive(Routes.CASH_SETUP_ALL_DONE) && !s.isRouteActive(Routes.CASH_SETUP_CARD_ADDED)
-  );
+  const visible = useStoreSharedValue(useCashDepositSetupNavigationStore, s => !s.isRouteActive(Routes.CASH_SETUP_CARD_ADDED));
 
   const headerStyle = useAnimatedStyle(() => ({
     opacity: visible.value ? 1 : 0,
@@ -53,6 +51,7 @@ export const SetupStepHeader = memo(function SetupStepHeader() {
           </Box>
         </ButtonPressAnimation>
       </Animated.View>
+      <SetupProgressIndicator />
       <SetupCancelButton disabled={submitting} onPress={cancelSetup} />
     </Animated.View>
   );

--- a/src/features/cash/screens/cash-deposit-setup/components/SetupSuccessStepLayout.tsx
+++ b/src/features/cash/screens/cash-deposit-setup/components/SetupSuccessStepLayout.tsx
@@ -6,37 +6,26 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { DEFAULT_HANDLE_COLOR_DARK, DEFAULT_HANDLE_COLOR_LIGHT } from '@/components/PanelSheet/PanelSheet';
 import { Box, Text, useColorMode } from '@/design-system';
 
-import { SetupCancelButton } from './SetupCancelButton';
-
-type SetupSuccessStepAccessory =
-  | {
-      type: 'cancel';
-      onPress: () => void;
-    }
-  | {
-      type: 'handle';
-    };
-
 type SetupSuccessStepLayoutProps = {
-  accessory: SetupSuccessStepAccessory;
   description: string;
+  showHandle?: boolean;
   title: string;
 };
 
 const CHECKMARK_CIRCLE = '􀁢';
 
-export const SetupSuccessStepLayout = memo(function SetupSuccessStepLayout({ accessory, description, title }: SetupSuccessStepLayoutProps) {
+export const SetupSuccessStepLayout = memo(function SetupSuccessStepLayout({
+  description,
+  showHandle,
+  title,
+}: SetupSuccessStepLayoutProps) {
   const insets = useSafeAreaInsets();
   const { isDarkMode } = useColorMode();
   const handleColor = isDarkMode ? DEFAULT_HANDLE_COLOR_DARK : DEFAULT_HANDLE_COLOR_LIGHT;
 
   return (
     <Box background="surfacePrimaryElevated" height="full" width="full">
-      {accessory.type === 'cancel' ? (
-        <Box position="absolute" right={{ custom: 16 }} top={{ custom: insets.top + 4 }} zIndex={1}>
-          <SetupCancelButton onPress={accessory.onPress} testID="cash-setup-success-cancel" />
-        </Box>
-      ) : (
+      {showHandle && (
         <Box alignItems="center" left="0px" position="absolute" right="0px" top={{ custom: insets.top + 4 }} zIndex={1}>
           <Box backgroundColor={handleColor} borderRadius={3} height={{ custom: 5 }} width={{ custom: 36 }} />
         </Box>

--- a/src/features/cash/screens/cash-deposit-setup/steps/AllDoneStep.tsx
+++ b/src/features/cash/screens/cash-deposit-setup/steps/AllDoneStep.tsx
@@ -3,16 +3,9 @@ import React, { memo } from 'react';
 import * as i18n from '@/languages';
 
 import { SetupSuccessStepLayout } from '../components/SetupSuccessStepLayout';
-import { cancelSetup } from '../setupNavigation';
 
 const l = i18n.l.cash.deposit_setup.all_done;
 
 export const AllDoneStep = memo(function AllDoneStep() {
-  return (
-    <SetupSuccessStepLayout
-      accessory={{ type: 'cancel', onPress: cancelSetup }}
-      description={i18n.t(l.description)}
-      title={i18n.t(l.title)}
-    />
-  );
+  return <SetupSuccessStepLayout description={i18n.t(l.description)} title={i18n.t(l.title)} />;
 });

--- a/src/features/cash/screens/cash-deposit-setup/steps/CardAddedStep.tsx
+++ b/src/features/cash/screens/cash-deposit-setup/steps/CardAddedStep.tsx
@@ -7,8 +7,8 @@ import { SetupSuccessStepLayout } from '../components/SetupSuccessStepLayout';
 export const CardAddedStep = memo(function CardAddedStep() {
   return (
     <SetupSuccessStepLayout
-      accessory={{ type: 'handle' }}
       description={i18n.t(i18n.l.cash.deposit_setup.card_added.description)}
+      showHandle
       title={i18n.t(i18n.l.cash.deposit_setup.card_added.title)}
     />
   );


### PR DESCRIPTION
Fixes APP-3983

## What changed (plus any additional context for devs)

- Adds an animated progress indicator to the shared Cash setup header
- Displays progress from `Identity` → `SSN` → `Review` → `Passkey`, then animates out after completion once the `All Done` step is reached
- Hidden during initial phone verification and final card linking

## Screen recordings / screenshots

https://github.com/user-attachments/assets/28951ab7-c4fb-48d0-a1fc-5a127f3f79a8

## What to test


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rainbow-me/rainbow/pull/7739?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

