### PR TITLE
test(imgix): cover URL signing and image format detection

### DIFF
--- a/src/components/RainbowImage.tsx
+++ b/src/components/RainbowImage.tsx
@@ -5,7 +5,7 @@ import { FasterImageView, type FasterImageProps, type ImageOptions } from '@cand
 import FastImage from 'react-native-fast-image';
 
 import { withStaticProperties } from '../helpers/withStaticProperties';
-import { memoFn } from '../utils/memoFn';
+import { getImageType, type DetectedImageExtension } from './images/imageType';
 
 export type RainbowImageProps = {
   source: Omit<ImageOptions, 'resizeMode'> | number;
@@ -130,18 +130,6 @@ export const RainbowImage = withStaticProperties(RainbowImageInternal, {
   },
 });
 
-const fastImageExtension = {
-  png: 'png',
-  jpg: 'jpg',
-  jpeg: 'jpeg',
-  bmp: 'bmp',
-  webp: 'webp',
-  gif: 'gif',
-  avif: 'avif',
-} as const;
-
-type FastImageExtensions = keyof typeof fastImageExtension;
-type DetectedImageExtension = FastImageExtensions | 'unknown';
 type ImageHandler = 'faster-image' | 'fast-image' | 'image';
 
 const getHandlerFromType = (extension: DetectedImageExtension): ImageHandler => {
@@ -153,20 +141,3 @@ const getHandlerFromType = (extension: DetectedImageExtension): ImageHandler => 
   }
   return 'image';
 };
-
-const pathRegex = /fm=([a-z]+)/;
-
-const getImageType = memoFn((path: string): DetectedImageExtension => {
-  try {
-    const url = new URL(path);
-    if (url.host.includes('imgix.net')) {
-      const [, type = 'png'] = path.match(pathRegex) || [];
-      return fastImageExtension[type as FastImageExtensions] || 'unknown';
-    }
-    const pathname = url.pathname;
-    const extension = pathname.split('.').pop()?.toLowerCase() || '';
-    return fastImageExtension[extension as FastImageExtensions] || 'unknown';
-  } catch {
-    return 'unknown';
-  }
-});

--- a/src/components/images/imageType.test.ts
+++ b/src/components/images/imageType.test.ts
@@ -1,0 +1,51 @@
+import { getImageType } from './imageType';
+
+const IMGIX = 'https://rainbow.imgix.net';
+const encoded = (source: string) => encodeURIComponent(source);
+
+describe('getImageType', () => {
+  describe('for imgix images', () => {
+    it('reads the format out of fm=', () => {
+      expect(getImageType(`${IMGIX}/${encoded('https://example.com/a.svg')}?w=120&fm=png`)).toBe('png');
+    });
+
+    it('reads a non-png fm', () => {
+      expect(getImageType(`${IMGIX}/${encoded('https://example.com/b.png')}?w=120&fm=gif`)).toBe('gif');
+    });
+
+    it('assumes png when fm is absent, whatever the source extension is', () => {
+      // The path is an encoded source URL, so its extension describes the source
+      // rather than the response. Without fm there is nothing else to go on.
+      expect(getImageType(`${IMGIX}/${encoded('https://example.com/c.svg')}?w=120`)).toBe('png');
+      expect(getImageType(`${IMGIX}/${encoded('https://example.com/d.jpg')}?w=120`)).toBe('png');
+    });
+
+    it('returns unknown for an fm we cannot decode', () => {
+      expect(getImageType(`${IMGIX}/${encoded('https://example.com/e.png')}?w=120&fm=tiff`)).toBe('unknown');
+    });
+  });
+
+  describe('for every other host, sniffed from the file extension', () => {
+    it.each([
+      ['https://example.com/a.png', 'png'],
+      ['https://example.com/a.jpg', 'jpg'],
+      ['https://example.com/a.jpeg', 'jpeg'],
+      ['https://example.com/a.webp', 'webp'],
+      ['https://example.com/a.gif', 'gif'],
+      ['https://example.com/a.avif', 'avif'],
+      ['https://example.com/a.bmp', 'bmp'],
+      ['https://example.com/a.svg', 'unknown'],
+      ['https://example.com/no-extension', 'unknown'],
+    ])('%s -> %s', (url, expected) => {
+      expect(getImageType(url)).toBe(expected);
+    });
+
+    it('ignores the query string when sniffing the extension', () => {
+      expect(getImageType('https://example.com/a.png?w=120')).toBe('png');
+    });
+  });
+
+  it('returns unknown for input that is not a URL', () => {
+    expect(getImageType('not-a-url')).toBe('unknown');
+  });
+});

--- a/src/components/images/imageType.ts
+++ b/src/components/images/imageType.ts
@@ -1,0 +1,41 @@
+import { memoFn } from '@/utils/memoFn';
+
+const fastImageExtension = {
+  png: 'png',
+  jpg: 'jpg',
+  jpeg: 'jpeg',
+  bmp: 'bmp',
+  webp: 'webp',
+  gif: 'gif',
+  avif: 'avif',
+} as const;
+
+type FastImageExtensions = keyof typeof fastImageExtension;
+export type DetectedImageExtension = FastImageExtensions | 'unknown';
+
+const pathRegex = /fm=([a-z]+)/;
+
+/**
+ * Derives the image format a URL will return.
+ *
+ * For our image CDN (currently any `imgix.net` host) the path is a
+ * percent-encoded source URL, so its file extension describes the source rather
+ * than the response. The `fm` parameter is the only reliable signal there, and
+ * png is assumed when it is absent.
+ *
+ * Every other URL is sniffed from the file extension.
+ */
+export const getImageType = memoFn((path: string): DetectedImageExtension => {
+  try {
+    const url = new URL(path);
+    if (url.host.includes('imgix.net')) {
+      const [, type = 'png'] = path.match(pathRegex) || [];
+      return fastImageExtension[type as FastImageExtensions] || 'unknown';
+    }
+    const pathname = url.pathname;
+    const extension = pathname.split('.').pop()?.toLowerCase() || '';
+    return fastImageExtension[extension as FastImageExtensions] || 'unknown';
+  } catch {
+    return 'unknown';
+  }
+});

--- a/src/handlers/imgix.test.ts
+++ b/src/handlers/imgix.test.ts
@@ -1,4 +1,7 @@
-import { getSizedImageUrl, maybeSignSource, maybeSignUri } from './imgix';
+import { getSizedImageUrl, maybeSignSource, maybeSignUri, staticSignatureLRU } from './imgix';
+
+// The LRU keys off the options as passed, before the pixel ratio is applied.
+const cacheKey = (uri: string, w?: number, fm?: string) => `${uri}-${w}-${fm}`;
 
 jest.mock('react-native-dotenv', () => ({
   IMGIX_DOMAIN: 'rainbow.imgix.net',
@@ -66,15 +69,24 @@ describe('maybeSignUri', () => {
     expect(maybeSignUri(undefined)).toBeUndefined();
   });
 
-  it('serves a repeated (uri, w, fm) from cache', () => {
+  it('caches the signed URL under the pre-scaling (uri, w, fm)', () => {
     const source = 'https://example.com/cached.png';
-    expect(maybeSignUri(source, { w: 40, h: 40 })).toBe(maybeSignUri(source, { w: 40, h: 40 }));
+    const signed = maybeSignUri(source, { w: 40, h: 40 });
+    expect(staticSignatureLRU.get(cacheKey(source, 40))).toBe(signed);
   });
 
-  it('skipCaching bypasses the cache but yields the same URL', () => {
+  it('returns a cached entry rather than re-signing', () => {
+    const source = 'https://example.com/preseeded.png';
+    staticSignatureLRU.set(cacheKey(source, 40), 'cached-sentinel');
+    expect(maybeSignUri(source, { w: 40 })).toBe('cached-sentinel');
+  });
+
+  it('skipCaching ignores a cached entry and re-signs', () => {
     const source = 'https://example.com/skip.png';
-    const first = maybeSignUri(source, { w: 40 });
-    expect(maybeSignUri(source, { w: 40 }, true)).toBe(first);
+    staticSignatureLRU.set(cacheKey(source, 40), 'cached-sentinel');
+    expect(maybeSignUri(source, { w: 40 }, true)).toBe(
+      'https://rainbow.imgix.net/https%3A%2F%2Fexample.com%2Fskip.png?w=120&s=4a6292056d91627774dde3f9c77442ef'
+    );
   });
 });
 

--- a/src/handlers/imgix.test.ts
+++ b/src/handlers/imgix.test.ts
@@ -1,0 +1,100 @@
+import { getSizedImageUrl, maybeSignSource, maybeSignUri } from './imgix';
+
+jest.mock('react-native-dotenv', () => ({
+  IMGIX_DOMAIN: 'rainbow.imgix.net',
+  IMGIX_TOKEN: 'test-secure-url-token',
+}));
+
+jest.mock('react-native', () => ({
+  PixelRatio: { getPixelSizeForLayoutSize: (n: number) => Math.round(n * 3) },
+}));
+
+// imgix-core-js is patched to sign via react-native-quick-md5, a native module.
+// Substitute a real md5 so the signatures below are the genuine ones.
+jest.mock('react-native-quick-md5', () => ({
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  stringMd5: (value: string) => require('crypto').createHash('md5').update(value).digest('hex'),
+}));
+
+jest.mock('@/logger', () => ({
+  logger: { error: jest.fn(), warn: jest.fn(), debug: jest.fn() },
+  RainbowError: class extends Error {},
+}));
+
+describe('maybeSignUri', () => {
+  it('encodes the source URL into the path and signs it', () => {
+    expect(maybeSignUri('https://rainbowme-res.cloudinary.com/image/upload/assets/ethereum/aaa.png', { w: 40, h: 40 })).toBe(
+      'https://rainbow.imgix.net/https%3A%2F%2Frainbowme-res.cloudinary.com%2Fimage%2Fupload%2Fassets%2Fethereum%2Faaa.png?w=120&h=120&s=340790d5bf71bf74ebd36e990ce81585'
+    );
+  });
+
+  it('multiplies w and h by the device pixel ratio (40 becomes 120 at 3x)', () => {
+    expect(maybeSignUri('https://example.com/dpr.png', { w: 40, h: 40 })).toBe(
+      'https://rainbow.imgix.net/https%3A%2F%2Fexample.com%2Fdpr.png?w=120&h=120&s=e42b7668f687e1280ee04ad6c37a7cd8'
+    );
+  });
+
+  it('emits w only when h is absent', () => {
+    expect(maybeSignUri('https://example.com/w-only.png', { w: 200 })).toBe(
+      'https://rainbow.imgix.net/https%3A%2F%2Fexample.com%2Fw-only.png?w=600&s=486799e9c247ac8d57bfb1930780f076'
+    );
+  });
+
+  it('passes fm through unscaled', () => {
+    expect(maybeSignUri('https://example.com/fm.svg', { w: 40, fm: 'png' })).toBe(
+      'https://rainbow.imgix.net/https%3A%2F%2Fexample.com%2Ffm.svg?w=120&fm=png&s=f1222d02fcfe4658c572f40ba95d2eb5'
+    );
+  });
+
+  it('signs with no transform params when none are given', () => {
+    expect(maybeSignUri('https://example.com/bare.png', {})).toBe(
+      'https://rainbow.imgix.net/https%3A%2F%2Fexample.com%2Fbare.png?s=6b766934e1361d82327a9472cda2acb4'
+    );
+  });
+
+  it('always emits w, h, fm in that order whatever order the caller passed', () => {
+    expect(maybeSignUri('https://example.com/order.png', { fm: 'png', h: 40, w: 40 })).toBe(
+      'https://rainbow.imgix.net/https%3A%2F%2Fexample.com%2Forder.png?w=120&h=120&fm=png&s=293d552080893249651b1247735efb59'
+    );
+  });
+
+  it('returns URLs with no host untouched', () => {
+    expect(maybeSignUri('not-a-url')).toBe('not-a-url');
+  });
+
+  it('returns undefined input untouched', () => {
+    expect(maybeSignUri(undefined)).toBeUndefined();
+  });
+
+  it('serves a repeated (uri, w, fm) from cache', () => {
+    const source = 'https://example.com/cached.png';
+    expect(maybeSignUri(source, { w: 40, h: 40 })).toBe(maybeSignUri(source, { w: 40, h: 40 }));
+  });
+
+  it('skipCaching bypasses the cache but yields the same URL', () => {
+    const source = 'https://example.com/skip.png';
+    const first = maybeSignUri(source, { w: 40 });
+    expect(maybeSignUri(source, { w: 40 }, true)).toBe(first);
+  });
+});
+
+describe('getSizedImageUrl', () => {
+  it('signs a square w/h from a single size, emitted in w,h order', () => {
+    expect(getSizedImageUrl('https://example.com/sized.png', 80)).toBe(
+      'https://rainbow.imgix.net/https%3A%2F%2Fexample.com%2Fsized.png?w=240&h=240&s=8838a788cb1e632090456b05369d0dda'
+    );
+  });
+
+  it('returns undefined for a missing url', () => {
+    expect(getSizedImageUrl(null)).toBeUndefined();
+  });
+});
+
+describe('maybeSignSource', () => {
+  it('signs the uri and preserves other source fields', () => {
+    expect(maybeSignSource({ uri: 'https://example.com/source.png', headers: { a: 'b' } }, { w: 40 })).toEqual({
+      headers: { a: 'b' },
+      uri: 'https://rainbow.imgix.net/https%3A%2F%2Fexample.com%2Fsource.png?w=120&s=5e0397bc0858d369116917aa7c173977',
+    });
+  });
+});

--- a/src/handlers/imgix.test.ts
+++ b/src/handlers/imgix.test.ts
@@ -24,6 +24,10 @@ jest.mock('@/logger', () => ({
   RainbowError: class extends Error {},
 }));
 
+beforeEach(() => {
+  staticSignatureLRU.clear();
+});
+
 describe('maybeSignUri', () => {
   it('encodes the source URL into the path and signs it', () => {
     expect(maybeSignUri('https://rainbowme-res.cloudinary.com/image/upload/assets/ethereum/aaa.png', { w: 40, h: 40 })).toBe(
@@ -79,6 +83,14 @@ describe('maybeSignUri', () => {
     const source = 'https://example.com/preseeded.png';
     staticSignatureLRU.set(cacheKey(source, 40), 'cached-sentinel');
     expect(maybeSignUri(source, { w: 40 })).toBe('cached-sentinel');
+  });
+
+  it('keys fm separately, so one uri and width can hold two formats', () => {
+    const source = 'https://example.com/two-formats.svg';
+    const png = maybeSignUri(source, { w: 40, fm: 'png' });
+
+    expect(maybeSignUri(source, { w: 40, fm: 'gif' })).not.toBe(png);
+    expect(maybeSignUri(source, { w: 40, fm: 'png' })).toBe(png);
   });
 
   it('skipCaching ignores a cached entry and re-signs', () => {


### PR DESCRIPTION
We're about to point the apps at our own image CDN domain which changes both how signed URLs get built and how we work out an image's format. Neither has any test coverage today, and a wrong format detection fails silently: the image still renders, just through a slower decoder.

This change adds tests for the current behavior of both with literal expected URLs, including two invariants the move depends on.

Format detection also moves out of `RainbowImage` into its own module. Reaching it in a test otherwise meant stubbing two native renderer modules it never calls, which is the signal that the file was doing two things and clobbering responsibility: deriving a format from a URL, and choosing a renderer for a format. Only the second is the component's business.

Ref APP-4019.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rainbow-me/rainbow/pull/7764?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

