### PR TITLE
fix(CASH): stop leaking amounts, orderId and server text into analytics

### DIFF
--- a/src/analytics/event.ts
+++ b/src/analytics/event.ts
@@ -534,20 +534,19 @@ export type EventProperties = {
   [event.rewardsViewedSheet]: undefined;
   [event.cashDepositIntroViewed]: undefined;
   [event.cashAmountEntered]: {
-    /** The chosen USD amount as a decimal string, e.g. "50". */
-    amount: string;
+    /** The chosen USD amount. */
+    amount: number | undefined;
     /** Which amount-entry surface the user used first. */
     entryMode: 'preset' | 'keypad';
   };
   [event.cashBuyOrderSubmitted]: {
-    /** The submitted USD amount as a decimal string. */
-    amount: string;
+    /** The submitted USD amount. */
+    amount: number | undefined;
   };
   [event.cashBuyOrderCompleted]: {
-    orderId: string;
-    fiatAmount: string;
+    fiatAmount: number | undefined;
     fiatCurrency: string;
-    cryptoAmount: string;
+    cryptoAmount: number | undefined;
     network: RampNetwork;
     /** Milliseconds from order creation to completion, derived from the backend `createdTime`/`completedTime`. */
     timeToUsdcMs: number;
@@ -577,7 +576,7 @@ export type EventProperties = {
     mode: 'signup' | 'resume';
   };
   [event.cashPhoneVerifyFailed]: {
-    reason: string;
+    reason: TelemetryErrorReason;
     mode: 'signup' | 'resume';
   };
   [event.cashKycSubmitted]: undefined;
@@ -586,24 +585,24 @@ export type EventProperties = {
     source: 'submit' | 'resume';
   };
   [event.cashKycFailed]: {
-    reason: string;
+    reason: TelemetryErrorReason | 'rejected';
   };
   [event.cashPasskeySubmitted]: undefined;
   [event.cashPasskeyAdded]: undefined;
   [event.cashPasskeyFailed]: {
-    reason: string;
+    reason: TelemetryErrorReason;
   };
   [event.cashCardLinked]: {
     /** Display brand of the linked card, e.g. "Visa". */
     brand: string;
   };
   [event.cashCardLinkFailed]: {
-    reason: string;
+    reason: TelemetryErrorReason;
   };
   [event.cashWalletLinkPrompted]: undefined;
   [event.cashWalletLinked]: undefined;
   [event.cashWalletLinkFailed]: {
-    reason: string;
+    reason: TelemetryErrorReason;
   };
   [event.cashSignInSubmitted]: {
     trigger: CashSignInTrigger;
@@ -613,7 +612,7 @@ export type EventProperties = {
   };
   [event.cashSignInFailed]: {
     trigger: CashSignInTrigger;
-    reason: string;
+    reason: TelemetryErrorReason;
   };
   [event.cashSignInCancelled]: {
     trigger: CashSignInTrigger;

--- a/src/features/cash/screens/add-cash-sheet/AddCashSheet.tsx
+++ b/src/features/cash/screens/add-cash-sheet/AddCashSheet.tsx
@@ -4,6 +4,7 @@ import { StyleSheet } from 'react-native';
 import Animated, { FadeIn, FadeOut, LinearTransition } from 'react-native-reanimated';
 
 import { analytics } from '@/analytics';
+import { toAnalyticsAmount } from '@/analytics/utils';
 import { SPRING_CONFIGS } from '@/components/animations/animationConfigs';
 import ButtonPressAnimation from '@/components/animations/ButtonPressAnimation';
 import RainbowCoinIcon from '@/components/coin-icon/RainbowCoinIcon';
@@ -404,7 +405,7 @@ export const AddCashSheet = memo(function AddCashSheet() {
   // Sample the amount whenever the user taps a preset chip.
   const handleSelectPreset = useCallback(
     (presetAmount: number) => {
-      analytics.track(analytics.event.cashAmountEntered, { amount: String(presetAmount), entryMode: 'preset' });
+      analytics.track(analytics.event.cashAmountEntered, { amount: toAnalyticsAmount(presetAmount), entryMode: 'preset' });
       amount.selectPresetAmount(presetAmount);
     },
     [amount]
@@ -413,7 +414,7 @@ export const AddCashSheet = memo(function AddCashSheet() {
   // Sample each keypad amount the user types; `canSubmit` skips the "0" reset and empty values.
   useEffect(() => {
     if (mode !== 'keypad' || !amount.canSubmit) return;
-    analytics.track(analytics.event.cashAmountEntered, { amount: amount.amount, entryMode: 'keypad' });
+    analytics.track(analytics.event.cashAmountEntered, { amount: toAnalyticsAmount(amount.amount), entryMode: 'keypad' });
   }, [mode, amount.canSubmit, amount.amount]);
 
   // A deposit can only credit a wallet the Cash account has linked, so resolve that first: the token

--- a/src/features/cash/screens/add-wallet-sheet/useWalletLinkFlow.ts
+++ b/src/features/cash/screens/add-wallet-sheet/useWalletLinkFlow.ts
@@ -7,6 +7,7 @@ import { logger, RainbowError } from '@/logger';
 
 import { isPasskeyCancellation } from '../../services/cashPasskeyService';
 import { linkWalletWithSignature, WalletSignatureError } from '../../services/walletLinkService';
+import { getTelemetryErrorReason } from '../../utils/getTelemetryErrorReason';
 
 export type WalletLinkState = 'idle' | 'linking' | 'linked' | 'error';
 
@@ -43,7 +44,7 @@ export function useWalletLinkFlow({ onLinked, walletAddress }: { onLinked: () =>
         return;
       }
       logger.error(new RainbowError('[useWalletLinkFlow]: Failed to link wallet', e));
-      analytics.track(analytics.event.cashWalletLinkFailed, { reason: e instanceof Error ? e.message : String(e) });
+      analytics.track(analytics.event.cashWalletLinkFailed, { reason: getTelemetryErrorReason(e) });
       // Recovered by confirming again rather than a dedicated retry: the timestamp is inside the
       // signed message, so replaying the old signature would land outside the server's skew window.
       setState('error');

--- a/src/features/cash/screens/cash-deposit-setup/steps/useAddPasskeyFlow.test.ts
+++ b/src/features/cash/screens/cash-deposit-setup/steps/useAddPasskeyFlow.test.ts
@@ -112,12 +112,12 @@ describe('useAddPasskeyFlowStore.submit', () => {
     expect(flow().state).toBe('entry');
   });
 
-  it('fails with the error message when the ceremony throws', async () => {
+  it('fails and reports the failure when the ceremony throws', async () => {
     mockCreatePasskeyCredential.mockRejectedValue(new Error('ceremony broke'));
 
     await expect(flow().submit()).resolves.toBe('failed');
 
-    expect(track).toHaveBeenCalledWith('cash.passkey_failed', { reason: 'ceremony broke' });
+    expect(track).toHaveBeenCalledWith('cash.passkey_failed', { reason: 'unknown' });
     expect(setUserId).not.toHaveBeenCalled();
     expect(logger.error).toHaveBeenCalled();
     expect(flow().state).toBe('error');
@@ -128,7 +128,7 @@ describe('useAddPasskeyFlowStore.submit', () => {
 
     await expect(flow().submit()).resolves.toBe('failed');
 
-    expect(track).toHaveBeenCalledWith('cash.passkey_failed', { reason: 'network down' });
+    expect(track).toHaveBeenCalledWith('cash.passkey_failed', { reason: 'unknown' });
     expect(setUserId).not.toHaveBeenCalled();
   });
 

--- a/src/features/cash/screens/cash-deposit-setup/steps/useAddPasskeyFlow.ts
+++ b/src/features/cash/screens/cash-deposit-setup/steps/useAddPasskeyFlow.ts
@@ -9,6 +9,7 @@ import { createPasskeyCredential, getPasskeyName, isPasskeyCancellation } from '
 import { addPasskey, finishAddPasskey } from '../../../services/userClient';
 import { useCashAccountStore } from '../../../stores/cashAccountStore';
 import { useCashSetupSessionStore } from '../../../stores/cashSetupSessionStore';
+import { getTelemetryErrorReason } from '../../../utils/getTelemetryErrorReason';
 import { useCashDepositSetupNavigation } from '../useCashDepositSetupNavigation';
 
 export type AddPasskeyState = 'entry' | 'submitting' | 'error';
@@ -49,7 +50,7 @@ export const useAddPasskeyFlowStore = createBaseStore<AddPasskeyFlowStore>((set,
         return 'cancelled';
       }
       logger.error(new RainbowError('[useAddPasskeyFlow]: Failed to add passkey', e));
-      analytics.track(analytics.event.cashPasskeyFailed, { reason: e instanceof Error ? e.message : String(e) });
+      analytics.track(analytics.event.cashPasskeyFailed, { reason: getTelemetryErrorReason(e) });
       set({ state: 'error' });
       return 'failed';
     }

--- a/src/features/cash/screens/cash-deposit-setup/steps/useSubmitKycFlow.test.ts
+++ b/src/features/cash/screens/cash-deposit-setup/steps/useSubmitKycFlow.test.ts
@@ -205,12 +205,12 @@ describe('useSubmitKycFlowStore.submit', () => {
     expect(track).not.toHaveBeenCalledWith('cash.kyc_approved');
   });
 
-  it('fails with the error message when the submission throws', async () => {
+  it('fails and reports the failure when the submission throws', async () => {
     mockSubmitOnboarding.mockRejectedValue(new Error('network down'));
 
     await expect(flow().submit()).resolves.toBe('failed');
 
-    expect(track).toHaveBeenCalledWith('cash.kyc_failed', { reason: 'network down' });
+    expect(track).toHaveBeenCalledWith('cash.kyc_failed', { reason: 'unknown' });
     expect(logger.error).toHaveBeenCalled();
     expect(flow().state).toBe('error');
   });

--- a/src/features/cash/screens/cash-deposit-setup/steps/useSubmitKycFlow.ts
+++ b/src/features/cash/screens/cash-deposit-setup/steps/useSubmitKycFlow.ts
@@ -9,6 +9,7 @@ import { delay } from '@/utils/delay';
 import { US_COUNTRY_CODE } from '../../../services/cashSetupIdentityService';
 import { getUserStatus, KycStatus, submitOnboarding, type KycOutcome } from '../../../services/userClient';
 import { useCashSetupSessionStore } from '../../../stores/cashSetupSessionStore';
+import { getTelemetryErrorReason } from '../../../utils/getTelemetryErrorReason';
 
 export const KYC_POLL_INTERVAL_MS = time.seconds(3);
 
@@ -64,7 +65,7 @@ export const useSubmitKycFlowStore = createBaseStore<SubmitKycFlowStore>((set, g
     } catch (e) {
       if (isStale()) return 'cancelled';
       logger.error(new RainbowError('[useSubmitKycFlow]: Failed to submit KYC', e));
-      analytics.track(analytics.event.cashKycFailed, { reason: e instanceof Error ? e.message : String(e) });
+      analytics.track(analytics.event.cashKycFailed, { reason: getTelemetryErrorReason(e) });
       set({ state: 'error' });
       return 'failed';
     }

--- a/src/features/cash/services/cashSignInService.test.ts
+++ b/src/features/cash/services/cashSignInService.test.ts
@@ -118,7 +118,7 @@ describe('ensureAccessToken', () => {
     expect(tokenStore().token).toBeNull();
     expect(track.mock.calls).toEqual([
       ['cash.sign_in_submitted', { trigger: 'cardLink' }],
-      ['cash.sign_in_failed', { trigger: 'cardLink', reason: 'login rejected' }],
+      ['cash.sign_in_failed', { trigger: 'cardLink', reason: 'unknown' }],
     ]);
   });
 
@@ -137,7 +137,7 @@ describe('ensureAccessToken', () => {
     expect(mockStartLogin).not.toHaveBeenCalled();
     expect(track.mock.calls).toEqual([
       ['cash.sign_in_submitted', { trigger: 'cardLink' }],
-      ['cash.sign_in_failed', { trigger: 'cardLink', reason: 'No cash account recorded on this device' }],
+      ['cash.sign_in_failed', { trigger: 'cardLink', reason: 'unknown' }],
     ]);
   });
 });
@@ -180,7 +180,7 @@ describe('signInWithPhone', () => {
     expect(tokenStore().token).toBeNull();
     expect(track.mock.calls).toEqual([
       ['cash.sign_in_submitted', { trigger: 'signInScreen' }],
-      ['cash.sign_in_failed', { trigger: 'signInScreen', reason: 'finalize failed' }],
+      ['cash.sign_in_failed', { trigger: 'signInScreen', reason: 'unknown' }],
     ]);
   });
 });

--- a/src/features/cash/services/cashSignInService.ts
+++ b/src/features/cash/services/cashSignInService.ts
@@ -3,6 +3,7 @@ import { time } from '@/framework/core/utils/time';
 
 import { useCashAccountStore } from '../stores/cashAccountStore';
 import { useCashAuthTokenStore } from '../stores/cashAuthTokenStore';
+import { getTelemetryErrorReason } from '../utils/getTelemetryErrorReason';
 import { US_COUNTRY_CALLING_CODE } from '../utils/phoneNumber';
 import { getPasskeyAssertion, isPasskeyCancellation } from './cashPasskeyService';
 import { finalizeAuth, finishLogin, startLogin, type StartLoginParams } from './userClient';
@@ -56,7 +57,7 @@ async function runLoginCeremony(trigger: CashSignInTrigger, resolveIdentifier: (
     if (isPasskeyCancellation(error)) {
       analytics.track(analytics.event.cashSignInCancelled, { trigger });
     } else {
-      analytics.track(analytics.event.cashSignInFailed, { trigger, reason: error instanceof Error ? error.message : String(error) });
+      analytics.track(analytics.event.cashSignInFailed, { trigger, reason: getTelemetryErrorReason(error) });
     }
     throw error;
   }

--- a/src/features/cash/stores/cardLinkFlowStore.test.ts
+++ b/src/features/cash/stores/cardLinkFlowStore.test.ts
@@ -90,7 +90,7 @@ describe('cardLinkFlowStore', () => {
 
     expect(flow().state).toBe('submitError');
     expect(linkedCard()).toBeNull();
-    expect(track).toHaveBeenCalledWith('cash.card_link_failed', { reason: 'vault exploded' });
+    expect(track).toHaveBeenCalledWith('cash.card_link_failed', { reason: 'unknown' });
   });
 
   it('ignores a second submit while one is in flight', async () => {

--- a/src/features/cash/stores/cardLinkFlowStore.ts
+++ b/src/features/cash/stores/cardLinkFlowStore.ts
@@ -7,6 +7,7 @@ import { logger, RainbowError } from '@/logger';
 import { linkCardWithVault } from '../services/cardLinkService';
 import { isPasskeyCancellation } from '../services/cashPasskeyService';
 import type { CardBrand } from '../services/rampClient';
+import { getTelemetryErrorReason } from '../utils/getTelemetryErrorReason';
 import { useCashPaymentMethodStore } from './cashPaymentMethodStore';
 
 export type CardLinkState = 'entry' | 'submitting' | 'submitError' | 'success';
@@ -43,7 +44,7 @@ export const useCardLinkFlowStore = createBaseStore<CardLinkFlowStore>((set, get
         return;
       }
       logger.error(new RainbowError('[cardLinkFlowStore]: Failed to link card', e));
-      analytics.track(analytics.event.cashCardLinkFailed, { reason: e instanceof Error ? e.message : String(e) });
+      analytics.track(analytics.event.cashCardLinkFailed, { reason: getTelemetryErrorReason(e) });
       set({ state: 'submitError' });
     } finally {
       if (inFlight === controller) inFlight = null;

--- a/src/features/cash/stores/cashBuyOrderStore.test.ts
+++ b/src/features/cash/stores/cashBuyOrderStore.test.ts
@@ -1,3 +1,4 @@
+import { analytics } from '@/analytics';
 import { RainbowFetchError } from '@/framework/data/http/rainbowFetch';
 import { logger } from '@/logger';
 import { pendingTransactionsActions } from '@/state/pendingTransactions';
@@ -18,6 +19,19 @@ import {
 import { buildCashPurchaseTransaction } from '../utils/buildCashPurchaseTransaction';
 import { cashBuyOrderActions, selectCashBuyPhase, useCashBuyOrderStore, type CashBuyStatus } from './cashBuyOrderStore';
 import { useCashWalletStore } from './cashWalletStore';
+
+jest.mock('@/analytics', () => ({
+  analytics: {
+    track: jest.fn(),
+    event: {
+      cashBuyOrderSubmitted: 'cash.buy_submitted',
+      cashBuyOrderCompleted: 'cash.buy_completed',
+      cashBuyOrderFailed: 'cash.buy_failed',
+    },
+  },
+}));
+
+jest.mock('@/features/local-auth/legacyKeychain', () => ({}));
 
 jest.mock('@/logger', () => ({
   logger: { debug: jest.fn(), error: jest.fn(), warn: jest.fn() },
@@ -50,6 +64,7 @@ const createBuyOrder = rampCreateBuyOrder as jest.Mock;
 const getOrder = rampGetOrder as jest.Mock;
 const addPendingTransaction = pendingTransactionsActions.addPendingTransaction as jest.Mock;
 const buildPurchaseTransaction = buildCashPurchaseTransaction as jest.Mock;
+const track = analytics.track as jest.Mock;
 
 const PURCHASE_TRANSACTION = { hash: '0xtx', type: 'purchase' };
 
@@ -112,6 +127,14 @@ beforeEach(() => {
 // ---------------------------------------------------------------------------
 
 describe('submitBuyOrder', () => {
+  it('rounds the amount before tracking a submitted order', async () => {
+    createBuyOrder.mockResolvedValue(CREATED_PENDING_ORDER);
+
+    await getState().submitBuyOrder({ ...SUBMIT_INPUT, depositAmount: '123.456789' });
+
+    expect(track).toHaveBeenCalledWith(analytics.event.cashBuyOrderSubmitted, { amount: 123 });
+  });
+
   it('builds a spec, creates the order, and surfaces the created order id as pending', async () => {
     createBuyOrder.mockResolvedValue(CREATED_PENDING_ORDER);
 
@@ -304,6 +327,26 @@ describe('syncActiveOrder', () => {
     });
     expect(getState().status).toEqual({ step: 'success', order: COMPLETED_ORDER });
     expect(phase()).toBe('success');
+  });
+
+  it('rounds the fiat and crypto amounts before tracking a completed order', async () => {
+    const completedOrder = {
+      ...COMPLETED_ORDER,
+      fiatAmount: { ...COMPLETED_ORDER.fiatAmount, amount: '123.456789' },
+      cryptoAmount: { ...COMPLETED_ORDER.cryptoAmount, amount: '0.123456789' },
+    };
+    startPolling(PROCESSING_ORDER);
+    getOrder.mockResolvedValue(completedOrder);
+
+    await getState().syncActiveOrder();
+
+    expect(track).toHaveBeenCalledWith(analytics.event.cashBuyOrderCompleted, {
+      fiatAmount: 123,
+      fiatCurrency: 'USD',
+      cryptoAmount: 0.123,
+      network: RampNetwork.Base,
+      timeToUsdcMs: 6_000,
+    });
   });
 
   // usePendingTransactionsStore is a raw-keyed map and every reader looks the row up under the app's

--- a/src/features/cash/stores/cashBuyOrderStore.ts
+++ b/src/features/cash/stores/cashBuyOrderStore.ts
@@ -2,6 +2,7 @@ import { createBaseStore, createStoreActions } from '@storesjs/stores';
 import { v4 as uuidv4 } from 'uuid';
 
 import { analytics } from '@/analytics';
+import { toAnalyticsAmount } from '@/analytics/utils';
 import { requireAddress } from '@/features/address/core/requireAddress';
 import { logger, RainbowError } from '@/logger';
 import { pendingTransactionsActions } from '@/state/pendingTransactions';
@@ -84,10 +85,9 @@ export const useCashBuyOrderStore = createBaseStore<CashBuyOrderState>(
     function applyTerminalOrder(order: TerminalBuyOrder): void {
       if (order.status === OrderStatus.Completed) {
         analytics.track(analytics.event.cashBuyOrderCompleted, {
-          orderId: order.id,
-          fiatAmount: order.fiatAmount.amount,
+          fiatAmount: toAnalyticsAmount(order.fiatAmount.amount),
           fiatCurrency: order.fiatAmount.currency,
-          cryptoAmount: order.cryptoAmount.amount,
+          cryptoAmount: toAnalyticsAmount(order.cryptoAmount.amount),
           network: order.cryptoAmount.asset.network,
           timeToUsdcMs: new Date(order.completedTime).getTime() - new Date(order.createdTime).getTime(),
         });
@@ -146,7 +146,7 @@ export const useCashBuyOrderStore = createBaseStore<CashBuyOrderState>(
         const { status } = get();
         if (selectCashBuyPhase({ status }) === 'pending') return;
 
-        analytics.track(analytics.event.cashBuyOrderSubmitted, { amount: depositAmount });
+        analytics.track(analytics.event.cashBuyOrderSubmitted, { amount: toAnalyticsAmount(depositAmount) });
 
         // decides whether the new submission should reuse the order id
         // from a previous failed attempt with not definitive rejection

--- a/src/features/cash/stores/verifyPhoneFlowStore.test.ts
+++ b/src/features/cash/stores/verifyPhoneFlowStore.test.ts
@@ -214,7 +214,7 @@ describe('useVerifyPhoneFlowStore.submit', () => {
     expect(flow().state).toBe('error');
     expect(flow().code).toBe('');
     expect(session().status).toBe('phoneSubmitted');
-    expect(track).toHaveBeenCalledWith('cash.phone_verify_failed', { reason: 'wrong code', mode: 'signup' });
+    expect(track).toHaveBeenCalledWith('cash.phone_verify_failed', { reason: 'unknown', mode: 'signup' });
     expect(track).not.toHaveBeenCalledWith('cash.phone_verified', expect.anything());
     expect(logger.error).toHaveBeenCalled();
   });

--- a/src/features/cash/stores/verifyPhoneFlowStore.ts
+++ b/src/features/cash/stores/verifyPhoneFlowStore.ts
@@ -118,7 +118,7 @@ export const useVerifyPhoneFlowStore = createBaseStore<VerifyPhoneFlowStore>((se
       }
       logger.error(new RainbowError('[useVerifyPhoneFlow]: Failed to verify phone', e));
       analytics.track(analytics.event.cashPhoneVerifyFailed, {
-        reason: e instanceof Error ? e.message : String(e),
+        reason: getTelemetryErrorReason(e),
         mode: challenge.kind,
       });
       set({ code: '', state: 'error' });


### PR DESCRIPTION
Fixes APP-4012

## Why?

CASH analytics events currently carry data that can identify the user or deanonymize the wallet:

- Six failure events forward server-controlled error text verbatim as their `reason`. The worst is the KYC failure, whose message describes a request carrying the user's legal name, date of birth and SSN-4.
- Exact deposit amounts are emitted on entry, submit and completion, riding alongside the hashed wallet address — bypassing the approximation helper the codebase already applies to send transactions, which exists precisely to prevent amount-based deanonymization.
- The completion event carries the order id, which the backend logs next to the real wallet address — joining the two datasets reverses the wallet hash.

## Approach

The failure events' `reason` is now a coarse, client-derived category (offline / client error / server error / unknown; the KYC event additionally keeps its client-produced `rejected` verdict), typed so that passing raw message text is a compile error. Amounts go through the same approximation used for send transactions, and the order id is dropped from the completion event — breaking the join without any backend change.
