### PR TITLE
fix(CASH): variable order polling and validate ramp responses

### DIFF
--- a/src/features/cash/constants.ts
+++ b/src/features/cash/constants.ts
@@ -8,7 +8,9 @@ export const USDC_NAME = 'USD Coin';
 export const USDC_SYMBOL = 'USDC';
 export const USDC_DECIMALS = 6;
 
-export const ORDER_POLL_INTERVAL_MS = time.seconds(2);
+export const ORDER_FAST_POLL_INTERVAL_MS = time.seconds(2);
+export const ORDER_FAST_POLL_DURATION_MS = time.minutes(5);
+export const ORDER_SLOW_POLL_INTERVAL_MS = time.seconds(15);
 
 /** Each platform admits exactly one destination: production `usdc/base`, staging `usdc/arbitrum_testnet`. */
 export const CASH_BUY_DESTINATION_ASSET: RampAsset = {
@@ -23,7 +25,7 @@ export const CASH_BUY_DESTINATION_ASSET: RampAsset = {
  * (POLYGON_USDC_ADDRESS) own theirs. Chain ids are pinned here rather than resolved
  * through the backend networks store, which never returns testnets.
  */
-export const CASH_USDC_BY_NETWORK: Partial<Record<RampNetwork, { chainId: ChainId; chainName: ChainName; address: string }>> = {
+export const CASH_USDC_BY_NETWORK: Record<RampAsset['network'], { chainId: ChainId; chainName: ChainName; address: string }> = {
   [RampNetwork.ArbitrumTestnet]: {
     chainId: ChainId.arbitrumSepolia,
     chainName: ChainName.arbitrumSepolia,

--- a/src/features/cash/screens/add-cash-sheet/AddCashSheet.tsx
+++ b/src/features/cash/screens/add-cash-sheet/AddCashSheet.tsx
@@ -12,7 +12,7 @@ import { HoldToActivateButton } from '@/components/hold-to-activate-button/HoldT
 import { NumberPad } from '@/components/number-pad/NumberPad';
 import { DEFAULT_HANDLE_COLOR_DARK, DEFAULT_HANDLE_COLOR_LIGHT, PanelSheet } from '@/components/PanelSheet/PanelSheet';
 import { Box, Inline, Text, useColorMode, useForegroundColor } from '@/design-system';
-import { ORDER_POLL_INTERVAL_MS } from '@/features/cash/constants';
+import { ORDER_FAST_POLL_DURATION_MS, ORDER_FAST_POLL_INTERVAL_MS, ORDER_SLOW_POLL_INTERVAL_MS } from '@/features/cash/constants';
 import { isPasskeyCancellation } from '@/features/cash/services/cashPasskeyService';
 import { checkWalletLink } from '@/features/cash/services/walletLinkService';
 import { cashBuyOrderActions, selectCashBuyPhase, useCashBuyOrderStore, useCashBuyPhase } from '@/features/cash/stores/cashBuyOrderStore';
@@ -20,6 +20,7 @@ import { useCashLinkedCard, type LinkedCard } from '@/features/cash/stores/cashP
 import { getTelemetryErrorReason } from '@/features/cash/utils/getTelemetryErrorReason';
 import { useRemoteConfig } from '@/features/config/stores/remoteConfig';
 import { ChainId } from '@/features/network/types/backendNetworks';
+import { useTimestampReached } from '@/framework/ui/hooks/useTimestampReached';
 import { useWatcher } from '@/framework/ui/hooks/useWatcher';
 import { opacity } from '@/framework/ui/utils/opacity';
 import { WrappedAlert as Alert } from '@/helpers/alert';
@@ -350,21 +351,7 @@ export const AddCashSheet = memo(function AddCashSheet() {
   // The pending view takes over only once the order has been in flight longer than the configured
   // delay; until then the hold-to-add button's processing state is the only affordance.
   const pendingViewAt = submittedAt !== null ? submittedAt + pendingViewDelayMs : null;
-  const [showPendingView, setShowPendingView] = useState(() => pendingViewAt !== null && Date.now() >= pendingViewAt);
-
-  useEffect(() => {
-    if (pendingViewAt === null) {
-      setShowPendingView(false);
-      return;
-    }
-    const remaining = pendingViewAt - Date.now();
-    if (remaining <= 0) {
-      setShowPendingView(true);
-      return;
-    }
-    const timeoutId = setTimeout(() => setShowPendingView(true), remaining);
-    return () => clearTimeout(timeoutId);
-  }, [pendingViewAt]);
+  const showPendingView = useTimestampReached(pendingViewAt);
 
   useEffect(() => {
     return () => {
@@ -382,9 +369,13 @@ export const AddCashSheet = memo(function AddCashSheet() {
     }
   }, []);
 
+  // A fresh order is most likely to settle inside the fast window; polling backs off past it.
+  const slowPollAt = submittedAt !== null ? submittedAt + ORDER_FAST_POLL_DURATION_MS : null;
+  const isSlowPolling = useTimestampReached(slowPollAt);
+
   useWatcher({
     enabled: isPolling,
-    interval: ORDER_POLL_INTERVAL_MS,
+    interval: isSlowPolling ? ORDER_SLOW_POLL_INTERVAL_MS : ORDER_FAST_POLL_INTERVAL_MS,
     watchFunction: cashBuyOrderActions.syncActiveOrder,
   });
 

--- a/src/features/cash/services/rampClient.test.ts
+++ b/src/features/cash/services/rampClient.test.ts
@@ -1,5 +1,6 @@
 import { ResponseParseError } from '@/framework/data/http/parseResponse';
 import { RainbowFetchError } from '@/framework/data/http/rainbowFetch';
+import { logger } from '@/logger';
 
 import { useCashAuthTokenStore } from '../stores/cashAuthTokenStore';
 import { getCashPlatformClient } from './cashPlatformClient';
@@ -30,6 +31,10 @@ jest.mock('./cashPlatformClient', () => ({
 
 jest.mock('./cashSignInService', () => ({
   ensureAccessToken: jest.fn(),
+}));
+
+jest.mock('@/logger', () => ({
+  logger: { warn: jest.fn() },
 }));
 
 const get = jest.fn();
@@ -258,6 +263,7 @@ describe('response validation', () => {
       id: CREATE_BUY_ORDER_PARAMS.id,
       status: OrderStatus.Completed,
     });
+    expect(logger.warn).not.toHaveBeenCalled();
   });
 
   const unusableCryptoAmounts: { label: string; body: unknown }[] = [
@@ -278,6 +284,11 @@ describe('response validation', () => {
     expect(order.status).toBe(OrderStatus.Completed);
     if (order.status !== OrderStatus.Completed) throw new Error('Expected a completed order');
     expect(order.cryptoAmount).toBeUndefined();
+    expect(logger.warn).toHaveBeenCalledWith('[rampClient] normalized malformed response from getOrder', {
+      issues: expect.arrayContaining([
+        expect.objectContaining({ code: expect.any(String), path: expect.stringContaining('order.cryptoAmount') }),
+      ]),
+    });
   });
 
   it('falls back to unspecified for a failure reason the client does not model', async () => {
@@ -346,6 +357,10 @@ describe('response validation', () => {
     });
 
     await expect(listWallets()).resolves.toEqual([{ id: 'wallet-valid', address: '0xabc' }]);
+    expect(logger.warn).toHaveBeenCalledWith('[rampClient] normalized malformed response from listWallets', {
+      issues: [{ code: 'too_small', path: '0.address' }],
+      totalRows: 2,
+    });
   });
 
   it('drops invalid cards without losing valid cards', async () => {
@@ -358,9 +373,7 @@ describe('response validation', () => {
       },
     });
 
-    await expect(listCards({ trigger: 'signInScreen' })).resolves.toEqual([
-      { brand: 'Mastercard', id: 'card-valid', last4: '8990' },
-    ]);
+    await expect(listCards({ trigger: 'signInScreen' })).resolves.toEqual([{ brand: 'Mastercard', id: 'card-valid', last4: '8990' }]);
   });
 
   it('reads an empty wallet list from an empty envelope', async () => {

--- a/src/features/cash/services/rampClient.test.ts
+++ b/src/features/cash/services/rampClient.test.ts
@@ -1,3 +1,4 @@
+import { ResponseParseError } from '@/framework/data/http/parseResponse';
 import { RainbowFetchError } from '@/framework/data/http/rainbowFetch';
 
 import { useCashAuthTokenStore } from '../stores/cashAuthTokenStore';
@@ -8,13 +9,18 @@ import {
   completeCardLinkSession,
   createBuyOrder,
   getOrder,
+  linkWallet,
+  listCards,
+  listWallets,
+  OrderFailureReason,
   OrderStatus,
   RampCryptoAsset,
   RampNetwork,
   startCardLinkSession,
+  WalletSignatureMethod,
   type BuyOrder,
   type CreateBuyOrderParams,
-  type CreatedBuyOrder,
+  type WalletSignature,
 } from './rampClient';
 
 jest.mock('./cashPlatformClient', () => ({
@@ -30,7 +36,14 @@ const get = jest.fn();
 const post = jest.fn();
 const mockEnsureAccessToken = ensureAccessToken as jest.Mock;
 
+// `tokenExpiresTime` rides along on the wire but nothing reads it, so the parsed session drops it.
 const SESSION = { linkUrl: 'https://link', token: 'vault-token', tokenExpiresTime: '2026-07-24T00:00:00Z' };
+const PARSED_SESSION = { linkUrl: SESSION.linkUrl, token: SESSION.token };
+const WALLET_SIGNATURE: WalletSignature = {
+  hexSignature: '0xsig',
+  method: WalletSignatureMethod.EthPersonalSign,
+  timestamp: '1750789885',
+};
 const CREATE_BUY_ORDER_PARAMS: CreateBuyOrderParams = {
   id: '997b3d75-9f76-4038-a173-73c7ff37992f',
   walletAddress: '0x4d957c58d081c1c8c8aafe1e08de047fff19eb88',
@@ -38,17 +51,37 @@ const CREATE_BUY_ORDER_PARAMS: CreateBuyOrderParams = {
   depositAmount: '0.10',
   cardId: '4a2dab9c-3bb6-4c32-8aea-e5fd4ad4c771',
 };
-const CREATED_BUY_ORDER: CreatedBuyOrder = {
+const CREATED_TIME = '2026-07-29T16:07:57.965076Z';
+const COMPLETED_TIME = '2026-07-29T16:08:20.000Z';
+const PENDING_BUY_ORDER: Extract<BuyOrder, { status: OrderStatus.Pending }> = {
   id: CREATE_BUY_ORDER_PARAMS.id,
   status: OrderStatus.Pending,
-  createdTime: '2026-07-29T16:07:57.965076Z',
 };
-const BUY_ORDER: BuyOrder = {
-  ...CREATED_BUY_ORDER,
+const PROCESSING_BUY_ORDER: Extract<BuyOrder, { status: OrderStatus.Processing }> = {
+  id: CREATE_BUY_ORDER_PARAMS.id,
+  status: OrderStatus.Processing,
+};
+const COMPLETED_ORDER_BODY = {
+  id: CREATE_BUY_ORDER_PARAMS.id,
+  status: OrderStatus.Completed as const,
   cryptoAmount: { amount: '0.10', asset: CREATE_BUY_ORDER_PARAMS.cryptoAsset },
   fiatAmount: { amount: '0.10', currency: 'USD' },
-  status: OrderStatus.Pending,
+  createdTime: CREATED_TIME,
   walletAddress: CREATE_BUY_ORDER_PARAMS.walletAddress,
+  transactionHash: '0xtx',
+  completedTime: COMPLETED_TIME,
+};
+// Timestamps arrive as ISO strings and land as epoch ms; `asset` keeps only the network, the one part anything reads.
+const COMPLETED_BUY_ORDER = {
+  ...COMPLETED_ORDER_BODY,
+  cryptoAmount: { amount: '0.10', asset: { network: CREATE_BUY_ORDER_PARAMS.cryptoAsset.network } },
+  createdTime: new Date(CREATED_TIME).getTime(),
+  completedTime: new Date(COMPLETED_TIME).getTime(),
+} satisfies Extract<BuyOrder, { status: OrderStatus.Completed }>;
+const FAILED_BUY_ORDER: Extract<BuyOrder, { status: OrderStatus.Failed }> = {
+  id: CREATE_BUY_ORDER_PARAMS.id,
+  status: OrderStatus.Failed,
+  failureReason: OrderFailureReason.PaymentRejected,
 };
 
 function fetchError(status: number, message: string) {
@@ -65,7 +98,7 @@ beforeEach(() => {
 
 describe('startCardLinkSession', () => {
   it('sends the user JWT as the bearer', async () => {
-    await expect(startCardLinkSession()).resolves.toEqual(SESSION);
+    await expect(startCardLinkSession()).resolves.toEqual(PARSED_SESSION);
 
     expect(mockEnsureAccessToken).toHaveBeenCalledWith('cardLink');
     expect(post).toHaveBeenCalledWith(
@@ -79,7 +112,7 @@ describe('startCardLinkSession', () => {
     post.mockRejectedValueOnce(fetchError(401, 'unauthorized'));
     mockEnsureAccessToken.mockResolvedValueOnce('jwt-stale').mockResolvedValueOnce('jwt-fresh');
 
-    await expect(startCardLinkSession()).resolves.toEqual(SESSION);
+    await expect(startCardLinkSession()).resolves.toEqual(PARSED_SESSION);
 
     expect(useCashAuthTokenStore.getState().token).toBeNull();
     expect(mockEnsureAccessToken).toHaveBeenCalledTimes(2);
@@ -122,9 +155,9 @@ describe('completeCardLinkSession', () => {
 
 describe('buy orders', () => {
   it('creates a buy order with the authenticated ramp endpoint', async () => {
-    post.mockResolvedValue({ data: CREATED_BUY_ORDER });
+    post.mockResolvedValue({ data: { id: CREATE_BUY_ORDER_PARAMS.id, status: 'ORDER_STATUS_NEW', createdTime: CREATED_TIME } });
 
-    await expect(createBuyOrder(CREATE_BUY_ORDER_PARAMS)).resolves.toEqual(CREATED_BUY_ORDER);
+    await expect(createBuyOrder(CREATE_BUY_ORDER_PARAMS)).resolves.toBeUndefined();
 
     expect(mockEnsureAccessToken).toHaveBeenCalledWith('addCash');
     expect(post).toHaveBeenCalledWith('/ramp/orders/buy', CREATE_BUY_ORDER_PARAMS, {
@@ -134,14 +167,205 @@ describe('buy orders', () => {
 
   it('fetches and unwraps an order by id', async () => {
     const abortController = new AbortController();
-    get.mockResolvedValue({ data: { order: BUY_ORDER } });
+    get.mockResolvedValue({ data: { order: { ...PENDING_BUY_ORDER, id: 'different-response-id' } } });
 
-    await expect(getOrder(CREATE_BUY_ORDER_PARAMS.id, abortController)).resolves.toEqual(BUY_ORDER);
+    await expect(getOrder(CREATE_BUY_ORDER_PARAMS.id, abortController)).resolves.toEqual(PENDING_BUY_ORDER);
 
     expect(mockEnsureAccessToken).toHaveBeenCalledWith('addCash');
     expect(get).toHaveBeenCalledWith(`/ramp/orders/${CREATE_BUY_ORDER_PARAMS.id}`, {
       abortController,
       headers: { Authorization: 'Bearer jwt-1' },
     });
+  });
+});
+
+describe('response validation', () => {
+  it('accepts a create response with no readable fields', async () => {
+    post.mockResolvedValue({ data: {} });
+
+    await expect(createBuyOrder(CREATE_BUY_ORDER_PARAMS)).resolves.toBeUndefined();
+  });
+
+  const readableOrders: { label: string; body: unknown; order: BuyOrder }[] = [
+    { label: 'pending', body: PENDING_BUY_ORDER, order: PENDING_BUY_ORDER },
+    { label: 'processing', body: PROCESSING_BUY_ORDER, order: PROCESSING_BUY_ORDER },
+    { label: 'completed', body: COMPLETED_ORDER_BODY, order: COMPLETED_BUY_ORDER },
+    { label: 'failed', body: FAILED_BUY_ORDER, order: FAILED_BUY_ORDER },
+  ];
+
+  // Every non-completed fixture carries nothing but its id and status: protojson omits each field the
+  // backend has not populated, so that is what an unquoted order looks like on the wire.
+  it.each(readableOrders)('accepts a $label order', async ({ body, order }) => {
+    get.mockResolvedValue({ data: { order: body } });
+
+    await expect(getOrder(CREATE_BUY_ORDER_PARAMS.id)).resolves.toEqual(order);
+  });
+
+  it.each([
+    { label: 'pending', body: { ...COMPLETED_ORDER_BODY, status: OrderStatus.Pending }, order: PENDING_BUY_ORDER },
+    { label: 'processing', body: { ...COMPLETED_ORDER_BODY, status: OrderStatus.Processing }, order: PROCESSING_BUY_ORDER },
+    {
+      label: 'failed',
+      body: { ...COMPLETED_ORDER_BODY, status: OrderStatus.Failed, failureReason: OrderFailureReason.PaymentRejected },
+      order: FAILED_BUY_ORDER,
+    },
+  ])('drops completed-order fields from a $label order', async ({ body, order }) => {
+    get.mockResolvedValue({ data: { order: body } });
+
+    await expect(getOrder(CREATE_BUY_ORDER_PARAMS.id)).resolves.toEqual(order);
+  });
+
+  const withCryptoAmount = (amount: unknown) => ({
+    order: { ...COMPLETED_ORDER_BODY, cryptoAmount: { ...COMPLETED_ORDER_BODY.cryptoAmount, amount } },
+  });
+  const withAsset = (asset: Record<string, unknown>) => ({
+    order: {
+      ...COMPLETED_ORDER_BODY,
+      cryptoAmount: { ...COMPLETED_ORDER_BODY.cryptoAmount, asset: { ...COMPLETED_ORDER_BODY.cryptoAmount.asset, ...asset } },
+    },
+  });
+  const withoutField = (field: keyof typeof COMPLETED_ORDER_BODY) => {
+    const order: Record<string, unknown> = { ...COMPLETED_ORDER_BODY };
+    delete order[field];
+    return { order };
+  };
+
+  const unreadableOrderBodies: { label: string; body: unknown }[] = [
+    // rainbowFetch returns the raw text for any body that is not application/json.
+    { label: 'a body that is not JSON', body: '<html>502 Bad Gateway</html>' },
+    { label: 'an envelope with no order', body: {} },
+    { label: 'an order with no status', body: { order: { id: CREATE_BUY_ORDER_PARAMS.id } } },
+    { label: 'a status the client cannot act on', body: { order: { ...PENDING_BUY_ORDER, status: 'ORDER_STATUS_REFUNDED' } } },
+  ];
+
+  it.each(unreadableOrderBodies)('rejects $label', async ({ body }) => {
+    get.mockResolvedValue({ data: body });
+
+    await expect(getOrder(CREATE_BUY_ORDER_PARAMS.id)).rejects.toThrow(ResponseParseError);
+  });
+
+  const readableCompletedOrderBodies: { label: string; body: unknown }[] = [
+    { label: 'no transaction hash', body: withoutField('transactionHash') },
+    { label: 'no wallet address', body: withoutField('walletAddress') },
+    { label: 'no fiat amount', body: withoutField('fiatAmount') },
+    { label: 'no crypto amount', body: withoutField('cryptoAmount') },
+  ];
+
+  it.each(readableCompletedOrderBodies)('accepts a completed order with $label', async ({ body }) => {
+    get.mockResolvedValue({ data: body });
+
+    await expect(getOrder(CREATE_BUY_ORDER_PARAMS.id)).resolves.toMatchObject({
+      id: CREATE_BUY_ORDER_PARAMS.id,
+      status: OrderStatus.Completed,
+    });
+  });
+
+  const unusableCryptoAmounts: { label: string; body: unknown }[] = [
+    { label: 'an unknown asset', body: withAsset({ asset: 'CRYPTO_ASSET_ETH' }) },
+    { label: 'an unknown network', body: withAsset({ network: 'NETWORK_SOLANA' }) },
+    { label: 'a malformed amount', body: withCryptoAmount('not-a-number') },
+    { label: 'a zero amount', body: withCryptoAmount('0') },
+    { label: 'a negative amount', body: withCryptoAmount('-1') },
+  ];
+
+  // An amount that cannot be turned into an Activity row drops out on its own rather than taking the
+  // order down with it: the status still resolves, so the purchase is not stranded mid-poll.
+  it.each(unusableCryptoAmounts)('drops a crypto amount with $label', async ({ body }) => {
+    get.mockResolvedValue({ data: body });
+
+    const order = await getOrder(CREATE_BUY_ORDER_PARAMS.id);
+
+    expect(order.status).toBe(OrderStatus.Completed);
+    if (order.status !== OrderStatus.Completed) throw new Error('Expected a completed order');
+    expect(order.cryptoAmount).toBeUndefined();
+  });
+
+  it('falls back to unspecified for a failure reason the client does not model', async () => {
+    get.mockResolvedValue({ data: { order: { ...FAILED_BUY_ORDER, failureReason: 'ORDER_FAILURE_REASON_FRAUD' } } });
+
+    await expect(getOrder(CREATE_BUY_ORDER_PARAMS.id)).resolves.toMatchObject({
+      status: OrderStatus.Failed,
+      failureReason: OrderFailureReason.Unspecified,
+    });
+  });
+
+  it('falls back to unspecified when a failed order carries no reason', async () => {
+    get.mockResolvedValue({ data: { order: { id: CREATE_BUY_ORDER_PARAMS.id, status: OrderStatus.Failed } } });
+
+    await expect(getOrder(CREATE_BUY_ORDER_PARAMS.id)).resolves.toMatchObject({ failureReason: OrderFailureReason.Unspecified });
+  });
+
+  it('accepts a card brand the client does not model', async () => {
+    post.mockResolvedValue({ data: { card: { brand: 'CARD_BRAND_JCB', id: 'card-1', lastFourDigits: '8990' } } });
+
+    await expect(completeCardLinkSession({ brand: CardBrand.Unspecified, providerCardId: 'prov-1' })).resolves.toEqual({
+      brand: 'Card',
+      id: 'card-1',
+      last4: '8990',
+    });
+  });
+
+  it('rejects a card-link session with no vault url', async () => {
+    post.mockResolvedValue({ data: { token: 'vault-token' } });
+
+    await expect(startCardLinkSession()).rejects.toThrow(ResponseParseError);
+  });
+
+  it('rejects a linked card with no last four digits', async () => {
+    post.mockResolvedValue({ data: { card: { brand: CardBrand.Visa, id: 'card-1' } } });
+
+    await expect(completeCardLinkSession({ brand: CardBrand.Visa, providerCardId: 'prov-1' })).rejects.toThrow(ResponseParseError);
+  });
+
+  it('uses the submitted address when the linked-wallet response has no address', async () => {
+    post.mockResolvedValue({ data: { wallet: { id: 'wallet-1' } } });
+
+    await expect(linkWallet({ address: '0xabc', signature: WALLET_SIGNATURE })).resolves.toEqual({
+      id: 'wallet-1',
+      address: '0xabc',
+    });
+  });
+
+  it.each([
+    { label: 'missing', wallet: { address: '0xabc' } },
+    { label: 'empty', wallet: { id: '', address: '0xabc' } },
+  ])('rejects a linked-wallet response whose id is $label', async ({ wallet }) => {
+    post.mockResolvedValue({ data: { wallet } });
+
+    await expect(linkWallet({ address: '0xabc', signature: WALLET_SIGNATURE })).rejects.toThrow(ResponseParseError);
+  });
+
+  it('drops invalid wallets without losing valid wallets', async () => {
+    get.mockResolvedValue({
+      data: {
+        wallets: [
+          { id: 'wallet-invalid', address: '' },
+          { id: 'wallet-valid', address: '0xabc' },
+        ],
+      },
+    });
+
+    await expect(listWallets()).resolves.toEqual([{ id: 'wallet-valid', address: '0xabc' }]);
+  });
+
+  it('drops invalid cards without losing valid cards', async () => {
+    get.mockResolvedValue({
+      data: {
+        cards: [
+          { brand: CardBrand.Visa, id: '', lastFourDigits: '1111' },
+          { brand: CardBrand.Mastercard, id: 'card-valid', lastFourDigits: '8990' },
+        ],
+      },
+    });
+
+    await expect(listCards({ trigger: 'signInScreen' })).resolves.toEqual([
+      { brand: 'Mastercard', id: 'card-valid', last4: '8990' },
+    ]);
+  });
+
+  it('reads an empty wallet list from an empty envelope', async () => {
+    get.mockResolvedValue({ data: {} });
+
+    await expect(listWallets()).resolves.toEqual([]);
   });
 });

--- a/src/features/cash/services/rampClient.ts
+++ b/src/features/cash/services/rampClient.ts
@@ -4,6 +4,7 @@ import { z } from 'zod';
 import { parseResponse } from '@/framework/data/http/parseResponse';
 import { RainbowFetchError } from '@/framework/data/http/rainbowFetch';
 import { greaterThan } from '@/helpers/utilities';
+import { logger } from '@/logger';
 
 import { useCashAuthTokenStore } from '../stores/cashAuthTokenStore';
 import type { LinkedCard } from '../stores/cashPaymentMethodStore';
@@ -77,27 +78,50 @@ const epochMsSchema = z
   .transform(value => new Date(value).getTime())
   .refine(Number.isFinite);
 
+type RampContractIssue = { code: string; path: string };
+
+function toRampContractIssues(issues: z.ZodIssue[], prefix: (string | number)[] = []): RampContractIssue[] {
+  return issues.map(issue => ({ code: issue.code, path: [...prefix, ...issue.path].join('.') || '<root>' }));
+}
+
+function reportRampContractViolation(source: string, issues: RampContractIssue[], metadata?: Record<string, unknown>): void {
+  logger.warn(`[rampClient] normalized malformed response from ${source}`, { issues, ...metadata });
+}
+
 /** A value the client cannot use degrades to `undefined`, so a readable status is never lost to a field the order can do without. */
-const lenient = <S extends z.ZodTypeAny>(schema: S) => schema.optional().catch(undefined);
-const validRowsSchema = <S extends z.ZodTypeAny>(schema: S) =>
+const lenient = <S extends z.ZodTypeAny>(source: string, schema: S) =>
+  schema.optional().catch(ctx => {
+    reportRampContractViolation(source, toRampContractIssues(ctx.error.issues));
+    return undefined;
+  });
+
+const validRowsSchema = <S extends z.ZodTypeAny>(source: string, schema: S) =>
   z
     .array(z.unknown())
     .default([])
-    .transform(rows =>
-      rows.flatMap((row): z.infer<S>[] => {
+    .transform(rows => {
+      const valid: z.infer<S>[] = [];
+      const issues: RampContractIssue[] = [];
+
+      for (const [index, row] of rows.entries()) {
         const result = schema.safeParse(row);
-        return result.success ? [result.data] : [];
-      })
-    );
+        if (result.success) valid.push(result.data);
+        else issues.push(...toRampContractIssues(result.error.issues, [index]));
+      }
+
+      if (issues.length) reportRampContractViolation(source, issues, { totalRows: rows.length });
+      return valid;
+    });
 
 const buyOrderSchema = z.discriminatedUnion('status', [
   z.object({ status: z.literal(OrderStatus.Pending) }),
   z.object({ status: z.literal(OrderStatus.Processing) }),
   z.object({
     status: z.literal(OrderStatus.Completed),
-    completedTime: lenient(epochMsSchema),
-    createdTime: lenient(epochMsSchema),
+    completedTime: lenient('getOrder', epochMsSchema),
+    createdTime: lenient('getOrder', epochMsSchema),
     cryptoAmount: lenient(
+      'getOrder',
       z.object({
         amount: z.string().refine(value => greaterThan(value, 0)),
         asset: z
@@ -105,9 +129,9 @@ const buyOrderSchema = z.discriminatedUnion('status', [
           .transform(({ network }) => ({ network })),
       })
     ),
-    fiatAmount: lenient(z.object({ amount: z.string(), currency: z.string() })),
-    transactionHash: lenient(z.string()),
-    walletAddress: lenient(z.string()),
+    fiatAmount: lenient('getOrder', z.object({ amount: z.string(), currency: z.string() })),
+    transactionHash: lenient('getOrder', z.string()),
+    walletAddress: lenient('getOrder', z.string()),
   }),
   z.object({
     status: z.literal(OrderStatus.Failed),
@@ -147,7 +171,7 @@ type CompleteCardLinkSessionRequest = { providerCardId: string; brand: CardBrand
 const completeCardLinkSessionResponseSchema = z.object({ card: rampCardSchema });
 
 // protojson drops empty repeated fields, so an account with no cards responds `{}`.
-const listCardsResponseSchema = z.object({ cards: validRowsSchema(rampCardSchema) });
+const listCardsResponseSchema = z.object({ cards: validRowsSchema('listCards', rampCardSchema) });
 
 const CARD_BRAND_LABELS: Record<CardBrand, string> = {
   [CardBrand.Unspecified]: 'Card',
@@ -237,7 +261,7 @@ export async function deleteCard(cardId: string, abortController?: AbortControll
 const rampWalletSchema = z.object({ id: z.string().min(1), address: z.string().min(1) });
 export type RampWallet = z.infer<typeof rampWalletSchema>;
 
-const listWalletsResponseSchema = z.object({ wallets: validRowsSchema(rampWalletSchema) });
+const listWalletsResponseSchema = z.object({ wallets: validRowsSchema('listWallets', rampWalletSchema) });
 const linkWalletResponseSchema = z.object({ wallet: rampWalletSchema.pick({ id: true }) });
 
 export type WalletSignature = {
@@ -276,11 +300,14 @@ export async function createBuyOrder(params: CreateBuyOrderParams): Promise<void
 }
 
 export async function getOrder(orderId: string, abortController?: AbortController | null): Promise<BuyOrder> {
-  if (IS_TESTING === 'true') return e2eGetOrder(orderId);
-
-  const { data } = await authorizedRequest('addCash', headers =>
-    getCashPlatformClient().get(`/ramp/orders/${encodeURIComponent(orderId)}`, { abortController, headers })
-  );
+  const data =
+    IS_TESTING === 'true'
+      ? e2eGetOrderResponse(orderId)
+      : (
+          await authorizedRequest('addCash', headers =>
+            getCashPlatformClient().get(`/ramp/orders/${encodeURIComponent(orderId)}`, { abortController, headers })
+          )
+        ).data;
   return { ...parseResponse(getOrderResponseSchema, data, 'getOrder').order, id: orderId };
 }
 
@@ -292,8 +319,8 @@ export async function getOrder(orderId: string, abortController?: AbortControlle
 const E2E_ORDER_PATH = [OrderStatus.Pending, OrderStatus.Processing, OrderStatus.Processing, OrderStatus.Completed] as const;
 
 type E2EOrderRecord = {
-  completedTime?: number;
-  createdTime: number;
+  completedTime?: string;
+  createdTime: string;
   cryptoAsset: RampAsset;
   depositAmount: string;
   step: number;
@@ -306,7 +333,7 @@ function e2eCreateBuyOrder(params: CreateBuyOrderParams): void {
   if (e2eOrders.has(params.id)) return;
 
   e2eOrders.set(params.id, {
-    createdTime: Date.now(),
+    createdTime: new Date().toISOString(),
     cryptoAsset: params.cryptoAsset,
     depositAmount: params.depositAmount,
     step: 0,
@@ -314,7 +341,7 @@ function e2eCreateBuyOrder(params: CreateBuyOrderParams): void {
   });
 }
 
-function e2eGetOrder(orderId: string): BuyOrder {
+function e2eGetOrderResponse(orderId: string) {
   const record = e2eOrders.get(orderId);
   if (!record) throw new RampError(`Unknown order ${orderId}`);
   if (record.step < E2E_ORDER_PATH.length - 1) record.step += 1;
@@ -322,21 +349,23 @@ function e2eGetOrder(orderId: string): BuyOrder {
   const status = E2E_ORDER_PATH[record.step];
   switch (status) {
     case OrderStatus.Completed:
-      record.completedTime ??= Date.now();
+      record.completedTime ??= new Date().toISOString();
       return {
-        id: orderId,
-        status,
-        // E2E treats USDC as 1:1 with USD; the real backend returns the quoted crypto amount.
-        cryptoAmount: { amount: record.depositAmount, asset: { network: record.cryptoAsset.network } },
-        fiatAmount: { amount: record.depositAmount, currency: 'USD' },
-        createdTime: record.createdTime,
-        walletAddress: record.walletAddress,
-        transactionHash: `mock-tx-${orderId}`,
-        completedTime: record.completedTime,
+        order: {
+          id: orderId,
+          status,
+          // E2E treats USDC as 1:1 with USD; the real backend returns the quoted crypto amount.
+          cryptoAmount: { amount: record.depositAmount, asset: record.cryptoAsset },
+          fiatAmount: { amount: record.depositAmount, currency: 'USD' },
+          createdTime: record.createdTime,
+          walletAddress: record.walletAddress,
+          transactionHash: `mock-tx-${orderId}`,
+          completedTime: record.completedTime,
+        },
       };
     case OrderStatus.Processing:
-      return { id: orderId, status };
+      return { order: { id: orderId, status } };
     default:
-      return { id: orderId, status: OrderStatus.Pending };
+      return { order: { id: orderId, status: OrderStatus.Pending } };
   }
 }

--- a/src/features/cash/services/rampClient.ts
+++ b/src/features/cash/services/rampClient.ts
@@ -1,6 +1,9 @@
 import { IS_TESTING } from 'react-native-dotenv';
+import { z } from 'zod';
 
+import { parseResponse } from '@/framework/data/http/parseResponse';
 import { RainbowFetchError } from '@/framework/data/http/rainbowFetch';
+import { greaterThan } from '@/helpers/utilities';
 
 import { useCashAuthTokenStore } from '../stores/cashAuthTokenStore';
 import type { LinkedCard } from '../stores/cashPaymentMethodStore';
@@ -48,9 +51,12 @@ export enum WalletSignatureMethod {
 
 // ---- Request / response shapes ---------------------------------------------
 
-export type RampAsset = { asset: RampCryptoAsset; network: RampNetwork };
-export type CryptoAmount = { amount: string; asset: RampAsset };
-export type FiatAmount = { amount: string; currency: string };
+const cashRampNetworkSchema = z.union([z.literal(RampNetwork.ArbitrumTestnet), z.literal(RampNetwork.Base)]);
+
+export type RampAsset = {
+  asset: RampCryptoAsset.USDC;
+  network: z.infer<typeof cashRampNetworkSchema>;
+};
 
 export type BuyOrderSpec = {
   cardId: string;
@@ -65,26 +71,51 @@ export type CreateBuyOrderParams = BuyOrderSpec & {
   cryptoAsset: RampAsset;
 };
 
-export type CreatedBuyOrder = {
-  id: string;
-  status: OrderStatus;
-  createdTime: string;
-};
+/** The wire carries ISO 8601; nothing displays these, so they land as epoch ms for the one reader that differences them. */
+const epochMsSchema = z
+  .string()
+  .transform(value => new Date(value).getTime())
+  .refine(Number.isFinite);
 
-type BuyOrderCommon = {
-  id: string;
-  cryptoAmount: CryptoAmount;
-  fiatAmount: FiatAmount;
-  /** ISO 8601 timestamp of when the order was created. */
-  createdTime: string;
-  walletAddress: string;
-};
+/** A value the client cannot use degrades to `undefined`, so a readable status is never lost to a field the order can do without. */
+const lenient = <S extends z.ZodTypeAny>(schema: S) => schema.optional().catch(undefined);
+const validRowsSchema = <S extends z.ZodTypeAny>(schema: S) =>
+  z
+    .array(z.unknown())
+    .default([])
+    .transform(rows =>
+      rows.flatMap((row): z.infer<S>[] => {
+        const result = schema.safeParse(row);
+        return result.success ? [result.data] : [];
+      })
+    );
 
-export type BuyOrder =
-  | (BuyOrderCommon & { status: OrderStatus.Pending })
-  | (BuyOrderCommon & { status: OrderStatus.Processing })
-  | (BuyOrderCommon & { status: OrderStatus.Completed; transactionHash: string; completedTime: string })
-  | (BuyOrderCommon & { status: OrderStatus.Failed; failureReason: OrderFailureReason });
+const buyOrderSchema = z.discriminatedUnion('status', [
+  z.object({ status: z.literal(OrderStatus.Pending) }),
+  z.object({ status: z.literal(OrderStatus.Processing) }),
+  z.object({
+    status: z.literal(OrderStatus.Completed),
+    completedTime: lenient(epochMsSchema),
+    createdTime: lenient(epochMsSchema),
+    cryptoAmount: lenient(
+      z.object({
+        amount: z.string().refine(value => greaterThan(value, 0)),
+        asset: z
+          .object({ asset: z.literal(RampCryptoAsset.USDC), network: cashRampNetworkSchema })
+          .transform(({ network }) => ({ network })),
+      })
+    ),
+    fiatAmount: lenient(z.object({ amount: z.string(), currency: z.string() })),
+    transactionHash: lenient(z.string()),
+    walletAddress: lenient(z.string()),
+  }),
+  z.object({
+    status: z.literal(OrderStatus.Failed),
+    failureReason: z.nativeEnum(OrderFailureReason).catch(OrderFailureReason.Unspecified),
+  }),
+]);
+
+export type BuyOrder = z.infer<typeof buyOrderSchema> & { id: string };
 
 export type TerminalBuyOrder = Extract<BuyOrder, { status: OrderStatus.Completed | OrderStatus.Failed }>;
 
@@ -101,19 +132,22 @@ export class RampError extends Error {
 
 // ---- Card link session -----------------------------------------------------
 
-type StartCardLinkSessionResponse = { linkUrl: string; token: string; tokenExpiresTime: string };
+const startCardLinkSessionResponseSchema = z.object({ linkUrl: z.string().min(1), token: z.string().min(1) });
+type StartCardLinkSessionResponse = z.infer<typeof startCardLinkSessionResponseSchema>;
 
-type RampCard = {
-  brand: CardBrand;
-  id: string;
-  lastFourDigits: string;
-  createdTime: string;
-};
+const rampCardSchema = z.object({
+  brand: z.nativeEnum(CardBrand).catch(CardBrand.Unspecified),
+  id: z.string().min(1),
+  lastFourDigits: z.string(),
+});
+type RampCard = z.infer<typeof rampCardSchema>;
 
 type CompleteCardLinkSessionRequest = { providerCardId: string; brand: CardBrand };
-type CompleteCardLinkSessionResponse = { card: RampCard };
 
-type ListCardsResponse = { cards?: RampCard[] };
+const completeCardLinkSessionResponseSchema = z.object({ card: rampCardSchema });
+
+// protojson drops empty repeated fields, so an account with no cards responds `{}`.
+const listCardsResponseSchema = z.object({ cards: validRowsSchema(rampCardSchema) });
 
 const CARD_BRAND_LABELS: Record<CardBrand, string> = {
   [CardBrand.Unspecified]: 'Card',
@@ -158,9 +192,9 @@ async function authorizedRequest<T>(trigger: CashSignInTrigger, send: (headers: 
 
 export async function startCardLinkSession(abortController?: AbortController | null): Promise<StartCardLinkSessionResponse> {
   const { data } = await authorizedRequest('cardLink', headers =>
-    getCashPlatformClient().post<StartCardLinkSessionResponse>('/ramp/payment-methods/link-card-session', {}, { abortController, headers })
+    getCashPlatformClient().post('/ramp/payment-methods/link-card-session', {}, { abortController, headers })
   );
-  return data;
+  return parseResponse(startCardLinkSessionResponseSchema, data, 'startCardLinkSession');
 }
 
 export async function completeCardLinkSession(
@@ -168,16 +202,13 @@ export async function completeCardLinkSession(
   abortController?: AbortController | null
 ): Promise<LinkedCard> {
   const { data } = await authorizedRequest('cardLink', headers =>
-    getCashPlatformClient().post<CompleteCardLinkSessionResponse>(
+    getCashPlatformClient().post(
       '/ramp/payment-methods/link-card-session/complete',
-      {
-        brand,
-        providerCardId,
-      },
+      { brand, providerCardId },
       { abortController, headers }
     )
   );
-  return toLinkedCard(data.card);
+  return toLinkedCard(parseResponse(completeCardLinkSessionResponseSchema, data, 'completeCardLinkSession').card);
 }
 
 export async function listCards({
@@ -190,10 +221,9 @@ export async function listCards({
   if (IS_TESTING === 'true') return [];
 
   const { data } = await authorizedRequest(trigger, headers =>
-    getCashPlatformClient().get<ListCardsResponse>('/ramp/payment-methods/cards', { abortController, headers })
+    getCashPlatformClient().get('/ramp/payment-methods/cards', { abortController, headers })
   );
-  // protojson drops empty repeated fields, so an account with no cards responds `{}`.
-  return (data.cards ?? []).map(toLinkedCard);
+  return parseResponse(listCardsResponseSchema, data, 'listCards').cards.map(toLinkedCard);
 }
 
 export async function deleteCard(cardId: string, abortController?: AbortController | null): Promise<void> {
@@ -204,7 +234,11 @@ export async function deleteCard(cardId: string, abortController?: AbortControll
 
 // ---- Wallet link -----------------------------------------------------------
 
-export type RampWallet = { id: string; address: string };
+const rampWalletSchema = z.object({ id: z.string().min(1), address: z.string().min(1) });
+export type RampWallet = z.infer<typeof rampWalletSchema>;
+
+const listWalletsResponseSchema = z.object({ wallets: validRowsSchema(rampWalletSchema) });
+const linkWalletResponseSchema = z.object({ wallet: rampWalletSchema.pick({ id: true }) });
 
 export type WalletSignature = {
   /** EIP-191 signature of the link message, 0x-prefixed. */
@@ -214,16 +248,11 @@ export type WalletSignature = {
   timestamp: string;
 };
 
-type ListWalletsResponse = { wallets?: RampWallet[] };
-
-type LinkWalletResponse = { wallet: RampWallet };
-
 export async function listWallets(abortController?: AbortController | null): Promise<RampWallet[]> {
   const { data } = await authorizedRequest('addCash', headers =>
-    getCashPlatformClient().get<ListWalletsResponse>('/ramp/wallets', { abortController, headers })
+    getCashPlatformClient().get('/ramp/wallets', { abortController, headers })
   );
-  // protojson drops empty repeated fields, so an account with no wallets responds `{}`.
-  return data.wallets ?? [];
+  return parseResponse(listWalletsResponseSchema, data, 'listWallets').wallets;
 }
 
 export async function linkWallet(
@@ -231,43 +260,40 @@ export async function linkWallet(
   abortController?: AbortController | null
 ): Promise<RampWallet> {
   const { data } = await authorizedRequest('addCash', headers =>
-    getCashPlatformClient().post<LinkWalletResponse>('/ramp/wallets/link', { address, signature }, { abortController, headers })
+    getCashPlatformClient().post('/ramp/wallets/link', { address, signature }, { abortController, headers })
   );
-  return data.wallet;
+  return { ...parseResponse(linkWalletResponseSchema, data, 'linkWallet').wallet, address };
 }
 
 // ---- Buy orders ------------------------------------------------------------
 
-type GetOrderResponse = { order: BuyOrder };
+const getOrderResponseSchema = z.object({ order: buyOrderSchema });
 
-export async function createBuyOrder(params: CreateBuyOrderParams): Promise<CreatedBuyOrder> {
+export async function createBuyOrder(params: CreateBuyOrderParams): Promise<void> {
   if (IS_TESTING === 'true') return e2eCreateBuyOrder(params);
 
-  const { data } = await authorizedRequest('addCash', headers =>
-    getCashPlatformClient().post<CreatedBuyOrder>('/ramp/orders/buy', params, { headers })
-  );
-  return data;
+  await authorizedRequest('addCash', headers => getCashPlatformClient().post('/ramp/orders/buy', params, { headers }));
 }
 
 export async function getOrder(orderId: string, abortController?: AbortController | null): Promise<BuyOrder> {
   if (IS_TESTING === 'true') return e2eGetOrder(orderId);
 
   const { data } = await authorizedRequest('addCash', headers =>
-    getCashPlatformClient().get<GetOrderResponse>(`/ramp/orders/${encodeURIComponent(orderId)}`, { abortController, headers })
+    getCashPlatformClient().get(`/ramp/orders/${encodeURIComponent(orderId)}`, { abortController, headers })
   );
-  return data.order;
+  return { ...parseResponse(getOrderResponseSchema, data, 'getOrder').order, id: orderId };
 }
 
 // ---- E2E buy orders ----------------------------------------------------------
 // In-memory stand-in for the two order endpoints: `getOrder` advances one scripted
-// step per call, and a `createBuyOrder` replay with a known id returns the existing
-// order without re-creating — mirroring the backend's idempotency contract.
+// step per call, and a `createBuyOrder` replay with a known id leaves the existing
+// order untouched — mirroring the backend's idempotency contract.
 
 const E2E_ORDER_PATH = [OrderStatus.Pending, OrderStatus.Processing, OrderStatus.Processing, OrderStatus.Completed] as const;
 
 type E2EOrderRecord = {
-  completedTime?: string;
-  createdTime: string;
+  completedTime?: number;
+  createdTime: number;
   cryptoAsset: RampAsset;
   depositAmount: string;
   step: number;
@@ -276,19 +302,16 @@ type E2EOrderRecord = {
 
 const e2eOrders = new Map<string, E2EOrderRecord>();
 
-function e2eCreateBuyOrder(params: CreateBuyOrderParams): CreatedBuyOrder {
-  let record = e2eOrders.get(params.id);
-  if (!record) {
-    record = {
-      createdTime: new Date().toISOString(),
-      cryptoAsset: params.cryptoAsset,
-      depositAmount: params.depositAmount,
-      step: 0,
-      walletAddress: params.walletAddress,
-    };
-    e2eOrders.set(params.id, record);
-  }
-  return { id: params.id, status: E2E_ORDER_PATH[record.step], createdTime: record.createdTime };
+function e2eCreateBuyOrder(params: CreateBuyOrderParams): void {
+  if (e2eOrders.has(params.id)) return;
+
+  e2eOrders.set(params.id, {
+    createdTime: Date.now(),
+    cryptoAsset: params.cryptoAsset,
+    depositAmount: params.depositAmount,
+    step: 0,
+    walletAddress: params.walletAddress,
+  });
 }
 
 function e2eGetOrder(orderId: string): BuyOrder {
@@ -296,22 +319,24 @@ function e2eGetOrder(orderId: string): BuyOrder {
   if (!record) throw new RampError(`Unknown order ${orderId}`);
   if (record.step < E2E_ORDER_PATH.length - 1) record.step += 1;
 
-  const common = {
-    id: orderId,
-    // E2E treats USDC as 1:1 with USD; the real backend returns the quoted crypto amount.
-    cryptoAmount: { amount: record.depositAmount, asset: record.cryptoAsset },
-    fiatAmount: { amount: record.depositAmount, currency: 'USD' },
-    createdTime: record.createdTime,
-    walletAddress: record.walletAddress,
-  };
   const status = E2E_ORDER_PATH[record.step];
   switch (status) {
     case OrderStatus.Completed:
-      record.completedTime ??= new Date().toISOString();
-      return { ...common, status, transactionHash: `mock-tx-${orderId}`, completedTime: record.completedTime };
+      record.completedTime ??= Date.now();
+      return {
+        id: orderId,
+        status,
+        // E2E treats USDC as 1:1 with USD; the real backend returns the quoted crypto amount.
+        cryptoAmount: { amount: record.depositAmount, asset: { network: record.cryptoAsset.network } },
+        fiatAmount: { amount: record.depositAmount, currency: 'USD' },
+        createdTime: record.createdTime,
+        walletAddress: record.walletAddress,
+        transactionHash: `mock-tx-${orderId}`,
+        completedTime: record.completedTime,
+      };
     case OrderStatus.Processing:
-      return { ...common, status };
+      return { id: orderId, status };
     default:
-      return { ...common, status: OrderStatus.Pending };
+      return { id: orderId, status: OrderStatus.Pending };
   }
 }

--- a/src/features/cash/stores/cashBuyOrderStore.test.ts
+++ b/src/features/cash/stores/cashBuyOrderStore.test.ts
@@ -8,12 +8,10 @@ import {
   OrderFailureReason,
   OrderStatus,
   createBuyOrder as rampCreateBuyOrder,
-  RampCryptoAsset,
   getOrder as rampGetOrder,
   RampNetwork,
   type BuyOrder,
   type BuyOrderSpec,
-  type CreatedBuyOrder,
   type TerminalBuyOrder,
 } from '../services/rampClient';
 import { buildCashPurchaseTransaction } from '../utils/buildCashPurchaseTransaction';
@@ -24,9 +22,9 @@ jest.mock('@/analytics', () => ({
   analytics: {
     track: jest.fn(),
     event: {
-      cashBuyOrderSubmitted: 'cash.buy_submitted',
       cashBuyOrderCompleted: 'cash.buy_completed',
       cashBuyOrderFailed: 'cash.buy_failed',
+      cashBuyOrderSubmitted: 'cash.buy_submitted',
     },
   },
 }));
@@ -35,7 +33,11 @@ jest.mock('@/features/local-auth/legacyKeychain', () => ({}));
 
 jest.mock('@/logger', () => ({
   logger: { debug: jest.fn(), error: jest.fn(), warn: jest.fn() },
-  RainbowError: class RainbowError extends Error {},
+  RainbowError: class RainbowError extends Error {
+    constructor(message: string, cause?: unknown) {
+      super(message, { cause });
+    }
+  },
 }));
 
 jest.mock('../services/rampClient', () => ({
@@ -77,30 +79,21 @@ const RAMP_WALLET_ADDRESS = WALLET_ADDRESS.toLowerCase();
 
 const SPEC: BuyOrderSpec = { cardId: 'card-1', depositAmount: '50', id: 'order-1', walletAddress: WALLET_ADDRESS };
 const SUBMITTED_AT = 1750789885000;
-const CREATED_PENDING_ORDER: CreatedBuyOrder = {
-  id: SPEC.id,
-  status: OrderStatus.Pending,
-  createdTime: '2026-06-24T18:31:25.000Z',
-};
-const CREATED_COMPLETED_ORDER: CreatedBuyOrder = { ...CREATED_PENDING_ORDER, status: OrderStatus.Completed };
 
-const ORDER_COMMON = {
+const PENDING_ORDER: Exclude<BuyOrder, TerminalBuyOrder> = { id: 'order-1', status: OrderStatus.Pending };
+const PROCESSING_ORDER: Exclude<BuyOrder, TerminalBuyOrder> = { id: 'order-1', status: OrderStatus.Processing };
+const COMPLETED_ORDER = {
   id: 'order-1',
-  cryptoAmount: { amount: '50', asset: { asset: RampCryptoAsset.USDC, network: RampNetwork.Base } },
-  fiatAmount: { amount: '50', currency: 'USD' },
-  createdTime: '2026-06-24T18:31:25.000Z',
-  walletAddress: RAMP_WALLET_ADDRESS,
-};
-const PENDING_ORDER: Exclude<BuyOrder, TerminalBuyOrder> = { ...ORDER_COMMON, status: OrderStatus.Pending };
-const PROCESSING_ORDER: Exclude<BuyOrder, TerminalBuyOrder> = { ...ORDER_COMMON, status: OrderStatus.Processing };
-const COMPLETED_ORDER: Extract<BuyOrder, { status: OrderStatus.Completed }> = {
-  ...ORDER_COMMON,
   status: OrderStatus.Completed,
+  cryptoAmount: { amount: '50', asset: { network: RampNetwork.Base } },
+  fiatAmount: { amount: '50', currency: 'USD' },
+  createdTime: new Date('2026-06-24T18:31:25.000Z').getTime(),
+  walletAddress: RAMP_WALLET_ADDRESS,
   transactionHash: '0xtx',
-  completedTime: '2026-06-24T18:31:31.000Z',
-};
+  completedTime: new Date('2026-06-24T18:31:31.000Z').getTime(),
+} satisfies Extract<BuyOrder, { status: OrderStatus.Completed }>;
 const FAILED_PAYMENT_ORDER: Extract<BuyOrder, { status: OrderStatus.Failed }> = {
-  ...ORDER_COMMON,
+  id: 'order-1',
   status: OrderStatus.Failed,
   failureReason: OrderFailureReason.PaymentRejected,
 };
@@ -128,7 +121,7 @@ beforeEach(() => {
 
 describe('submitBuyOrder', () => {
   it('rounds the amount before tracking a submitted order', async () => {
-    createBuyOrder.mockResolvedValue(CREATED_PENDING_ORDER);
+    createBuyOrder.mockResolvedValue(undefined);
 
     await getState().submitBuyOrder({ ...SUBMIT_INPUT, depositAmount: '123.456789' });
 
@@ -136,7 +129,7 @@ describe('submitBuyOrder', () => {
   });
 
   it('builds a spec, creates the order, and surfaces the created order id as pending', async () => {
-    createBuyOrder.mockResolvedValue(CREATED_PENDING_ORDER);
+    createBuyOrder.mockResolvedValue(undefined);
 
     await getState().submitBuyOrder(SUBMIT_INPUT);
 
@@ -145,8 +138,8 @@ describe('submitBuyOrder', () => {
     expect(phase()).toBe('pending');
   });
 
-  it('fetches full details before applying a terminal status returned by an idempotent create replay', async () => {
-    createBuyOrder.mockResolvedValue(CREATED_COMPLETED_ORDER);
+  it('fetches full details before applying a terminal order', async () => {
+    createBuyOrder.mockResolvedValue(undefined);
     getOrder.mockResolvedValue(COMPLETED_ORDER);
 
     await getState().submitBuyOrder(SUBMIT_INPUT);
@@ -156,7 +149,7 @@ describe('submitBuyOrder', () => {
 
     await getState().syncActiveOrder();
 
-    expect(getOrder).toHaveBeenCalledWith(CREATED_COMPLETED_ORDER.id, expect.any(AbortController));
+    expect(getOrder).toHaveBeenCalledWith(SPEC.id, expect.any(AbortController));
     expect(addPendingTransaction).toHaveBeenCalled();
     expect(phase()).toBe('success');
   });
@@ -180,7 +173,7 @@ describe('submitBuyOrder', () => {
     { label: 'a 429', failure: fetchError(429) },
     { label: 'a 500', failure: fetchError(500) },
   ])('replays the same order id when retrying after $label', async ({ failure }) => {
-    createBuyOrder.mockRejectedValueOnce(failure).mockResolvedValueOnce(CREATED_PENDING_ORDER);
+    createBuyOrder.mockRejectedValueOnce(failure).mockResolvedValueOnce(undefined);
 
     await getState().submitBuyOrder(SUBMIT_INPUT);
     await getState().submitBuyOrder(SUBMIT_INPUT);
@@ -191,7 +184,7 @@ describe('submitBuyOrder', () => {
   });
 
   it('generates a fresh order id when retrying after a definitive backend rejection', async () => {
-    createBuyOrder.mockRejectedValueOnce(fetchError(422)).mockResolvedValueOnce({ ...CREATED_PENDING_ORDER, id: 'order-2' });
+    createBuyOrder.mockRejectedValueOnce(fetchError(422)).mockResolvedValueOnce(undefined);
 
     await getState().submitBuyOrder(SUBMIT_INPUT);
     expect(getState().status).toEqual({ step: 'error', errorCode: 'GENERIC', order: null, spec: undefined });
@@ -201,7 +194,7 @@ describe('submitBuyOrder', () => {
   });
 
   it('generates a fresh order id when the retried inputs differ from the retained spec', async () => {
-    createBuyOrder.mockRejectedValueOnce(new Error('network down')).mockResolvedValueOnce({ ...CREATED_PENDING_ORDER, id: 'order-2' });
+    createBuyOrder.mockRejectedValueOnce(new Error('network down')).mockResolvedValueOnce(undefined);
 
     await getState().submitBuyOrder(SUBMIT_INPUT);
     await getState().submitBuyOrder({ ...SUBMIT_INPUT, depositAmount: '100' });
@@ -229,7 +222,7 @@ describe('submitBuyOrder', () => {
 
   it('keeps the linked-wallet cache when the order is created', async () => {
     useCashWalletStore.setState({ linkedWallets: [LINKED_WALLET] });
-    createBuyOrder.mockResolvedValue(CREATED_PENDING_ORDER);
+    createBuyOrder.mockResolvedValue(undefined);
 
     await getState().submitBuyOrder(SUBMIT_INPUT);
 
@@ -237,9 +230,9 @@ describe('submitBuyOrder', () => {
   });
 
   it('ignores a second submission while one is already in flight', async () => {
-    let resolveOrder: (order: CreatedBuyOrder) => void = () => undefined;
+    let resolveOrder: () => void = () => undefined;
     createBuyOrder.mockReturnValue(
-      new Promise<CreatedBuyOrder>(resolve => {
+      new Promise<void>(resolve => {
         resolveOrder = resolve;
       })
     );
@@ -249,7 +242,7 @@ describe('submitBuyOrder', () => {
 
     expect(createBuyOrder).toHaveBeenCalledTimes(1);
 
-    resolveOrder(CREATED_PENDING_ORDER);
+    resolveOrder();
     await inFlight;
   });
 });
@@ -332,6 +325,51 @@ describe('syncActiveOrder', () => {
     });
     expect(getState().status).toEqual({ step: 'success', order: COMPLETED_ORDER });
     expect(phase()).toBe('success');
+    expect(track).toHaveBeenCalledWith('cash.buy_completed', {
+      fiatAmount: 50,
+      fiatCurrency: 'USD',
+      cryptoAmount: 50,
+      network: RampNetwork.Base,
+      timeToUsdcMs: 6_000,
+    });
+  });
+
+  it('surfaces success without an Activity entry when its required payload is malformed', async () => {
+    startPolling(PROCESSING_ORDER);
+    const orderWithoutWalletAddress = { ...COMPLETED_ORDER, walletAddress: undefined };
+    getOrder.mockResolvedValue(orderWithoutWalletAddress);
+
+    await getState().syncActiveOrder();
+
+    expect(addPendingTransaction).not.toHaveBeenCalled();
+    expect(logger.error).toHaveBeenCalled();
+    expect(getState().status).toEqual({ step: 'success', order: orderWithoutWalletAddress });
+  });
+
+  it('preserves an Activity error as the logged cause', async () => {
+    startPolling(PROCESSING_ORDER);
+    const cause = new Error('failed to build Activity entry');
+    buildPurchaseTransaction.mockImplementationOnce(() => {
+      throw cause;
+    });
+    getOrder.mockResolvedValue(COMPLETED_ORDER);
+
+    await getState().syncActiveOrder();
+
+    const [loggedError] = (logger.error as jest.Mock).mock.calls[0];
+    expect(loggedError.cause).toBe(cause);
+  });
+
+  it('skips completion analytics without blocking the Activity entry or success', async () => {
+    startPolling(PROCESSING_ORDER);
+    const order = { ...COMPLETED_ORDER, completedTime: undefined };
+    getOrder.mockResolvedValue(order);
+
+    await getState().syncActiveOrder();
+
+    expect(track).not.toHaveBeenCalledWith('cash.buy_completed', expect.anything());
+    expect(addPendingTransaction).toHaveBeenCalled();
+    expect(getState().status).toEqual({ step: 'success', order });
   });
 
   it('rounds the fiat and crypto amounts before tracking a completed order', async () => {
@@ -377,13 +415,13 @@ describe('syncActiveOrder', () => {
     expect(phase()).toBe('error');
   });
 
-  it('keeps the current order and logs when polling throws', async () => {
+  it('keeps the current order and rethrows so the watcher can back off', async () => {
     startPolling(PENDING_ORDER);
-    getOrder.mockRejectedValue(new Error('timeout'));
+    const error = new Error('timeout');
+    getOrder.mockRejectedValue(error);
 
-    await getState().syncActiveOrder();
+    await expect(getState().syncActiveOrder()).rejects.toBe(error);
 
-    expect(logger.error).toHaveBeenCalled();
     expect(getState().status).toMatchObject({ step: 'polling', order: PENDING_ORDER });
     expect(phase()).toBe('pending');
   });
@@ -414,13 +452,13 @@ describe('resumePendingSubmission', () => {
   it('replays a rehydrated spec to (idempotently) recreate the order', async () => {
     // Mimics state restored from disk after a crash mid-submission: spec present, no order yet.
     store.setState({ status: { step: 'submitting', spec: SPEC, submittedAt: SUBMITTED_AT } });
-    createBuyOrder.mockResolvedValue(CREATED_PENDING_ORDER);
+    createBuyOrder.mockResolvedValue(undefined);
 
     await getState().resumePendingSubmission();
 
     // same id ⇒ the backend replays, never re-creates
     expect(createBuyOrder).toHaveBeenCalledWith({ ...SPEC, cryptoAsset: CASH_BUY_DESTINATION_ASSET });
-    expect(getState().status).toEqual({ step: 'polling', orderId: CREATED_PENDING_ORDER.id, order: null, submittedAt: SUBMITTED_AT });
+    expect(getState().status).toEqual({ step: 'polling', orderId: SPEC.id, order: null, submittedAt: SUBMITTED_AT });
     expect(phase()).toBe('pending');
   });
 
@@ -442,7 +480,7 @@ describe('concurrent submissions of the same spec', () => {
           rejectOriginal = reject;
         })
       )
-      .mockResolvedValueOnce(CREATED_PENDING_ORDER);
+      .mockResolvedValueOnce(undefined);
 
     const original = getState().submitBuyOrder(SUBMIT_INPUT); // hangs in flight
     await getState().resumePendingSubmission(); // reopen replays the same spec and resolves first
@@ -457,21 +495,21 @@ describe('concurrent submissions of the same spec', () => {
   });
 
   it('drops a late success once polling has already advanced past submission', async () => {
-    let resolveOriginal: (created: CreatedBuyOrder) => void = () => undefined;
+    let resolveOriginal: () => void = () => undefined;
     createBuyOrder
       .mockReturnValueOnce(
-        new Promise<CreatedBuyOrder>(resolve => {
+        new Promise<void>(resolve => {
           resolveOriginal = resolve;
         })
       )
-      .mockResolvedValueOnce(CREATED_PENDING_ORDER);
+      .mockResolvedValueOnce(undefined);
 
     const original = getState().submitBuyOrder(SUBMIT_INPUT);
     await getState().resumePendingSubmission();
     getOrder.mockResolvedValue(PENDING_ORDER);
     await getState().syncActiveOrder();
 
-    resolveOriginal(CREATED_PENDING_ORDER);
+    resolveOriginal();
     await original;
 
     // The late success must not rewind `order` to null.

--- a/src/features/cash/stores/cashBuyOrderStore.ts
+++ b/src/features/cash/stores/cashBuyOrderStore.ts
@@ -84,23 +84,24 @@ export const useCashBuyOrderStore = createBaseStore<CashBuyOrderState>(
   (set, get) => {
     function applyTerminalOrder(order: TerminalBuyOrder): void {
       if (order.status === OrderStatus.Completed) {
-        analytics.track(analytics.event.cashBuyOrderCompleted, {
-          fiatAmount: toAnalyticsAmount(order.fiatAmount.amount),
-          fiatCurrency: order.fiatAmount.currency,
-          cryptoAmount: toAnalyticsAmount(order.cryptoAmount.amount),
-          network: order.cryptoAmount.asset.network,
-          timeToUsdcMs: new Date(order.completedTime).getTime() - new Date(order.createdTime).getTime(),
-        });
+        const { completedTime, createdTime, cryptoAmount, fiatAmount } = order;
+        if (cryptoAmount && fiatAmount && createdTime !== undefined && completedTime !== undefined) {
+          analytics.track(analytics.event.cashBuyOrderCompleted, {
+            fiatAmount: toAnalyticsAmount(fiatAmount.amount),
+            fiatCurrency: fiatAmount.currency,
+            cryptoAmount: toAnalyticsAmount(cryptoAmount.amount),
+            network: cryptoAmount.asset.network,
+            timeToUsdcMs: completedTime - createdTime,
+          });
+        }
         try {
-          // The ramp echoes the address lowercased, while every reader of the pending-transaction store
-          // keys off the app's checksummed account address.
           const walletAddress = requireAddress(order.walletAddress, '[cashBuyOrderStore] ramp returned an invalid wallet address');
           pendingTransactionsActions.addPendingTransaction({
             address: walletAddress,
             pendingTransaction: buildCashPurchaseTransaction({ order, walletAddress }),
           });
         } catch (error) {
-          logger.error(new RainbowError('[cashBuyOrderStore] failed to enqueue purchase transaction', { error }), {
+          logger.error(new RainbowError('[cashBuyOrderStore] failed to enqueue purchase transaction', error), {
             orderId: order.id,
             transactionHash: order.transactionHash,
           });
@@ -123,9 +124,9 @@ export const useCashBuyOrderStore = createBaseStore<CashBuyOrderState>(
 
     async function submitBuyOrderSpec({ spec, submittedAt }: { spec: BuyOrderSpec; submittedAt: number }): Promise<void> {
       try {
-        const created = await createBuyOrder({ ...spec, cryptoAsset: CASH_BUY_DESTINATION_ASSET });
+        await createBuyOrder({ ...spec, cryptoAsset: CASH_BUY_DESTINATION_ASSET });
         if (!isCurrentSubmission(spec)) return;
-        set({ status: { step: 'polling', orderId: created.id, order: null, submittedAt } });
+        set({ status: { step: 'polling', orderId: spec.id, order: null, submittedAt } });
       } catch (error) {
         if (!isCurrentSubmission(spec)) return;
         logger.error(new RainbowError('[cashBuyOrderStore] createBuyOrder failed', error));
@@ -189,8 +190,7 @@ export const useCashBuyOrderStore = createBaseStore<CashBuyOrderState>(
           }
         } catch (error) {
           if (abortController?.signal.aborted) return;
-          // Transient poll failure; retry on the watcher's next tick.
-          logger.error(new RainbowError('[cashBuyOrderStore] getOrder failed', error));
+          throw error;
         } finally {
           abortController?.signal.removeEventListener('abort', propagateAbort);
         }

--- a/src/features/cash/utils/buildCashPurchaseTransaction.test.ts
+++ b/src/features/cash/utils/buildCashPurchaseTransaction.test.ts
@@ -1,28 +1,47 @@
-import { OrderStatus, RampCryptoAsset, RampNetwork, type BuyOrder } from '../services/rampClient';
+import { OrderStatus, RampError, RampNetwork, type BuyOrder } from '../services/rampClient';
 import { buildCashPurchaseTransaction } from './buildCashPurchaseTransaction';
 
-jest.mock('@/utils/getUrlForTrustIconFallback', () => jest.fn(() => undefined));
+jest.mock('@/utils/ethereumUtils', () => ({ getUniqueId: jest.fn(() => 'usdc-base') }));
+jest.mock('@/utils/getUrlForTrustIconFallback', () => jest.fn(() => null));
 
-jest.mock('../services/rampClient', () => ({
-  OrderStatus: { Completed: 'ORDER_STATUS_COMPLETED' },
-  RampCryptoAsset: { USDC: 'CRYPTO_ASSET_USDC' },
-  RampError: class RampError extends Error {},
-  RampNetwork: { ArbitrumTestnet: 'NETWORK_ARBITRUM_TESTNET', Base: 'NETWORK_BASE' },
-}));
+type CompletedBuyOrder = Extract<BuyOrder, { status: OrderStatus.Completed }>;
 
-it('normalizes the transaction hash for Activity deduplication', () => {
-  const order: Extract<BuyOrder, { status: OrderStatus.Completed }> = {
-    id: 'order-1',
-    status: OrderStatus.Completed,
-    cryptoAmount: { amount: '50', asset: { asset: RampCryptoAsset.USDC, network: RampNetwork.Base } },
-    fiatAmount: { amount: '50', currency: 'USD' },
-    createdTime: '2026-06-24T18:31:25.000Z',
-    completedTime: '2026-06-24T18:31:31.000Z',
-    transactionHash: '0xAbCdEf123456',
-    walletAddress: '0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed',
-  };
+const WALLET_ADDRESS = '0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed';
+const ORDER = {
+  id: 'order-1',
+  status: OrderStatus.Completed,
+  cryptoAmount: { amount: '50', asset: { network: RampNetwork.Base } },
+  fiatAmount: { amount: '50', currency: 'USD' },
+  transactionHash: '0xtx',
+} satisfies CompletedBuyOrder;
 
-  const transaction = buildCashPurchaseTransaction({ order, walletAddress: order.walletAddress });
+describe('buildCashPurchaseTransaction', () => {
+  // The amount's format and the network are settled at the ramp boundary; what can still be absent here
+  // is a field the backend simply did not populate.
+  const invalidOrders: { label: string; order: CompletedBuyOrder }[] = [
+    { label: 'no crypto amount', order: { ...ORDER, cryptoAmount: undefined } },
+    { label: 'no transaction hash', order: { ...ORDER, transactionHash: undefined } },
+    { label: 'an empty transaction hash', order: { ...ORDER, transactionHash: '' } },
+  ];
 
-  expect(transaction.hash).toBe('0xabcdef123456');
+  it.each(invalidOrders)('rejects $label before building an Activity entry', ({ order }) => {
+    expect(() => buildCashPurchaseTransaction({ order, walletAddress: WALLET_ADDRESS })).toThrow(RampError);
+  });
+
+  it('passes the amount through untouched and omits the description when there is no fiat amount', () => {
+    const order = { ...ORDER, cryptoAmount: { ...ORDER.cryptoAmount, amount: '1e-3' }, fiatAmount: undefined };
+
+    const transaction = buildCashPurchaseTransaction({ order, walletAddress: WALLET_ADDRESS });
+
+    expect(transaction.amount).toBe('1e-3');
+    expect(transaction.description).toBeUndefined();
+  });
+
+  it('normalizes the transaction hash for Activity deduplication', () => {
+    const order = { ...ORDER, transactionHash: '0xAbCdEf123456' };
+
+    const transaction = buildCashPurchaseTransaction({ order, walletAddress: WALLET_ADDRESS });
+
+    expect(transaction.hash).toBe('0xabcdef123456');
+  });
 });

--- a/src/features/cash/utils/buildCashPurchaseTransaction.ts
+++ b/src/features/cash/utils/buildCashPurchaseTransaction.ts
@@ -16,15 +16,12 @@ export function buildCashPurchaseTransaction({
   order: CompletedBuyOrder;
   walletAddress: string;
 }): RainbowTransaction {
+  const { cryptoAmount, fiatAmount, transactionHash } = order;
+  if (!cryptoAmount || !transactionHash) throw new RampError('Completed order carries no usable purchase details');
+
   const status = TransactionStatus.pending;
-
-  const { network: rampNetwork } = order.cryptoAmount.asset;
-  const usdc = CASH_USDC_BY_NETWORK[rampNetwork];
-  if (!usdc) throw new RampError(`Unsupported ramp network: ${rampNetwork}`);
-
-  const { address, chainId, chainName: network } = usdc;
-  const fiatSymbol = supportedCurrencies[order.fiatAmount.currency as keyof typeof supportedCurrencies]?.symbol ?? '';
-  const rawCryptoAmount = convertAmountToRawAmount(order.cryptoAmount.amount, USDC_DECIMALS);
+  const { address, chainId, chainName: network } = CASH_USDC_BY_NETWORK[cryptoAmount.asset.network];
+  const rawCryptoAmount = convertAmountToRawAmount(cryptoAmount.amount, USDC_DECIMALS);
   const asset = {
     address,
     balance: convertRawAmountToBalance(rawCryptoAmount, { decimals: USDC_DECIMALS, symbol: USDC_SYMBOL }),
@@ -41,7 +38,7 @@ export function buildCashPurchaseTransaction({
   };
 
   return {
-    amount: order.cryptoAmount.amount,
+    amount: cryptoAmount.amount,
     asset,
     chainId,
     changes: [
@@ -53,10 +50,12 @@ export function buildCashPurchaseTransaction({
         value: rawCryptoAmount,
       },
     ],
-    description: `${fiatSymbol}${order.fiatAmount.amount}`,
+    description: fiatAmount
+      ? `${supportedCurrencies[fiatAmount.currency as keyof typeof supportedCurrencies]?.symbol ?? ''}${fiatAmount.amount}`
+      : undefined,
     direction: TransactionDirection.IN,
     from: null,
-    hash: order.transactionHash.toLowerCase(),
+    hash: transactionHash.toLowerCase(),
     network,
     nonce: null,
     status,

--- a/src/framework/data/http/parseResponse.ts
+++ b/src/framework/data/http/parseResponse.ts
@@ -1,0 +1,15 @@
+import type { z } from 'zod';
+
+/** Reports the failing paths and issue codes only — never the received values, which may carry user data. */
+export class ResponseParseError extends Error {
+  constructor(source: string, issues: z.ZodIssue[]) {
+    super(`Malformed response from ${source} (${issues.map(issue => `${issue.path.join('.') || '<root>'}: ${issue.code}`).join(', ')})`);
+    this.name = 'ResponseParseError';
+  }
+}
+
+export function parseResponse<S extends z.ZodTypeAny>(schema: S, data: unknown, source: string): z.infer<S> {
+  const result = schema.safeParse(data);
+  if (!result.success) throw new ResponseParseError(source, result.error.issues);
+  return result.data;
+}

--- a/src/framework/ui/hooks/useTimestampReached.test.ts
+++ b/src/framework/ui/hooks/useTimestampReached.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+import { useTimestampReached } from './useTimestampReached';
+
+const mockUseEffect = jest.fn<(effect: () => void | (() => void)) => void>();
+let mockState: boolean | undefined;
+
+jest.mock('react', () => ({
+  ...(jest.requireActual('react') as object),
+  useEffect: (effect: () => void | (() => void)) => mockUseEffect(effect),
+  useState: (initialValue: () => boolean) => {
+    mockState ??= initialValue();
+    return [mockState, (next: boolean) => void (mockState = next)] as const;
+  },
+}));
+
+describe('useTimestampReached', () => {
+  let cleanup: (() => void) | undefined;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2026-08-20T12:00:00.000Z'));
+    mockState = undefined;
+    mockUseEffect.mockImplementation(effect => {
+      cleanup?.();
+      cleanup = effect() ?? undefined;
+    });
+  });
+
+  afterEach(() => {
+    cleanup?.();
+    cleanup = undefined;
+    jest.clearAllTimers();
+    jest.useRealTimers();
+  });
+
+  it('reports a future timestamp as reached only once it passes', () => {
+    const timestamp = Date.now() + 5_000;
+
+    expect(useTimestampReached(timestamp)).toBe(false);
+
+    jest.advanceTimersByTime(4_999);
+    expect(useTimestampReached(timestamp)).toBe(false);
+
+    jest.advanceTimersByTime(1);
+    expect(useTimestampReached(timestamp)).toBe(true);
+  });
+
+  it('reports a timestamp already in the past as reached without arming a timer', () => {
+    expect(useTimestampReached(Date.now() - 1)).toBe(true);
+    expect(jest.getTimerCount()).toBe(0);
+  });
+
+  it('resets and clears its timer when the timestamp is removed', () => {
+    expect(useTimestampReached(Date.now() + 1_000)).toBe(false);
+    expect(jest.getTimerCount()).toBe(1);
+
+    expect(useTimestampReached(null)).toBe(false);
+    expect(jest.getTimerCount()).toBe(0);
+  });
+
+  it('clears its previous timer when a future timestamp changes', () => {
+    const initialTimestamp = Date.now() + 1_000;
+    const updatedTimestamp = Date.now() + 5_000;
+
+    expect(useTimestampReached(initialTimestamp)).toBe(false);
+    expect(jest.getTimerCount()).toBe(1);
+
+    expect(useTimestampReached(updatedTimestamp)).toBe(false);
+    expect(jest.getTimerCount()).toBe(1);
+
+    jest.advanceTimersByTime(1_000);
+    expect(useTimestampReached(updatedTimestamp)).toBe(false);
+
+    jest.advanceTimersByTime(4_000);
+    expect(useTimestampReached(updatedTimestamp)).toBe(true);
+    expect(jest.getTimerCount()).toBe(0);
+  });
+});

--- a/src/framework/ui/hooks/useTimestampReached.ts
+++ b/src/framework/ui/hooks/useTimestampReached.ts
@@ -1,0 +1,24 @@
+import { useEffect, useState } from 'react';
+
+export function useTimestampReached(timestamp: number | null): boolean {
+  const [hasReached, setHasReached] = useState(() => timestamp !== null && Date.now() >= timestamp);
+
+  useEffect(() => {
+    if (timestamp === null) {
+      setHasReached(false);
+      return;
+    }
+
+    const remaining = timestamp - Date.now();
+    if (remaining <= 0) {
+      setHasReached(true);
+      return;
+    }
+
+    setHasReached(false);
+    const timeoutId = setTimeout(() => setHasReached(true), remaining);
+    return () => clearTimeout(timeoutId);
+  }, [timestamp]);
+
+  return hasReached;
+}


### PR DESCRIPTION
Fixed: APP-4010

## Why?

Two findings from the CASH front-end audit affect the deposit path. The flow is not production-reachable yet, but both issues are live in the code.

Unresolved orders must remain active so the client never assumes it is safe to charge the user again. Polling every two seconds forever, however, wastes network and battery, while repeatedly retrying deterministic failures at that cadence creates noisy error reporting without improving recovery.

Ramp responses also crossed into persisted and user-visible state without runtime validation. Malformed order details could create an invalid Activity entry, and one malformed card or wallet could make every valid row in the same response unavailable.

## Approach

Orders are checked immediately and polled every two seconds for the first five minutes, then every fifteen seconds until the backend returns a terminal status. Failed polls use the existing failure backoff and log once per failure streak. The active order remains persisted and continues blocking duplicate submissions throughout.

Ramp responses are normalized at the HTTP boundary. Order states retain only the fields the client uses, and purchase details are accepted only for the supported USDC destination and network. Unusable optional completion details are discarded without hiding a terminal status, while malformed card and wallet rows are dropped independently so valid rows remain available. Unknown card brands and failure reasons degrade to their generic representation when the client can still handle the response safely.

Validation diagnostics report only failing paths and issue codes, keeping response data out of logs.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rainbow-me/rainbow/pull/7750?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
