### PR TITLE
fix(CASH): block sheet dismissal while a deposit submit is in flight

### DIFF
--- a/src/features/cash/screens/add-cash-sheet/AddCashSheet.tsx
+++ b/src/features/cash/screens/add-cash-sheet/AddCashSheet.tsx
@@ -26,6 +26,7 @@ import * as i18n from '@/languages';
 import { logger, RainbowError } from '@/logger';
 import { useNavigation } from '@/navigation/Navigation';
 import Routes from '@/navigation/routesNames';
+import { usePreventSheetDismissal } from '@/navigation/usePreventSheetDismissal';
 import { USDC_ADDRESS } from '@/references/constants';
 import { useAccountAddress } from '@/state/wallets/walletsStore';
 import { DEVICE_HEIGHT, DEVICE_WIDTH } from '@/utils/deviceUtils';
@@ -336,6 +337,7 @@ export const AddCashSheet = memo(function AddCashSheet() {
   const previousPhase = usePrevious(phase);
   const errorCode = useCashBuyOrderStore(state => (state.status.step === 'error' ? state.status.errorCode : null));
   const isPolling = useCashBuyOrderStore(state => state.status.step === 'polling');
+  const isSubmitting = useCashBuyOrderStore(state => state.status.step === 'submitting');
   const submittedAt = useCashBuyOrderStore(state =>
     state.status.step === 'submitting' || state.status.step === 'polling' ? state.status.submittedAt : null
   );
@@ -344,6 +346,11 @@ export const AddCashSheet = memo(function AddCashSheet() {
   const walletCheckRef = useRef<AbortController | null>(null);
   const isPending = phase === 'pending';
   const isProcessing = isCheckingWallet || isPending;
+
+  // The spec is already on disk under its own id and `resumePendingSubmission` replays it, so a dismissal
+  // here is recoverable — but only if the user comes back. Hold the sheet for the one request rather than
+  // let a stray backdrop tap drop them out of the flow mid-commit.
+  usePreventSheetDismissal(isSubmitting);
 
   // The pending view takes over only once the order has been in flight longer than the configured
   // delay; until then the hold-to-add button's processing state is the only affordance.

--- a/src/features/cash/screens/add-wallet-sheet/AddWalletSheet.tsx
+++ b/src/features/cash/screens/add-wallet-sheet/AddWalletSheet.tsx
@@ -13,6 +13,7 @@ import * as i18n from '@/languages';
 import { useNavigation } from '@/navigation/Navigation';
 import type Routes from '@/navigation/routesNames';
 import { type RootStackParamList } from '@/navigation/types';
+import { usePreventSheetDismissal } from '@/navigation/usePreventSheetDismissal';
 import { useAccountProfileInfo, useIsHardwareWallet, useIsReadOnlyWallet } from '@/state/wallets/walletsStore';
 import { formatAddressForDisplay } from '@/utils/abbreviations';
 
@@ -79,6 +80,9 @@ export const AddWalletSheet = memo(function AddWalletSheet() {
 
   const { state, confirm } = useWalletLinkFlow({ onLinked: handleLinked, walletAddress });
   const isUnsupportedWallet = isReadOnlyWallet || isHardwareWallet;
+  const isLinking = state === 'linking';
+
+  usePreventSheetDismissal(isLinking);
 
   useFocusEffect(
     useCallback(() => {

--- a/src/features/cash/screens/payment-methods-sheet/PaymentMethodsSheet.tsx
+++ b/src/features/cash/screens/payment-methods-sheet/PaymentMethodsSheet.tsx
@@ -14,6 +14,7 @@ import { useCashLinkedCard, type LinkedCard } from '@/features/cash/stores/cashP
 import { WrappedAlert as Alert } from '@/helpers/alert';
 import * as i18n from '@/languages';
 import { useNavigation } from '@/navigation/Navigation';
+import { usePreventSheetDismissal } from '@/navigation/usePreventSheetDismissal';
 
 const l = i18n.l.cash.payment_methods;
 const cardRemovalFlowActions = createStoreActions(useCardRemovalFlowStore);
@@ -77,13 +78,7 @@ export const PaymentMethodsSheet = memo(function PaymentMethodsSheet() {
     Alert.alert(i18n.t(l.remove_error_title), i18n.t(l.remove_error_description));
   }, []);
 
-  useEffect(
-    () =>
-      navigation.addListener('beforeRemove', event => {
-        if (useCardRemovalFlowStore.getState().state === 'removing') event.preventDefault();
-      }),
-    [navigation]
-  );
+  usePreventSheetDismissal(useCardRemovalFlowStore(state => state.state === 'removing'));
 
   useEffect(() => {
     if (linkedCard || !navigation.isFocused()) return;

--- a/src/navigation/bottom-sheet/views/BottomSheetRoute.tsx
+++ b/src/navigation/bottom-sheet/views/BottomSheetRoute.tsx
@@ -133,7 +133,7 @@ const BottomSheetRoute = ({ routeKey, descriptor: { options, render, navigation 
         {...props}
       />
     ),
-    [backdropOpacity, backdropStyle]
+    [backdropOpacity, backdropPressBehavior, backdropStyle]
   );
 
   return (

--- a/src/navigation/config.tsx
+++ b/src/navigation/config.tsx
@@ -37,6 +37,9 @@ import type Routes from './routesNames';
 
 export const sharedCoolModalTopOffset = safeAreaInsetValues.top;
 
+/** Height of the band at the top of a cool modal that the pan-to-dismiss gesture responds to. */
+export const DEFAULT_COOL_MODAL_HEADER_HEIGHT = 25;
+
 export type CoolModalConfigOptions = StackNavigationOptions & {
   allowsDragToDismiss?: boolean;
   allowsTapToDismiss?: boolean;
@@ -100,7 +103,7 @@ const buildCoolModalConfig = (params: CoolModalConfigParams): CoolModalConfigOpt
   customStack: true,
   disableShortFormAfterTransitionToLongForm: params.disableShortFormAfterTransitionToLongForm,
   gestureEnabled: true,
-  headerHeight: params.headerHeight || 25,
+  headerHeight: params.headerHeight || DEFAULT_COOL_MODAL_HEADER_HEIGHT,
   ignoreBottomOffset: true,
   isShortFormEnabled: params.isShortFormEnabled,
   longFormHeight: params.longFormHeight,

--- a/src/navigation/usePreventSheetDismissal.test.ts
+++ b/src/navigation/usePreventSheetDismissal.test.ts
@@ -1,0 +1,113 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+import { usePreventSheetDismissal } from './usePreventSheetDismissal';
+
+type BeforeRemoveListener = (event: { preventDefault: () => void }) => void;
+
+const mockUseEffect = jest.fn<(effect: () => void | (() => void)) => void>();
+const mockRef = { current: false };
+const mockSetOptions = jest.fn();
+const mockAddListener = jest.fn<(event: string, listener: BeforeRemoveListener) => () => void>();
+const mockNavigation = { addListener: mockAddListener, setOptions: mockSetOptions };
+
+jest.mock('react', () => ({
+  ...(jest.requireActual('react') as object),
+  useEffect: (effect: () => void | (() => void)) => mockUseEffect(effect),
+  useRef: () => mockRef,
+}));
+
+jest.mock('@/navigation/config', () => ({ DEFAULT_COOL_MODAL_HEADER_HEIGHT: 25 }));
+
+jest.mock('@/navigation/Navigation', () => ({ useNavigation: () => mockNavigation }));
+
+const UNLOCKED = {
+  allowsDragToDismiss: true,
+  allowsTapToDismiss: true,
+  backdropPressBehavior: 'close',
+  dismissable: true,
+  enablePanDownToClose: true,
+  headerHeight: 25,
+};
+
+const LOCKED = {
+  allowsDragToDismiss: false,
+  allowsTapToDismiss: false,
+  backdropPressBehavior: 'none',
+  dismissable: false,
+  enablePanDownToClose: false,
+  headerHeight: 0,
+};
+
+function beforeRemoveListener(): BeforeRemoveListener {
+  const call = mockAddListener.mock.calls.find(([event]) => event === 'beforeRemove');
+  if (!call) throw new Error('no beforeRemove listener was registered');
+  return call[1];
+}
+
+function dismiss(): { prevented: boolean } {
+  const preventDefault = jest.fn();
+  beforeRemoveListener()({ preventDefault });
+  return { prevented: preventDefault.mock.calls.length > 0 };
+}
+
+describe('usePreventSheetDismissal', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockRef.current = false;
+    mockUseEffect.mockImplementation(effect => void effect());
+  });
+
+  it('leaves every gesture channel open when nothing is in flight', () => {
+    usePreventSheetDismissal(false);
+
+    expect(mockSetOptions).toHaveBeenCalledWith(UNLOCKED);
+  });
+
+  // A drag closes the sheet before navigation hears about it, so these have to be off at the source.
+  // `headerHeight` is part of that: `dismissable: false` alone still leaves the header band draggable.
+  it('closes every gesture channel while in flight', () => {
+    usePreventSheetDismissal(true);
+
+    expect(mockSetOptions).toHaveBeenCalledWith(LOCKED);
+  });
+
+  it('cancels a navigation-driven dismissal while in flight', () => {
+    usePreventSheetDismissal(true);
+
+    expect(dismiss().prevented).toBe(true);
+  });
+
+  it('allows a navigation-driven dismissal when nothing is in flight', () => {
+    usePreventSheetDismissal(false);
+
+    expect(dismiss().prevented).toBe(false);
+  });
+
+  // The listener is registered once against `navigation`, so it has to read the current value rather
+  // than the one captured when it was subscribed.
+  it('applies the latest value to a listener registered before the lock', () => {
+    usePreventSheetDismissal(false);
+    expect(dismiss().prevented).toBe(false);
+
+    usePreventSheetDismissal(true);
+    expect(dismiss().prevented).toBe(true);
+
+    usePreventSheetDismissal(false);
+    expect(dismiss().prevented).toBe(false);
+  });
+
+  it('unsubscribes the listener on unmount', () => {
+    const unsubscribe = jest.fn();
+    mockAddListener.mockReturnValue(unsubscribe);
+    const cleanups: (() => void)[] = [];
+    mockUseEffect.mockImplementation(effect => {
+      const cleanup = effect();
+      if (cleanup) cleanups.push(cleanup);
+    });
+
+    usePreventSheetDismissal(true);
+    cleanups.forEach(cleanup => cleanup());
+
+    expect(unsubscribe).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/navigation/usePreventSheetDismissal.ts
+++ b/src/navigation/usePreventSheetDismissal.ts
@@ -1,0 +1,60 @@
+import { useEffect, useRef } from 'react';
+
+import { DEFAULT_COOL_MODAL_HEADER_HEIGHT } from '@/navigation/config';
+import { useNavigation } from '@/navigation/Navigation';
+
+/**
+ * The gesture channels, spanning both navigators a panel sheet can be registered in: cool-modals on iOS
+ * (`Routes.ios.tsx`), the bottom-sheet navigator on Android (`Routes.android.tsx`). A caller cannot know
+ * which one it landed in, so every key is always sent and the inapplicable half is ignored.
+ *
+ * `setOptions` types its argument as stack options, which name none of these, so the cast below is the
+ * boundary — this type is what actually holds the shape.
+ */
+type GestureDismissalOptions = {
+  allowsDragToDismiss: boolean;
+  allowsTapToDismiss: boolean;
+  backdropPressBehavior: 'close' | 'none';
+  dismissable: boolean;
+  enablePanDownToClose: boolean;
+  headerHeight: number;
+};
+
+function gestureDismissalOptions(prevented: boolean): GestureDismissalOptions {
+  return {
+    allowsDragToDismiss: !prevented,
+    allowsTapToDismiss: !prevented,
+    backdropPressBehavior: prevented ? 'none' : 'close',
+    dismissable: !prevented,
+    enablePanDownToClose: !prevented,
+    // `dismissable: false` alone leaves the pan gesture responding to touches that start inside the
+    // header band, so the band has to collapse too.
+    headerHeight: prevented ? 0 : DEFAULT_COOL_MODAL_HEADER_HEIGHT,
+  };
+}
+
+/**
+ * Holds a panel sheet open while `prevented`, closing every way out of it at once.
+ *
+ * Two mechanisms, because dismissals arrive in two orders. A gesture closes the sheet first and tells
+ * navigation afterwards, so it has to be switched off before it can start. Everything else — Android
+ * hardware back, `PanelSheet`'s tap cover, any `goBack()` — reaches navigation first and is cancelled here.
+ */
+export function usePreventSheetDismissal(prevented: boolean): void {
+  const navigation = useNavigation();
+  const { setOptions } = navigation;
+  const preventedRef = useRef(prevented);
+  preventedRef.current = prevented;
+
+  useEffect(() => {
+    setOptions(gestureDismissalOptions(prevented) as Parameters<typeof setOptions>[0]);
+  }, [prevented, setOptions]);
+
+  useEffect(
+    () =>
+      navigation.addListener('beforeRemove', event => {
+        if (preventedRef.current) event.preventDefault();
+      }),
+    [navigation]
+  );
+}


### PR DESCRIPTION
Fixes APP-4014

## What changed (plus any additional context for devs)

Add Cash and Add Wallet could be dismissed mid-submit — by backdrop tap, swipe-down, or Android back. That window matters because the order id doesn't exist yet, so a dismissal leaves a possible card charge with nothing to reconcile it against.

All four channels are closed at their source: `SHEET_DISMISSAL_LOCKED`/`_UNLOCKED` applied via `setOptions` (iOS drag/tap, Android pan-down/backdrop), `useHardwareBackOnFocus` for back, and `showTapToDismiss` for `PanelSheet`'s own cover — gating only the cover would *enable* dismissal, since removing it exposes the native backdrop. Toggled rather than set at registration, since neither sheet has a close button and both must stay dismissible when idle.

Locks on `step: 'submitting'` only (`state: 'linking'` for Add Wallet) — the waiting view stays dismissible on purpose, since order tracking is sheet-scoped by decision and locking through `polling` would trap the user in a spinner.

Also adds the missing `backdropPressBehavior` dep in `BottomSheetRoute`, without which the Android change never propagated.

## What to test

1. Hold to add — during the processing state, backdrop tap / swipe-down / Android back should all do nothing.
2. Once polling starts, all three should dismiss again.
3. Add Wallet: same during the signature prompt.
4. Idle Add Cash still dismisses normally, presets and keypad.

