### PR TITLE
fix(tsconfig): skipLibCheck->true to align CI and local type checking

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "lint:js": "eslint --cache . --quiet",
     "lint:js:ci": "eslint . --quiet",
     "lint:js-types": "./scripts/check-js-types.sh",
-    "lint:ts": "yarn tsc --skipLibCheck --noEmit",
+    "lint:ts": "yarn tsc --noEmit",
     "nuke": "./scripts/nuke.sh",
     "prepare": "husky install",
     "rc-push": "./scripts/rc-push.sh",

--- a/scripts/check-js-types.sh
+++ b/scripts/check-js-types.sh
@@ -12,7 +12,7 @@ fi
 baseline_pattern=$(grep -oE '^TS[0-9]+' "$BASELINE" | paste -sd '|' -)
 
 # Run tsc with checkJs and capture JS file errors
-js_errors=$(npx tsc --skipLibCheck --noEmit --checkJs 2>&1 | grep '\.js\b.*error TS' || true)
+js_errors=$(npx tsc --noEmit --checkJs 2>&1 | grep '\.js\b.*error TS' || true)
 
 if [ -z "$js_errors" ]; then
   echo "No JS type errors found."

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,7 @@
     "moduleResolution": "node",
     "moduleSuffixes": [".ios", ".android", ""],
     "noEmit": true,
+    "skipLibCheck": true,
     "strict": true,
     "target": "esnext",
     "baseUrl": ".",


### PR DESCRIPTION
We use `skipLibCheck: true` in CI and from the CLI commands around TS (linting, type checking etc), but since our tsconfig doesn't have this value the local TypeScript and LSP servers default to `skipLibCheck: false` which causes type checking on the `d.ts` files across the entire repo (including `node_modules`). This significantly increases compilation time, memory usage and degrades perf in local dev and LSP (AI) usage for little benefit.

This change moves `skipLibCheck: true` into the `tsconfig` so all instances get the same configuration, both CI, local dev and LSP. Note that both TS and React Native default setup ships `skipLibCheck: true` too - it is the canonical recommended value for this prop.

As a side effect this also hides 13 stale errors in the bottom sheet navigator's declaration file. Since `skipLibCheck` keys purely off the `.d.ts` extension, renaming that file to `.ts` puts it back under checking and forces us to fix it. Will do this in a follow up PR.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rainbow-me/rainbow/pull/7746?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

