### PR TITLE
[Cash]: Add recovery flow tests

### DIFF
--- a/e2e/flows/cash/SetupRecovery.yaml
+++ b/e2e/flows/cash/SetupRecovery.yaml
@@ -1,0 +1,96 @@
+appId: ${APP_ID}
+tags:
+  - cash
+  - parallel
+---
+- launchApp:
+    clearState: true
+    clearKeychain: true
+    arguments:
+      isE2ETest: true
+- runFlow: ../../utils/Prepare.yaml
+- runFlow: ../../utils/ImportWalletWithKey.yaml
+- runFlow:
+    file: ../../utils/SetExperimentalFlag.yaml
+    env:
+      FLAG: Cash
+      VALUE: 'true'
+- tapOn:
+    id: buy-button
+- assertVisible:
+    id: cash-deposit-intro-set-up-account
+- tapOn:
+    id: cash-deposit-intro-set-up-account
+- assertVisible:
+    text: 'Connect your phone number'
+# Mock 5550001303 starts account recovery instead of the already-registered dead end.
+- tapOn:
+    id: cash-setup-phone-input
+- inputText: '5550001303'
+- tapOn:
+    id: cash-setup-next
+- extendedWaitUntil:
+    visible:
+      text: 'Confirm your phone'
+    timeout: 10000
+- waitForAnimationToEnd
+# Recovery retains the OTP until Review submits it with the identity details.
+- inputText: '000000'
+- extendedWaitUntil:
+    visible:
+      text: 'Enter some information about yourself'
+    timeout: 10000
+- tapOn:
+    id: cash-setup-first-name-input
+- inputText: 'Ada'
+- tapOn:
+    id: cash-setup-last-name-input
+- inputText: 'Lovelace'
+- tapOn:
+    id: cash-setup-dob-input
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - assertVisible:
+          id: cash-setup-dob-picker
+      - tapOn:
+          id: cash-setup-dob-picker-confirm
+- runFlow:
+    when:
+      platform: Android
+    commands:
+      - assertVisible:
+          id: android:id/datePicker
+      - tapOn:
+          id: android:id/button1
+- tapOn:
+    id: cash-setup-next
+- assertVisible:
+    text: 'Enter the last 4 digits of your SSN'
+- tapOn:
+    id: cash-setup-ssn-input
+- inputText: '6789'
+- tapOn:
+    id: cash-setup-next
+- assertVisible:
+    text: 'Review your information'
+- assertVisible:
+    text: 'Ada Lovelace'
+- tapOn:
+    id: cash-setup-next
+- extendedWaitUntil:
+    visible:
+      text: 'Add a Passkey'
+    timeout: 10000
+- assertNotVisible:
+    id: cash-setup-kyc-success-overlay
+# Recovery completes setup after passkey enrollment; an account with no saved card returns to Add Cash.
+- tapOn:
+    id: cash-setup-next
+- extendedWaitUntil:
+    visible:
+      id: cash-deposit-add-cash-add-card
+    timeout: 15000
+- assertNotVisible:
+    id: cash-deposit-add-cash-add-from

--- a/src/features/cash/screens/cash-deposit-setup/steps/useAddPasskeyFlow.test.ts
+++ b/src/features/cash/screens/cash-deposit-setup/steps/useAddPasskeyFlow.test.ts
@@ -2,9 +2,11 @@ import { analytics } from '@/analytics';
 import { logger } from '@/logger';
 
 import { createPasskeyCredential } from '../../../services/cashPasskeyService';
+import { listCards } from '../../../services/rampClient';
 import { addPasskey, finishAddPasskey } from '../../../services/userClient';
 import { useCashAccountStore } from '../../../stores/cashAccountStore';
-import { useCashSetupSessionStore } from '../../../stores/cashSetupSessionStore';
+import { useCashPaymentMethodStore } from '../../../stores/cashPaymentMethodStore';
+import { useCashSetupSessionStore, type RecoveryPhoneChallenge } from '../../../stores/cashSetupSessionStore';
 import { useAddPasskeyFlowStore } from './useAddPasskeyFlow';
 
 jest.mock('@/analytics', () => ({
@@ -28,25 +30,38 @@ jest.mock('../../../services/userClient', () => ({
   finishAddPasskey: jest.fn(),
 }));
 
+jest.mock('../../../services/rampClient', () => ({
+  listCards: jest.fn(),
+}));
+
 jest.mock('../../../services/cashPasskeyService', () => ({
   createPasskeyCredential: jest.fn(),
   getPasskeyName: jest.fn(() => 'iPhone 15 Pro'),
   isPasskeyCancellation: jest.fn((error: unknown) => error instanceof Error && error.message === 'UserCancelled'),
 }));
 
-jest.mock('../../../stores/cashAccountStore', () => ({
-  useCashAccountStore: { getState: jest.fn() },
-}));
+jest.mock('../../../stores/cashAccountStore', () => {
+  const state = { userId: null, setUserId: jest.fn(), clearUserId: jest.fn() };
+  return { useCashAccountStore: { getState: jest.fn(() => state) } };
+});
 
-const mockAddPasskey = addPasskey as jest.Mock;
-const mockFinishAddPasskey = finishAddPasskey as jest.Mock;
-const mockCreatePasskeyCredential = createPasskeyCredential as jest.Mock;
-const track = analytics.track as jest.Mock;
-const setUserId = jest.fn();
+jest.mock('../../../stores/cashPaymentMethodStore', () => {
+  const state = { linkedCard: null, setLinkedCard: jest.fn(), clearLinkedCard: jest.fn() };
+  return { useCashPaymentMethodStore: { getState: jest.fn(() => state) } };
+});
+
+const mockAddPasskey = jest.mocked(addPasskey);
+const mockFinishAddPasskey = jest.mocked(finishAddPasskey);
+const mockCreatePasskeyCredential = jest.mocked(createPasskeyCredential);
+const mockListCards = jest.mocked(listCards);
+const track = jest.mocked(analytics.track);
+const setUserId = jest.mocked(useCashAccountStore.getState().setUserId);
+const setLinkedCard = jest.mocked(useCashPaymentMethodStore.getState().setLinkedCard);
 
 const TOKEN = 'bst_1';
 const OPTIONS_JSON = '{"publicKey":{"challenge":"abc"}}';
 const CREDENTIAL_JSON = '{"id":"cred-1"}';
+const RECOVERED_CARD = { id: 'card-1', brand: 'Visa', last4: '4242' };
 
 const flow = () => useAddPasskeyFlowStore.getState();
 const session = () => useCashSetupSessionStore.getState();
@@ -55,10 +70,19 @@ const challenge = () => {
   if (current.status !== 'phoneSubmitted') throw new Error('expected a phoneSubmitted session');
   return current.challenge;
 };
+const verifyRecoverySession = () => {
+  session().reset();
+  const recoveryChallenge: RecoveryPhoneChallenge = { kind: 'recovery', recoveryId: 'recovery-1' };
+  session().setPhoneSubmitted({ challenge: recoveryChallenge, phoneNationalNumber: '4155550100', resendAfter: 0 });
+  session().setFirstName('Ada');
+  session().setLastName('Lovelace');
+  session().setDateOfBirth({ year: 1815, month: 12, day: 10 });
+  session().setSsnLast4('1234');
+  session().setPhoneVerified(recoveryChallenge, { bootstrapToken: TOKEN, expiresAt: Date.now() + 60_000 });
+};
 
 beforeEach(() => {
   jest.clearAllMocks();
-  (useCashAccountStore.getState as jest.Mock).mockReturnValue({ setUserId });
   flow().reset();
   session().reset();
   session().setPhoneSubmitted({ challenge: { kind: 'signup', userId: 'user-1' }, phoneNationalNumber: '4155550100', resendAfter: 0 });
@@ -66,6 +90,7 @@ beforeEach(() => {
   mockAddPasskey.mockResolvedValue({ passkeyId: 'pk-1', publicKeyOptionsJson: OPTIONS_JSON, userId: 'user-1' });
   mockCreatePasskeyCredential.mockResolvedValue(CREDENTIAL_JSON);
   mockFinishAddPasskey.mockResolvedValue(undefined);
+  mockListCards.mockResolvedValue([]);
 });
 
 describe('useAddPasskeyFlowStore.submit', () => {
@@ -136,6 +161,31 @@ describe('useAddPasskeyFlowStore.submit', () => {
 
     expect(mockAddPasskey).toHaveBeenCalledTimes(2);
     expect(setUserId).toHaveBeenCalledWith('user-1');
+  });
+
+  it('restores the recovered account card after passkey enrollment', async () => {
+    verifyRecoverySession();
+    mockListCards.mockResolvedValue([RECOVERED_CARD]);
+
+    await expect(flow().submit()).resolves.toBe('recovered');
+
+    expect(mockListCards).toHaveBeenCalledWith({ trigger: 'recovery' });
+    expect(setLinkedCard).toHaveBeenCalledWith(RECOVERED_CARD);
+    expect(setUserId).toHaveBeenCalledWith('user-1');
+    expect(mockFinishAddPasskey).toHaveBeenCalledTimes(1);
+  });
+
+  it('completes recovery when card restoration fails after passkey enrollment', async () => {
+    verifyRecoverySession();
+    mockListCards.mockRejectedValue(new Error('network down'));
+
+    await expect(flow().submit()).resolves.toBe('recovered');
+
+    expect(setUserId).toHaveBeenCalledWith('user-1');
+    expect(mockAddPasskey).toHaveBeenCalledTimes(1);
+    expect(mockFinishAddPasskey).toHaveBeenCalledTimes(1);
+    expect(track).not.toHaveBeenCalledWith('cash.passkey_failed', expect.anything());
+    expect(logger.error).toHaveBeenCalled();
   });
 
   it('skips a second submit while one is in flight', async () => {

--- a/src/features/cash/screens/cash-deposit-setup/steps/useSubmitReviewFlow.recovery.test.ts
+++ b/src/features/cash/screens/cash-deposit-setup/steps/useSubmitReviewFlow.recovery.test.ts
@@ -96,7 +96,7 @@ describe('useSubmitReviewFlowStore.submit recovery', () => {
 
     await expect(flow().submit()).resolves.toBe('failed');
 
-    expect(flow().state).toBe('error');
+    expect(flow().state).toBe('identityMismatch');
     expect(verifyFlow().code).toBe(CODE);
     expect(sessionStore().session).toMatchObject({ status: 'recovery', identity: IDENTITY, ssnLast4 });
   });
@@ -155,14 +155,16 @@ describe('useSubmitReviewFlowStore.submit recovery', () => {
     expect(mockFinishRecovery).toHaveBeenCalledTimes(1);
   });
 
-  it('reports an unexpected request failure without changing the recovery session', async () => {
-    mockFinishRecovery.mockRejectedValue(new Error('network down'));
+  it('keeps an unexpected request failure retryable without changing the recovery session', async () => {
+    mockFinishRecovery.mockRejectedValueOnce(new Error('network down'));
 
     await expect(flow().submit()).resolves.toBe('failed');
 
     expect(flow().state).toBe('error');
     expect(sessionStore().session).toMatchObject({ status: 'recovery', challenge: CHALLENGE });
     expect(logger.error).toHaveBeenCalled();
+
+    await expect(flow().submit()).resolves.toBe('recovered');
   });
 
   it('does not apply a recovery result after the setup session changes', async () => {

--- a/src/features/cash/screens/cash-deposit-setup/steps/useSubmitReviewFlow.recovery.test.ts
+++ b/src/features/cash/screens/cash-deposit-setup/steps/useSubmitReviewFlow.recovery.test.ts
@@ -1,0 +1,183 @@
+import { analytics } from '@/analytics';
+import { logger } from '@/logger';
+
+import { createUsSsnLast4GovernmentId, isValidUsSsnLast4 } from '../../../services/cashSetupIdentityService';
+import { finishRecovery, startRecovery, startSignupResume } from '../../../services/userClient';
+import { useCashSetupSessionStore, type RecoveryPhoneChallenge } from '../../../stores/cashSetupSessionStore';
+import { useVerifyPhoneFlowStore } from '../../../stores/verifyPhoneFlowStore';
+import { useSubmitReviewFlowStore } from './useSubmitReviewFlow';
+
+jest.mock('@/analytics', () => ({
+  analytics: {
+    track: jest.fn(),
+    event: {
+      cashPhoneSubmitted: 'cash.phone_submitted',
+      cashPhoneVerified: 'cash.phone_verified',
+      cashPhoneVerifyFailed: 'cash.phone_verify_failed',
+    },
+  },
+}));
+
+jest.mock('@/logger', () => ({
+  logger: { debug: jest.fn(), error: jest.fn(), warn: jest.fn() },
+  RainbowError: class RainbowError extends Error {},
+}));
+
+jest.mock('@/features/config/stores/remoteConfig', () => ({
+  getRemoteConfig: () => ({ cash_kyc_review_delay_ms: 60_000 }),
+}));
+
+jest.mock('../../../services/userClient', () => ({
+  finishRecovery: jest.fn(),
+  startRecovery: jest.fn(),
+  startSignupResume: jest.fn(),
+}));
+
+const mockFinishRecovery = jest.mocked(finishRecovery);
+const mockStartRecovery = jest.mocked(startRecovery);
+const mockStartSignupResume = jest.mocked(startSignupResume);
+const track = jest.mocked(analytics.track);
+
+const CODE = '123456';
+const IDENTITY = { firstName: 'Ada', lastName: 'Lovelace', dateOfBirth: { year: 1815, month: 12, day: 10 } };
+const CHALLENGE: RecoveryPhoneChallenge = { kind: 'recovery', recoveryId: 'recovery-1' };
+const TOKEN = { bootstrapToken: 'bst_recovered', expiresAt: 1_750_000_060_000 };
+const RESEND_AFTER = 1_750_000_030_000;
+
+const ssnLast4 = '1234';
+if (!isValidUsSsnLast4(ssnLast4)) throw new Error('Invalid test SSN');
+const GOVERNMENT_ID = createUsSsnLast4GovernmentId(ssnLast4);
+
+const flow = () => useSubmitReviewFlowStore.getState();
+const sessionStore = () => useCashSetupSessionStore.getState();
+const verifyFlow = () => useVerifyPhoneFlowStore.getState();
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  flow().reset();
+  sessionStore().reset();
+  verifyFlow().reset();
+  sessionStore().setPhoneSubmitted({ challenge: CHALLENGE, phoneNationalNumber: '4155550100', resendAfter: 0 });
+  sessionStore().setFirstName(IDENTITY.firstName);
+  sessionStore().setLastName(IDENTITY.lastName);
+  sessionStore().setDateOfBirth(IDENTITY.dateOfBirth);
+  sessionStore().setSsnLast4(ssnLast4);
+  verifyFlow().setCode(CODE);
+  mockFinishRecovery.mockResolvedValue({ outcome: 'recovered', ...TOKEN });
+  mockStartRecovery.mockResolvedValue({ recoveryId: 'recovery-2', resendAfter: RESEND_AFTER });
+  mockStartSignupResume.mockResolvedValue({ resumeId: 'resume-1', resendAfter: RESEND_AFTER });
+});
+
+describe('useSubmitReviewFlowStore.submit recovery', () => {
+  it('finishes recovery and stores the bootstrap credential', async () => {
+    await expect(flow().submit()).resolves.toBe('recovered');
+
+    expect(mockFinishRecovery).toHaveBeenCalledWith({
+      recoveryId: 'recovery-1',
+      code: CODE,
+      identity: IDENTITY,
+      governmentId: GOVERNMENT_ID,
+    });
+    expect(sessionStore().session).toEqual({
+      status: 'phoneVerified',
+      source: 'recovery',
+      phoneNationalNumber: '4155550100',
+      bootstrapToken: TOKEN.bootstrapToken,
+      bootstrapTokenExpiresAt: TOKEN.expiresAt,
+      identity: IDENTITY,
+      ssnLast4,
+    });
+    expect(track).toHaveBeenCalledWith('cash.phone_verified', { mode: 'recovery' });
+    expect(flow().state).toBe('entry');
+  });
+
+  it('keeps the recovery inputs available after an identity mismatch', async () => {
+    mockFinishRecovery.mockResolvedValue({ outcome: 'identityMismatch' });
+
+    await expect(flow().submit()).resolves.toBe('failed');
+
+    expect(flow().state).toBe('error');
+    expect(verifyFlow().code).toBe(CODE);
+    expect(sessionStore().session).toMatchObject({ status: 'recovery', identity: IDENTITY, ssnLast4 });
+  });
+
+  it('returns to OTP entry without replacing the session when the code is invalid', async () => {
+    mockFinishRecovery.mockResolvedValue({ outcome: 'codeInvalid' });
+
+    await expect(flow().submit()).resolves.toBe('phoneCodeRequired');
+
+    expect(verifyFlow()).toMatchObject({ code: '', state: 'error' });
+    expect(sessionStore().session).toMatchObject({ status: 'recovery', challenge: CHALLENGE });
+    expect(mockStartRecovery).not.toHaveBeenCalled();
+    expect(track).toHaveBeenCalledWith('cash.phone_verify_failed', { mode: 'recovery', reason: 'client_error' });
+  });
+
+  it('starts a fresh recovery session after the old session expires and preserves the identity draft', async () => {
+    mockFinishRecovery.mockResolvedValue({ outcome: 'sessionInvalid' });
+
+    await expect(flow().submit()).resolves.toBe('phoneCodeRequired');
+
+    expect(mockStartRecovery).toHaveBeenCalledWith({ nationalNumber: '4155550100' });
+    expect(sessionStore().session).toEqual({
+      status: 'recovery',
+      challenge: { kind: 'recovery', recoveryId: 'recovery-2' },
+      phoneNationalNumber: '4155550100',
+      resendAfter: RESEND_AFTER,
+      identity: IDENTITY,
+      ssnLast4,
+    });
+    expect(verifyFlow()).toMatchObject({ code: '', state: 'entry' });
+  });
+
+  it('switches to signup resume when the account has no passkey', async () => {
+    mockFinishRecovery.mockResolvedValue({ outcome: 'signupIncomplete' });
+
+    await expect(flow().submit()).resolves.toBe('phoneCodeRequired');
+
+    expect(mockStartSignupResume).toHaveBeenCalledWith({ nationalNumber: '4155550100' });
+    expect(sessionStore().session).toEqual({
+      status: 'phoneSubmitted',
+      challenge: { kind: 'resume', resumeId: 'resume-1' },
+      phoneNationalNumber: '4155550100',
+      resendAfter: RESEND_AFTER,
+    });
+    expect(track).toHaveBeenCalledWith('cash.phone_submitted', { mode: 'resume' });
+    expect(verifyFlow()).toMatchObject({ code: '', state: 'entry' });
+  });
+
+  it('locks further submissions when recovery access is blocked', async () => {
+    mockFinishRecovery.mockResolvedValue({ outcome: 'accessBlocked' });
+
+    await expect(flow().submit()).resolves.toBe('failed');
+    await expect(flow().submit()).resolves.toBe('skipped');
+
+    expect(flow().state).toBe('locked');
+    expect(mockFinishRecovery).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports an unexpected request failure without changing the recovery session', async () => {
+    mockFinishRecovery.mockRejectedValue(new Error('network down'));
+
+    await expect(flow().submit()).resolves.toBe('failed');
+
+    expect(flow().state).toBe('error');
+    expect(sessionStore().session).toMatchObject({ status: 'recovery', challenge: CHALLENGE });
+    expect(logger.error).toHaveBeenCalled();
+  });
+
+  it('does not apply a recovery result after the setup session changes', async () => {
+    mockFinishRecovery.mockImplementation(async () => {
+      sessionStore().setPhoneSubmitted({
+        challenge: { kind: 'signup', userId: 'user-2' },
+        phoneNationalNumber: '4155550101',
+        resendAfter: 0,
+      });
+      return { outcome: 'recovered', ...TOKEN };
+    });
+
+    await expect(flow().submit()).resolves.toBe('cancelled');
+
+    expect(sessionStore().session).toMatchObject({ status: 'phoneSubmitted', phoneNationalNumber: '4155550101' });
+    expect(track).not.toHaveBeenCalledWith('cash.phone_verified', expect.anything());
+  });
+});

--- a/src/features/cash/screens/cash-deposit-setup/steps/useSubmitReviewFlow.test.ts
+++ b/src/features/cash/screens/cash-deposit-setup/steps/useSubmitReviewFlow.test.ts
@@ -194,16 +194,23 @@ describe('useSubmitReviewFlowStore.submit onboarding', () => {
     expect(logger.warn).toHaveBeenCalled();
   });
 
-  it('stops writing once the flow is reset, so an abandoned poll cannot resurface later', async () => {
+  it('ignores an active status poll after the flow is reset', async () => {
+    const poll = Promise.withResolvers<{ kycStatus: KycStatus }>();
+    const pollStarted = Promise.withResolvers<void>();
     mockSubmitOnboarding.mockResolvedValue({ kycStatus: KycStatus.Pending });
-    mockDelay.mockImplementationOnce(() => {
-      flow().reset();
-      return Promise.resolve();
+    mockGetUserStatus.mockImplementationOnce(() => {
+      pollStarted.resolve();
+      return poll.promise;
     });
 
-    await expect(flow().submit()).resolves.toBe('cancelled');
+    const submission = flow().submit();
+    await pollStarted.promise;
+    flow().reset();
+    poll.resolve({ kycStatus: KycStatus.Approved });
 
-    expect(mockGetUserStatus).not.toHaveBeenCalled();
+    await expect(submission).resolves.toBe('cancelled');
+
+    expect(mockGetUserStatus).toHaveBeenCalledTimes(1);
     expect(flow().state).toBe('entry');
     expect(track).not.toHaveBeenCalledWith('cash.kyc_approved');
   });

--- a/src/features/cash/services/rampClient.ts
+++ b/src/features/cash/services/rampClient.ts
@@ -187,6 +187,8 @@ export async function listCards({
   abortController?: AbortController | null;
   trigger: CashSignInTrigger;
 }): Promise<LinkedCard[]> {
+  if (IS_TESTING === 'true') return [];
+
   const { data } = await authorizedRequest(trigger, headers =>
     getCashPlatformClient().get<ListCardsResponse>('/ramp/payment-methods/cards', { abortController, headers })
   );

--- a/src/features/cash/services/userClient.test.ts
+++ b/src/features/cash/services/userClient.test.ts
@@ -31,8 +31,12 @@ afterEach(() => {
   jest.restoreAllMocks();
 });
 
-function platformError(code: unknown) {
-  return new RainbowFetchError({ message: 'phone already registered', responseBody: { code, message: 'phone already registered' } });
+function platformError(code: unknown, httpStatus?: number) {
+  return new RainbowFetchError({
+    message: 'phone already registered',
+    response: httpStatus === undefined ? undefined : new Response(null, { status: httpStatus }),
+    responseBody: { code, message: 'phone already registered' },
+  });
 }
 
 describe('createUserWithPhone', () => {
@@ -178,19 +182,19 @@ describe('account recovery', () => {
   });
 
   it.each([
-    { code: 403, outcome: 'identityMismatch' },
+    { code: 403, httpStatus: 403, outcome: 'identityMismatch' },
     { code: 1320, outcome: 'sessionInvalid' },
     { code: 1321, outcome: 'codeInvalid' },
     { code: 1323, outcome: 'signupIncomplete' },
-    { code: 1340, outcome: 'accessBlocked' },
-  ])('maps recovery error code $code to $outcome', async ({ code, outcome }) => {
-    post.mockRejectedValue(platformError(code));
+    { code: 1340, httpStatus: 403, outcome: 'accessBlocked' },
+  ])('maps recovery error body code $code to $outcome', async ({ code, httpStatus, outcome }) => {
+    post.mockRejectedValue(platformError(code, httpStatus));
 
     await expect(finishRecovery(finishParams)).resolves.toEqual({ outcome });
   });
 
-  it('rethrows an unrecognized recovery error', async () => {
-    const error = platformError(1399);
+  it('rethrows an unrecognized HTTP 403 recovery error', async () => {
+    const error = platformError(7, 403);
     post.mockRejectedValue(error);
 
     await expect(finishRecovery(finishParams)).rejects.toBe(error);

--- a/src/features/cash/services/userClient.test.ts
+++ b/src/features/cash/services/userClient.test.ts
@@ -1,22 +1,34 @@
 import { RainbowFetchError } from '@/framework/data/http/rainbowFetch';
 
-import { getCashPlatformClient } from './cashPlatformClient';
-import { createUserWithPhone, finishSignupResume, startSignupResume, verifyPhone } from './userClient';
+import { createUsSsnLast4GovernmentId, isValidUsSsnLast4 } from './cashSetupIdentityService';
+import { createUserWithPhone, finishRecovery, finishSignupResume, startRecovery, startSignupResume, verifyPhone } from './userClient';
 
 jest.mock('react-native-dotenv', () => ({ IS_TESTING: 'false' }));
 
+const mockPost = jest.fn();
+
 jest.mock('./cashPlatformClient', () => ({
-  getCashPlatformClient: jest.fn(),
+  getCashPlatformClient: () => ({ post: mockPost }),
   buildAuthenticatedHeader: (token: string) => ({ Authorization: `Bearer ${token}` }),
 }));
 
-const post = jest.fn();
-(getCashPlatformClient as jest.Mock).mockReturnValue({ post });
+const post = mockPost;
 
 const PARAMS = { userId: 'user-1', code: '123456' };
+const IDENTITY = { firstName: 'Ada', lastName: 'Lovelace', dateOfBirth: { year: 1815, month: 12, day: 10 } };
+
+function governmentId() {
+  const value = '1234';
+  if (!isValidUsSsnLast4(value)) throw new Error('Invalid test SSN');
+  return createUsSsnLast4GovernmentId(value);
+}
 
 beforeEach(() => {
   post.mockReset();
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
 });
 
 function platformError(code: unknown) {
@@ -59,8 +71,6 @@ describe('startSignupResume', () => {
     post.mockResolvedValue({ data: { resumeId: 'rcv_1', resendAfter: '30s' } });
 
     await expect(startSignupResume({ nationalNumber: '5869132511' })).resolves.toEqual({ resumeId: 'rcv_1', resendAfter: now + 30_000 });
-
-    jest.restoreAllMocks();
   });
 });
 
@@ -118,7 +128,71 @@ describe('verifyPhone', () => {
     post.mockResolvedValue({ data: { bootstrapToken: 'bst_test', expiresIn: '600s' } });
 
     await expect(verifyPhone(PARAMS)).resolves.toEqual({ bootstrapToken: 'bst_test', expiresAt: now + 600_000 });
+  });
+});
 
-    jest.restoreAllMocks();
+describe('account recovery', () => {
+  const finishParams = {
+    recoveryId: 'recovery-1',
+    code: '123456',
+    identity: IDENTITY,
+    governmentId: governmentId(),
+  };
+
+  it('starts the personal-details recovery method', async () => {
+    const now = 1_750_000_000_000;
+    jest.spyOn(Date, 'now').mockReturnValue(now);
+    post.mockResolvedValue({
+      data: { recoveryId: 'recovery-1', methods: ['RECOVERY_METHOD_PERSONAL_DETAILS'], resendAfter: '30s' },
+    });
+
+    await expect(startRecovery({ nationalNumber: '5869132511' })).resolves.toEqual({
+      recoveryId: 'recovery-1',
+      resendAfter: now + 30_000,
+    });
+    expect(post).toHaveBeenCalledWith('/recovery/StartRecovery', {
+      phone: { countryCode: '1', nationalNumber: '5869132511' },
+    });
+  });
+
+  it('rejects a response without a supported recovery method', async () => {
+    post.mockResolvedValue({ data: { recoveryId: 'recovery-1', resendAfter: '30s' } });
+
+    await expect(startRecovery({ nationalNumber: '5869132511' })).rejects.toThrow('no supported recovery method');
+  });
+
+  it('submits the OTP and personal details and returns the bootstrap credential', async () => {
+    post.mockResolvedValue({ data: { bootstrapToken: 'bst_recovered', expiresIn: '600s' } });
+
+    await expect(finishRecovery(finishParams)).resolves.toMatchObject({ outcome: 'recovered', bootstrapToken: 'bst_recovered' });
+    expect(post).toHaveBeenCalledWith('/recovery/FinishRecovery', {
+      recoveryId: 'recovery-1',
+      code: '123456',
+      personalDetails: {
+        countryCode: 'US',
+        legalName: { firstName: 'Ada', lastName: 'Lovelace' },
+        dateOfBirth: { year: 1815, month: 12, day: 10 },
+        governmentId: finishParams.governmentId,
+      },
+    });
+  });
+
+  it.each([
+    { code: 403, outcome: 'identityMismatch' },
+    { code: 1320, outcome: 'sessionInvalid' },
+    { code: 1321, outcome: 'codeInvalid' },
+    { code: 1323, outcome: 'signupIncomplete' },
+    { code: 1340, outcome: 'accessBlocked' },
+  ])('maps recovery error code $code to $outcome', async ({ code, outcome }) => {
+    post.mockRejectedValue(platformError(code));
+
+    await expect(finishRecovery(finishParams)).resolves.toEqual({ outcome });
+  });
+
+  it('rethrows an unrecognized recovery error', async () => {
+    const error = platformError(1399);
+    post.mockRejectedValue(error);
+
+    await expect(finishRecovery(finishParams)).rejects.toBe(error);
   });
 });

--- a/src/features/cash/stores/verifyPhoneFlowStore.test.ts
+++ b/src/features/cash/stores/verifyPhoneFlowStore.test.ts
@@ -239,6 +239,25 @@ describe('useVerifyPhoneFlowStore.submit', () => {
     expect(session()).toMatchObject({ status: 'recovery', challenge: { recoveryId: 'recovery-1' } });
   });
 
+  it('does not accept a recovery OTP while a resend is pending', async () => {
+    const resend = Promise.withResolvers<{ recoveryId: string; resendAfter: number }>();
+    mockStartRecovery.mockReturnValue(resend.promise);
+    startAccountRecovery();
+    flow().setCode(CODE);
+
+    const pending = flow().resend();
+    await expect(flow().submit()).resolves.toBe('failed');
+
+    expect(flow().state).toBe('entry');
+    expect(session()).toMatchObject({ status: 'recovery', challenge: { recoveryId: 'recovery-1' } });
+
+    resend.resolve({ recoveryId: 'recovery-2', resendAfter: RESEND_AFTER });
+    await pending;
+
+    expect(flow().code).toBe('');
+    expect(session()).toMatchObject({ status: 'recovery', challenge: { recoveryId: 'recovery-2' } });
+  });
+
   it('clears the code, stores no token, and reports the failure when verification throws', async () => {
     mockVerifyPhone.mockRejectedValue(new Error('wrong code'));
     flow().setCode(CODE);
@@ -386,6 +405,19 @@ describe('useVerifyPhoneFlowStore.submit', () => {
     expect(mockVerifyPhone).toHaveBeenCalledTimes(1);
     resolveVerify(TOKEN);
     await expect(first).resolves.toBe('verified');
+  });
+
+  it('does not resend while verification is active', async () => {
+    const verify = Promise.withResolvers<typeof TOKEN>();
+    mockVerifyPhone.mockReturnValue(verify.promise);
+    flow().setCode(CODE);
+
+    const pending = flow().submit();
+    await flow().resend();
+
+    expect(mockResendPhoneCode).not.toHaveBeenCalled();
+    verify.resolve(TOKEN);
+    await pending;
   });
 
   // The Confirm button is briefly tappable again between acceptance and the pager moving on.


### PR DESCRIPTION
## What changed (plus any additional context for devs)
- Adds test coverage for the recovery flow additions in #7740

## Screen recordings / screenshots

## What to test


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rainbow-me/rainbow/pull/7741?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

