### PR TITLE
fix(CASH): add money-path failure telemetry

### DIFF
--- a/src/analytics/event.ts
+++ b/src/analytics/event.ts
@@ -7,6 +7,7 @@ import { type FiatProviderName } from '@/entities/f2c';
 import { type UnlockableAppIconKey } from '@/features/app-icon/models/appIcons';
 import { type CashSignInTrigger } from '@/features/cash/services/cashSignInService';
 import { type OrderFailureReason, type RampNetwork } from '@/features/cash/services/rampClient';
+import { type TelemetryErrorReason } from '@/features/cash/utils/getTelemetryErrorReason';
 import { type CandleResolution, type ChartType } from '@/features/charts/types';
 import { type FavoritedSite } from '@/features/dapp-browser/stores/favoriteDappsStore';
 import { type RequestSource } from '@/features/dapp-request/types';
@@ -126,7 +127,10 @@ export const event = {
   cashBuyOrderSubmitted: 'cash.buy_submitted',
   cashBuyOrderCompleted: 'cash.buy_completed',
   cashBuyOrderFailed: 'cash.buy_failed',
+  cashWalletCheckFailed: 'cash.wallet_check_failed',
   cashPhoneSubmitted: 'cash.phone_submitted',
+  cashPhoneSubmitFailed: 'cash.phone_submit_failed',
+  cashPhoneResendFailed: 'cash.phone_resend_failed',
   cashPhoneAlreadyRegistered: 'cash.phone_already_registered',
   cashPhoneVerified: 'cash.phone_verified',
   cashPhoneVerifyFailed: 'cash.phone_verify_failed',
@@ -553,7 +557,17 @@ export type EventProperties = {
     failureReason: OrderFailureReason | null;
     errorCode: 'PAYMENT_REJECTED' | 'GENERIC';
   };
+  [event.cashWalletCheckFailed]: {
+    reason: TelemetryErrorReason;
+  };
   [event.cashPhoneSubmitted]: {
+    mode: 'signup' | 'resume';
+  };
+  [event.cashPhoneSubmitFailed]: {
+    reason: TelemetryErrorReason;
+  };
+  [event.cashPhoneResendFailed]: {
+    reason: TelemetryErrorReason;
     mode: 'signup' | 'resume';
   };
   [event.cashPhoneAlreadyRegistered]: {

--- a/src/features/cash/screens/add-cash-sheet/AddCashSheet.tsx
+++ b/src/features/cash/screens/add-cash-sheet/AddCashSheet.tsx
@@ -16,6 +16,7 @@ import { isPasskeyCancellation } from '@/features/cash/services/cashPasskeyServi
 import { checkWalletLink } from '@/features/cash/services/walletLinkService';
 import { cashBuyOrderActions, selectCashBuyPhase, useCashBuyOrderStore, useCashBuyPhase } from '@/features/cash/stores/cashBuyOrderStore';
 import { useCashLinkedCard, type LinkedCard } from '@/features/cash/stores/cashPaymentMethodStore';
+import { getTelemetryErrorReason } from '@/features/cash/utils/getTelemetryErrorReason';
 import { useRemoteConfig } from '@/features/config/stores/remoteConfig';
 import { ChainId } from '@/features/network/types/backendNetworks';
 import { useWatcher } from '@/framework/ui/hooks/useWatcher';
@@ -438,6 +439,7 @@ export const AddCashSheet = memo(function AddCashSheet() {
     } catch (error) {
       if (controller.signal.aborted || isPasskeyCancellation(error)) return;
       logger.error(new RainbowError('[AddCashSheet]: Failed to resolve the deposit wallet', error));
+      analytics.track(analytics.event.cashWalletCheckFailed, { reason: getTelemetryErrorReason(error) });
       Alert.alert(
         i18n.t(i18n.l.cash.add_cash_screen.wallet_check_error_title),
         i18n.t(i18n.l.cash.add_cash_screen.wallet_check_error_generic)

--- a/src/features/cash/screens/cash-deposit-setup/steps/useSubmitPhoneFlow.test.ts
+++ b/src/features/cash/screens/cash-deposit-setup/steps/useSubmitPhoneFlow.test.ts
@@ -9,7 +9,11 @@ import { useSubmitPhoneFlowStore } from './useSubmitPhoneFlow';
 jest.mock('@/analytics', () => ({
   analytics: {
     track: jest.fn(),
-    event: { cashPhoneSubmitted: 'cash.phone_submitted', cashPhoneAlreadyRegistered: 'cash.phone_already_registered' },
+    event: {
+      cashPhoneSubmitted: 'cash.phone_submitted',
+      cashPhoneSubmitFailed: 'cash.phone_submit_failed',
+      cashPhoneAlreadyRegistered: 'cash.phone_already_registered',
+    },
   },
 }));
 
@@ -120,7 +124,8 @@ describe('useSubmitPhoneFlowStore.submit', () => {
 
     expect(flow().state).toBe('error');
     expect(session().status).toBe('empty');
-    expect(track).not.toHaveBeenCalled();
+    expect(track).toHaveBeenCalledWith('cash.phone_submit_failed', { reason: 'unknown' });
+    expect(track).not.toHaveBeenCalledWith('cash.phone_submitted', expect.anything());
     expect(logger.error).toHaveBeenCalled();
   });
 
@@ -158,7 +163,8 @@ describe('useSubmitPhoneFlowStore.submit', () => {
     expect(flow().state).toBe('error');
     expect(flow().digits).toBe(DIGITS);
     expect(session().status).toBe('empty');
-    expect(track).not.toHaveBeenCalled();
+    expect(track).toHaveBeenCalledWith('cash.phone_submit_failed', { reason: 'unknown' });
+    expect(track).not.toHaveBeenCalledWith('cash.phone_submitted', expect.anything());
     expect(logger.error).toHaveBeenCalled();
   });
 

--- a/src/features/cash/screens/cash-deposit-setup/steps/useSubmitPhoneFlow.ts
+++ b/src/features/cash/screens/cash-deposit-setup/steps/useSubmitPhoneFlow.ts
@@ -8,6 +8,7 @@ import { logger, RainbowError } from '@/logger';
 import { createUserWithPhone, startSignupResume } from '../../../services/userClient';
 import { useCashSetupSessionStore, type PhoneChallenge } from '../../../stores/cashSetupSessionStore';
 import { useVerifyPhoneFlowStore } from '../../../stores/verifyPhoneFlowStore';
+import { getTelemetryErrorReason } from '../../../utils/getTelemetryErrorReason';
 import { extractNationalDigits, NATIONAL_NUMBER_LENGTH } from '../../../utils/phoneNumber';
 import { useCashDepositSetupNavigation } from '../useCashDepositSetupNavigation';
 
@@ -69,6 +70,7 @@ export const useSubmitPhoneFlowStore = createBaseStore<SubmitPhoneFlowStore>((se
       return true;
     } catch (e) {
       logger.error(new RainbowError('[useSubmitPhoneFlow]: Failed to create user with phone', e));
+      analytics.track(analytics.event.cashPhoneSubmitFailed, { reason: getTelemetryErrorReason(e) });
       set({ state: 'error' });
       return false;
     }

--- a/src/features/cash/stores/cashBuyOrderStore.ts
+++ b/src/features/cash/stores/cashBuyOrderStore.ts
@@ -128,7 +128,7 @@ export const useCashBuyOrderStore = createBaseStore<CashBuyOrderState>(
         set({ status: { step: 'polling', orderId: created.id, order: null, submittedAt } });
       } catch (error) {
         if (!isCurrentSubmission(spec)) return;
-        logger.error(new RainbowError('[cashBuyOrderStore] createBuyOrder failed'), { error });
+        logger.error(new RainbowError('[cashBuyOrderStore] createBuyOrder failed', error));
         analytics.track(analytics.event.cashBuyOrderFailed, { orderId: spec.id, failureReason: null, errorCode: 'GENERIC' });
         set({ status: { step: 'error', errorCode: 'GENERIC', order: null, spec: isDefinitiveRejection(error) ? undefined : spec } });
         // A 404 says the backend did not recognise something this order named, and the linked wallet
@@ -190,7 +190,7 @@ export const useCashBuyOrderStore = createBaseStore<CashBuyOrderState>(
         } catch (error) {
           if (abortController?.signal.aborted) return;
           // Transient poll failure; retry on the watcher's next tick.
-          logger.error(new RainbowError('[cashBuyOrderStore] getOrder failed'), { error });
+          logger.error(new RainbowError('[cashBuyOrderStore] getOrder failed', error));
         } finally {
           abortController?.signal.removeEventListener('abort', propagateAbort);
         }

--- a/src/features/cash/stores/verifyPhoneFlowStore.test.ts
+++ b/src/features/cash/stores/verifyPhoneFlowStore.test.ts
@@ -12,6 +12,7 @@ jest.mock('@/analytics', () => ({
     event: {
       cashPhoneVerified: 'cash.phone_verified',
       cashPhoneVerifyFailed: 'cash.phone_verify_failed',
+      cashPhoneResendFailed: 'cash.phone_resend_failed',
       cashPhoneAlreadyRegistered: 'cash.phone_already_registered',
       cashKycApproved: 'cash.kyc_approved',
       cashKycAwaitingDecision: 'cash.kyc_awaiting_decision',
@@ -393,6 +394,16 @@ describe('useVerifyPhoneFlowStore.resend', () => {
       phoneNationalNumber: '4155550100',
       resendAfter: RESEND_AFTER,
     });
+    expect(flow().resending).toBeNull();
+  });
+
+  it('reports the failure and clears the in-flight flag when the resend throws', async () => {
+    mockResendPhoneCode.mockRejectedValue(new Error('resend failed'));
+
+    await flow().resend();
+
+    expect(track).toHaveBeenCalledWith('cash.phone_resend_failed', { reason: 'unknown', mode: 'signup' });
+    expect(logger.error).toHaveBeenCalled();
     expect(flow().resending).toBeNull();
   });
 

--- a/src/features/cash/stores/verifyPhoneFlowStore.ts
+++ b/src/features/cash/stores/verifyPhoneFlowStore.ts
@@ -14,6 +14,7 @@ import {
   verifyPhone,
   type KycOutcome,
 } from '../services/userClient';
+import { getTelemetryErrorReason } from '../utils/getTelemetryErrorReason';
 import { useCashSetupSessionStore, type PhoneChallenge } from './cashSetupSessionStore';
 
 export const OTP_LENGTH = 6;
@@ -148,6 +149,7 @@ export const useVerifyPhoneFlowStore = createBaseStore<VerifyPhoneFlowStore>((se
     } catch (e) {
       if (!sessionStore.getIsCurrentChallenge(challenge)) return;
       logger.error(new RainbowError('[useVerifyPhoneFlow]: Failed to resend code', e));
+      analytics.track(analytics.event.cashPhoneResendFailed, { reason: getTelemetryErrorReason(e), mode: challenge.kind });
     } finally {
       set(state => (state.resending === challenge ? { resending: null } : state));
     }

--- a/src/features/cash/utils/getTelemetryErrorReason.test.ts
+++ b/src/features/cash/utils/getTelemetryErrorReason.test.ts
@@ -1,0 +1,28 @@
+import { RainbowFetchError } from '@/framework/data/http/rainbowFetch';
+
+import { getTelemetryErrorReason, type TelemetryErrorReason } from './getTelemetryErrorReason';
+
+function fetchError(status?: number, message = 'failed') {
+  return new RainbowFetchError({ message, response: status === undefined ? undefined : ({ status } as unknown as Response) });
+}
+
+describe('getTelemetryErrorReason', () => {
+  const cases: { name: string; input: unknown; expected: TelemetryErrorReason }[] = [
+    { name: 'fetch error with 500', input: fetchError(500), expected: 'server_error' },
+    { name: 'fetch error with 503', input: fetchError(503), expected: 'server_error' },
+    { name: 'fetch error with 400', input: fetchError(400), expected: 'client_error' },
+    { name: 'fetch error with 404', input: fetchError(404), expected: 'client_error' },
+    { name: 'fetch error without a response', input: fetchError(), expected: 'offline' },
+    { name: 'wrapped network failure without a response', input: fetchError(undefined, 'Network request failed'), expected: 'offline' },
+    { name: 'whatwg-fetch offline error', input: new TypeError('Network request failed'), expected: 'offline' },
+    { name: 'other TypeError', input: new TypeError('undefined is not a function'), expected: 'unknown' },
+    { name: 'plain Error', input: new Error('boom'), expected: 'unknown' },
+    { name: 'non-error value', input: 'boom', expected: 'unknown' },
+  ];
+
+  for (const { name, input, expected } of cases) {
+    it(`classifies ${name} as ${expected}`, () => {
+      expect(getTelemetryErrorReason(input)).toBe(expected);
+    });
+  }
+});

--- a/src/features/cash/utils/getTelemetryErrorReason.ts
+++ b/src/features/cash/utils/getTelemetryErrorReason.ts
@@ -1,0 +1,16 @@
+import { RainbowFetchError } from '@/framework/data/http/rainbowFetch';
+
+export type TelemetryErrorReason = 'offline' | 'client_error' | 'server_error' | 'unknown';
+
+export function getTelemetryErrorReason(error: unknown): TelemetryErrorReason {
+  if (error instanceof RainbowFetchError) {
+    const status = error.response?.status;
+    if (status !== undefined && status >= 500) return 'server_error';
+    if (status !== undefined && status >= 400) return 'client_error';
+    // rainbowFetch wraps network failures in a response-less RainbowFetchError, preserving the message.
+    if (error.response === undefined) return 'offline';
+    return 'unknown';
+  }
+  if (error instanceof TypeError && error.message === 'Network request failed') return 'offline';
+  return 'unknown';
+}


### PR DESCRIPTION
Fixes APP-4011

## Why?

Failures on the CASH money path are invisible today, in both directions:

- On the Add Cash sheet, the wallet pre-check before a deposit, the phone-number submit and the OTP resend all fail without a trace — the user gets an alert (or nothing), and nothing is recorded. A user blocked at the last gate before a charge is indistinguishable from one who changed their mind.
- Failed buy orders do reach Sentry, but as unfilterable noise: the fetch error was attached as log metadata rather than as an error cause, which bypasses the 5xx/offline suppression filter and ships the full request/response context — including the deposit amount — as loggable extras.

## Approach

New failure events carry a coarse, client-derived category (offline / client error / server error / unknown) instead of the server-provided error text, so no request or response content can leak into analytics.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rainbow-me/rainbow/pull/7751?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
