### PR TITLE
chore: consolidate remote config mocking across test suites

### DIFF
--- a/src/features/cash/screens/cash-deposit-setup/steps/useSubmitKycFlow.test.ts
+++ b/src/features/cash/screens/cash-deposit-setup/steps/useSubmitKycFlow.test.ts
@@ -1,4 +1,5 @@
 import { analytics } from '@/analytics';
+import { setRemoteConfig } from '@/features/config/testing/mockRemoteConfig';
 import { logger } from '@/logger';
 import { delay } from '@/utils/delay';
 
@@ -19,9 +20,10 @@ jest.mock('@/analytics', () => ({
   },
 }));
 
-jest.mock('@/features/config/stores/remoteConfig', () => ({
-  getRemoteConfig: () => ({ cash_kyc_review_delay_ms: 60_000 }),
-}));
+const REVIEW_DELAY_MS = 60_000;
+
+jest.mock('@/features/config/stores/remoteConfig');
+setRemoteConfig({ cash_kyc_review_delay_ms: REVIEW_DELAY_MS });
 
 jest.mock('@/logger', () => ({
   logger: { debug: jest.fn(), error: jest.fn(), warn: jest.fn() },
@@ -54,7 +56,6 @@ const IDENTITY = { firstName: 'Ada', lastName: 'Lovelace', dateOfBirth: { year: 
 const SSN_LAST4 = '6789';
 if (!isValidUsSsnLast4(SSN_LAST4)) throw new Error('expected a valid SSN last four');
 const GOVERNMENT_ID = createUsSsnLast4GovernmentId(SSN_LAST4);
-const REVIEW_DELAY_MS = 60_000;
 
 function fakeClock(start = 1_750_000_000_000) {
   let clock = start;

--- a/src/features/config/stores/__mocks__/remoteConfig.ts
+++ b/src/features/config/stores/__mocks__/remoteConfig.ts
@@ -1,0 +1,22 @@
+import { mockedRemoteConfig } from '../../testing/mockRemoteConfig';
+import type { RemoteConfigKey, RemoteConfigState } from '../remoteConfig';
+
+const state = (): RemoteConfigState => ({
+  config: mockedRemoteConfig(),
+  lastFetchedVersion: 0,
+  getRemoteConfigKey: key => mockedRemoteConfig()[key],
+});
+
+export const getRemoteConfig = mockedRemoteConfig;
+
+export const useRemoteConfig = (...keys: RemoteConfigKey[]) =>
+  keys.length ? Object.fromEntries(keys.map(key => [key, mockedRemoteConfig()[key]])) : mockedRemoteConfig();
+
+export const useRemoteConfigStore = Object.assign(
+  jest.fn((selector?: (state: RemoteConfigState) => unknown) => (selector ? selector(state()) : state())),
+  { getState: state, subscribe: jest.fn(() => () => undefined) }
+);
+
+export const initializeRemoteConfig = async (): Promise<void> => undefined;
+
+export const useRemoteConfigUpdates = (): void => undefined;

--- a/src/features/config/stores/remoteConfig.ts
+++ b/src/features/config/stores/remoteConfig.ts
@@ -242,7 +242,7 @@ export const DEFAULT_CONFIG = {
   go_relay_backend_enabled: true,
 } as const satisfies Readonly<RainbowConfig>;
 
-type RemoteConfigKey = keyof typeof DEFAULT_CONFIG;
+export type RemoteConfigKey = keyof typeof DEFAULT_CONFIG;
 
 // ============ Firebase Defaults ============================================== //
 

--- a/src/features/config/testing/mockRemoteConfig.test.ts
+++ b/src/features/config/testing/mockRemoteConfig.test.ts
@@ -1,0 +1,92 @@
+import { getRemoteConfig, useRemoteConfig, useRemoteConfigStore } from '@/features/config/stores/remoteConfig';
+
+import { setRemoteConfig, withRemoteConfig } from './mockRemoteConfig';
+
+jest.mock('@/features/config/stores/remoteConfig');
+setRemoteConfig({ nfts_enabled: true });
+
+const nftsEnabled = () => getRemoteConfig().nfts_enabled;
+
+describe('the remote config mock', () => {
+  it('serves the config through every read the store exposes', () => {
+    expect(getRemoteConfig().nfts_enabled).toBe(true);
+    expect(useRemoteConfig().nfts_enabled).toBe(true);
+    expect(useRemoteConfigStore.getState().getRemoteConfigKey('nfts_enabled')).toBe(true);
+  });
+
+  it('narrows to the requested keys', () => {
+    expect(useRemoteConfig('nfts_enabled')).toEqual({ nfts_enabled: true });
+  });
+
+  it('reads undefined for keys that were not supplied', () => {
+    expect(getRemoteConfig().perps_enabled).toBeUndefined();
+  });
+
+  it('rejects keys the config does not declare, and values of the wrong type', () => {
+    withRemoteConfig(
+      // @ts-expect-error 'nfts_enabld' is not a config key
+      { nfts_enabld: true },
+      () => undefined
+    );
+    // @ts-expect-error nfts_enabled is a boolean
+    withRemoteConfig({ nfts_enabled: 'yes' }, () => undefined);
+
+    expect(nftsEnabled()).toBe(true);
+  });
+
+  it('resolves reads on each call rather than snapshotting', () => {
+    const { getRemoteConfigKey } = useRemoteConfigStore.getState();
+    withRemoteConfig({ nfts_enabled: false }, () => {
+      expect(getRemoteConfigKey('nfts_enabled')).toBe(false);
+    });
+  });
+});
+
+describe('withRemoteConfig', () => {
+  it('applies the override inside the block and restores the previous config after it', () => {
+    withRemoteConfig({ nfts_enabled: false }, () => {
+      expect(nftsEnabled()).toBe(false);
+    });
+    expect(nftsEnabled()).toBe(true);
+  });
+
+  it('returns the block result', () => {
+    expect(withRemoteConfig({ nfts_enabled: false }, () => 'value')).toBe('value');
+  });
+
+  it('restores when the block throws', () => {
+    expect(() =>
+      withRemoteConfig({ nfts_enabled: false }, () => {
+        throw new Error('boom');
+      })
+    ).toThrow('boom');
+    expect(nftsEnabled()).toBe(true);
+  });
+
+  it('restores only once an async block resolves', async () => {
+    const pending = withRemoteConfig({ nfts_enabled: false }, async () => {
+      await Promise.resolve();
+      return nftsEnabled();
+    });
+    expect(nftsEnabled()).toBe(false);
+    await expect(pending).resolves.toBe(false);
+    expect(nftsEnabled()).toBe(true);
+  });
+
+  it('restores when an async block rejects', async () => {
+    await expect(withRemoteConfig({ nfts_enabled: false }, () => Promise.reject(new Error('boom')))).rejects.toThrow('boom');
+    expect(nftsEnabled()).toBe(true);
+  });
+
+  it('merges when nested and unwinds one level at a time', () => {
+    withRemoteConfig({ nfts_enabled: false }, () => {
+      withRemoteConfig({ perps_enabled: true }, () => {
+        expect(nftsEnabled()).toBe(false);
+        expect(getRemoteConfig().perps_enabled).toBe(true);
+      });
+      expect(nftsEnabled()).toBe(false);
+      expect(getRemoteConfig().perps_enabled).toBeUndefined();
+    });
+    expect(nftsEnabled()).toBe(true);
+  });
+});

--- a/src/features/config/testing/mockRemoteConfig.test.ts
+++ b/src/features/config/testing/mockRemoteConfig.test.ts
@@ -73,6 +73,15 @@ describe('withRemoteConfig', () => {
     expect(nftsEnabled()).toBe(true);
   });
 
+  it('restores only once a thenable that is not a native Promise settles', async () => {
+    const thenable = <T>(value: T): PromiseLike<T> => ({ then: onFulfilled => Promise.resolve(value).then(onFulfilled) });
+
+    const pending = withRemoteConfig({ nfts_enabled: false }, () => thenable('done'));
+    expect(nftsEnabled()).toBe(false);
+    await expect(pending).resolves.toBe('done');
+    expect(nftsEnabled()).toBe(true);
+  });
+
   it('restores when an async block rejects', async () => {
     await expect(withRemoteConfig({ nfts_enabled: false }, () => Promise.reject(new Error('boom')))).rejects.toThrow('boom');
     expect(nftsEnabled()).toBe(true);

--- a/src/features/config/testing/mockRemoteConfig.ts
+++ b/src/features/config/testing/mockRemoteConfig.ts
@@ -4,6 +4,9 @@ export type MockedRemoteConfigValues = Partial<Pick<RainbowConfig, RemoteConfigK
 
 let values: MockedRemoteConfigValues = {};
 
+const isThenable = (value: unknown): value is PromiseLike<unknown> =>
+  typeof (value as PromiseLike<unknown> | null | undefined)?.then === 'function';
+
 export const mockedRemoteConfig = (): RainbowConfig => values as RainbowConfig;
 
 export function setRemoteConfig(config: MockedRemoteConfigValues): void {
@@ -26,7 +29,7 @@ export function withRemoteConfig<T>(config: MockedRemoteConfigValues, body: () =
     throw error;
   }
 
-  if (result instanceof Promise) return result.finally(restore) as T;
+  if (isThenable(result)) return Promise.resolve(result).finally(restore) as T;
   restore();
   return result;
 }

--- a/src/features/config/testing/mockRemoteConfig.ts
+++ b/src/features/config/testing/mockRemoteConfig.ts
@@ -1,0 +1,32 @@
+import type { RainbowConfig, RemoteConfigKey } from '../stores/remoteConfig';
+
+export type MockedRemoteConfigValues = Partial<Pick<RainbowConfig, RemoteConfigKey>>;
+
+let values: MockedRemoteConfigValues = {};
+
+export const mockedRemoteConfig = (): RainbowConfig => values as RainbowConfig;
+
+export function setRemoteConfig(config: MockedRemoteConfigValues): void {
+  values = { ...config };
+}
+
+export function withRemoteConfig<T>(config: MockedRemoteConfigValues, body: () => T): T {
+  const previous = values;
+  values = { ...previous, ...config };
+
+  const restore = () => {
+    values = previous;
+  };
+
+  let result: T;
+  try {
+    result = body();
+  } catch (error) {
+    restore();
+    throw error;
+  }
+
+  if (result instanceof Promise) return result.finally(restore) as T;
+  restore();
+  return result;
+}

--- a/src/features/polymarket/stores/polymarketSportsEventsStore.test.ts
+++ b/src/features/polymarket/stores/polymarketSportsEventsStore.test.ts
@@ -35,11 +35,7 @@ jest.mock('@/framework/data/http/rainbowFetch', () => ({
   rainbowFetch: jest.fn(),
 }));
 
-jest.mock('@/features/config/stores/remoteConfig', () => ({
-  useRemoteConfigStore: mockStore({
-    getRemoteConfigKey: jest.fn(() => false),
-  }),
-}));
+jest.mock('@/features/config/stores/remoteConfig');
 
 function mockStore<T>(state: T) {
   return Object.assign(jest.fn(), {

--- a/src/features/rnbw-staking/utils/unstakeRnbwCalls.test.ts
+++ b/src/features/rnbw-staking/utils/unstakeRnbwCalls.test.ts
@@ -53,9 +53,13 @@ describe('unstakeRnbwCalls', () => {
   });
 
   it('omits requirements when sponsorship is unavailable', async () => {
-    await expect(buildUnstakeRnbwExecutionPlan({ address: ACCOUNT })).resolves.toEqual({
-      calls: [buildUnstakeCall()],
+    await withRemoteConfig({ sponsored_rnbw_unstaking_enabled: true }, async () => {
+      await expect(buildUnstakeRnbwExecutionPlan({ address: ACCOUNT })).resolves.toEqual({
+        calls: [buildUnstakeCall()],
+      });
     });
+
+    expect(mockCanUseSponsoredRnbwStaking).toHaveBeenCalledWith(ACCOUNT, STAKING_CHAIN_ID);
   });
 
   it('omits requirements when the feature flag is off, even if sponsored execution is available', async () => {

--- a/src/features/rnbw-staking/utils/unstakeRnbwCalls.test.ts
+++ b/src/features/rnbw-staking/utils/unstakeRnbwCalls.test.ts
@@ -1,20 +1,18 @@
 import { encodeFunctionData, type Address } from 'viem';
 
+import { withRemoteConfig } from '@/features/config/testing/mockRemoteConfig';
 import { type Call, type CallsRequirements } from '@rainbow-me/sdk';
 
 import { STAKING_ABI, STAKING_CHAIN_ID, STAKING_CONTRACT_ADDRESS } from '../constants';
 import { buildUnstakeRnbwCalls, buildUnstakeRnbwExecutionPlan } from './unstakeRnbwCalls';
 
 const mockCanUseSponsoredRnbwStaking = jest.fn<Promise<boolean>, [Address, number]>();
-const mockGetRemoteConfig = jest.fn<{ sponsored_rnbw_unstaking_enabled: boolean }, []>();
 
 jest.mock('./canUseSponsoredRnbwStaking', () => ({
   canUseSponsoredRnbwStaking: (address: Address, chainId: number) => mockCanUseSponsoredRnbwStaking(address, chainId),
 }));
 
-jest.mock('@/features/config/stores/remoteConfig', () => ({
-  getRemoteConfig: () => mockGetRemoteConfig(),
-}));
+jest.mock('@/features/config/stores/remoteConfig');
 
 jest.mock('@/utils/ethereumUtils', () => ({
   getUniqueId: (address: string, chainId: number) => `${address}_${chainId}`,
@@ -35,7 +33,6 @@ describe('unstakeRnbwCalls', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockCanUseSponsoredRnbwStaking.mockResolvedValue(false);
-    mockGetRemoteConfig.mockReturnValue({ sponsored_rnbw_unstaking_enabled: true });
   });
 
   it('builds a single unstakeAll call', () => {
@@ -45,9 +42,11 @@ describe('unstakeRnbwCalls', () => {
   it('adds sponsor-paid requirements when unstaking can use sponsored execution and flag is on', async () => {
     mockCanUseSponsoredRnbwStaking.mockResolvedValue(true);
 
-    await expect(buildUnstakeRnbwExecutionPlan({ address: ACCOUNT })).resolves.toEqual({
-      calls: [buildUnstakeCall()],
-      requirements: SPONSORED_REQUIREMENTS,
+    await withRemoteConfig({ sponsored_rnbw_unstaking_enabled: true }, async () => {
+      await expect(buildUnstakeRnbwExecutionPlan({ address: ACCOUNT })).resolves.toEqual({
+        calls: [buildUnstakeCall()],
+        requirements: SPONSORED_REQUIREMENTS,
+      });
     });
 
     expect(mockCanUseSponsoredRnbwStaking).toHaveBeenCalledWith(ACCOUNT, STAKING_CHAIN_ID);
@@ -61,10 +60,11 @@ describe('unstakeRnbwCalls', () => {
 
   it('omits requirements when the feature flag is off, even if sponsored execution is available', async () => {
     mockCanUseSponsoredRnbwStaking.mockResolvedValue(true);
-    mockGetRemoteConfig.mockReturnValue({ sponsored_rnbw_unstaking_enabled: false });
 
-    await expect(buildUnstakeRnbwExecutionPlan({ address: ACCOUNT })).resolves.toEqual({
-      calls: [buildUnstakeCall()],
+    await withRemoteConfig({ sponsored_rnbw_unstaking_enabled: false }, async () => {
+      await expect(buildUnstakeRnbwExecutionPlan({ address: ACCOUNT })).resolves.toEqual({
+        calls: [buildUnstakeCall()],
+      });
     });
 
     expect(mockCanUseSponsoredRnbwStaking).not.toHaveBeenCalled();

--- a/src/features/transfer/hooks/useSponsoredSendPreparation.test.ts
+++ b/src/features/transfer/hooks/useSponsoredSendPreparation.test.ts
@@ -4,10 +4,7 @@ import { ChainId } from '@/features/network/types/backendNetworks';
 
 import { getCachedDelegationSupport, getDelegationSupportRequestKey, getSponsoredSendRequestKey } from './useSponsoredSendPreparation';
 
-jest.mock('@/features/config/stores/remoteConfig', () => ({
-  getRemoteConfig: () => ({ sponsored_sends_enabled: true }),
-  useRemoteConfig: () => ({ sponsored_sends_enabled: true }),
-}));
+jest.mock('@/features/config/stores/remoteConfig');
 
 jest.mock('../utils/sponsoredSend', () => ({
   predictSponsoredSend: jest.fn(),

--- a/src/features/transfer/utils/sponsoredSend.test.ts
+++ b/src/features/transfer/utils/sponsoredSend.test.ts
@@ -4,6 +4,7 @@ import { Wallet } from '@ethersproject/wallet';
 import { type Address } from 'viem';
 
 import { TransactionStatus, type NewTransaction } from '@/entities/transactions/transaction';
+import { setRemoteConfig, withRemoteConfig } from '@/features/config/testing/mockRemoteConfig';
 import { ChainId } from '@/features/network/types/backendNetworks';
 import { type Call, type PreparedCallsExecution } from '@rainbow-me/sdk';
 
@@ -24,10 +25,6 @@ const mockResolveManagedExecutionFailure = jest.fn<Promise<string | null>, [unkn
 const mockSupportsDelegatedExecution = jest.fn<Promise<boolean>, [unknown]>();
 const mockTrackCallsExecution = jest.fn<void, [unknown]>();
 
-const mockRemoteConfig = {
-  sponsored_sends_enabled: true,
-};
-
 const mockSponsoredCallsRequirements = {
   atomic: 'required',
   fees: { payer: 'sponsor' },
@@ -42,9 +39,8 @@ jest.mock('@rainbow-me/sdk', () => ({
   },
 }));
 
-jest.mock('@/features/config/stores/remoteConfig', () => ({
-  getRemoteConfig: () => mockRemoteConfig,
-}));
+jest.mock('@/features/config/stores/remoteConfig');
+setRemoteConfig({ sponsored_sends_enabled: true });
 
 jest.mock('@/features/network/stores/backendNetworksStore', () => ({
   backendNetworksActions: {
@@ -127,7 +123,6 @@ function executeWith(params?: Partial<Parameters<typeof executeSponsoredSend>[0]
 describe('sponsoredSend', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockRemoteConfig.sponsored_sends_enabled = true;
     mockCanUseDelegatedExecution.mockReturnValue(true);
     mockCreateDelegationPublicClient.mockReturnValue(publicClient);
     mockIsSponsorshipEligible.mockReturnValue(true);
@@ -141,12 +136,10 @@ describe('sponsoredSend', () => {
   });
 
   it('requires remote config and a valid address before predicting sponsored sends', () => {
-    mockRemoteConfig.sponsored_sends_enabled = false;
-
-    expect(predictSponsoredSend({ address: ACCOUNT, chainId })).toBe(false);
-    expect(mockCanUseDelegatedExecution).not.toHaveBeenCalled();
-
-    mockRemoteConfig.sponsored_sends_enabled = true;
+    withRemoteConfig({ sponsored_sends_enabled: false }, () => {
+      expect(predictSponsoredSend({ address: ACCOUNT, chainId })).toBe(false);
+      expect(mockCanUseDelegatedExecution).not.toHaveBeenCalled();
+    });
 
     expect(predictSponsoredSend({ address: 'not-an-address', chainId })).toBe(false);
     expect(mockCanUseDelegatedExecution).not.toHaveBeenCalled();

--- a/src/raps/atomicSwapPreparation.test.ts
+++ b/src/raps/atomicSwapPreparation.test.ts
@@ -1,5 +1,6 @@
 import { StaticJsonRpcProvider } from '@ethersproject/providers';
 
+import { withRemoteConfig } from '@/features/config/testing/mockRemoteConfig';
 import { backendNetworksActions } from '@/features/network/stores/backendNetworksStore';
 import { type Call } from '@rainbow-me/sdk';
 import { SwapType, type CrosschainQuote, type Quote } from '@rainbow-me/swaps';
@@ -10,8 +11,6 @@ import { prepareApprovalCall } from './actions/unlock';
 import { resolveApprovalRequirement } from './approval';
 import { buildAtomicExecutionRequirements, prepareAtomicSwapCalls } from './atomicSwapPreparation';
 
-const mockGetRemoteConfig = jest.fn(() => ({ sponsored_swaps_enabled: true }));
-
 jest.mock('@rainbow-me/sdk', () => ({
   execute: {
     prepare: {
@@ -20,9 +19,7 @@ jest.mock('@rainbow-me/sdk', () => ({
   },
 }));
 
-jest.mock('@/features/config/stores/remoteConfig', () => ({
-  getRemoteConfig: () => mockGetRemoteConfig(),
-}));
+jest.mock('@/features/config/stores/remoteConfig');
 
 jest.mock('@/features/network/stores/backendNetworksStore', () => ({
   backendNetworksActions: {
@@ -94,7 +91,6 @@ describe('atomicSwapPreparation', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     jest.mocked(backendNetworksActions.isSponsorshipEligible).mockImplementation(chainId => chainId !== 1);
-    mockGetRemoteConfig.mockReturnValue({ sponsored_swaps_enabled: true });
   });
 
   it('builds the same-chain atomic call list without approval when none is required', async () => {
@@ -165,16 +161,18 @@ describe('atomicSwapPreparation', () => {
   });
 
   it('requests sponsor fees only when sponsorship is enabled and eligible', async () => {
-    expect(buildAtomicExecutionRequirements(8453)).toEqual({
-      atomic: 'required',
-      fees: { payer: 'sponsor' },
+    withRemoteConfig({ sponsored_swaps_enabled: true }, () => {
+      expect(buildAtomicExecutionRequirements(8453)).toEqual({
+        atomic: 'required',
+        fees: { payer: 'sponsor' },
+      });
     });
 
-    mockGetRemoteConfig.mockReturnValue({ sponsored_swaps_enabled: false });
-
-    expect(buildAtomicExecutionRequirements(8453)).toEqual({
-      atomic: 'required',
-      fees: undefined,
+    withRemoteConfig({ sponsored_swaps_enabled: false }, () => {
+      expect(buildAtomicExecutionRequirements(8453)).toEqual({
+        atomic: 'required',
+        fees: undefined,
+      });
     });
   });
 });


### PR DESCRIPTION
There's no canonical way to mock remote config today in our test suites which means each has invented their own approach and looks slightly different from eachother. Furthermore, some of the tests mocking specific flags don't even need them.

This change introduces two centralized APIs to mock remote config going forward and moves all existing tests to them:
* `withRemoteConfig` wraps a function and scopes the flag value inside, also workes nested
* `setRemoteConfig` allows setting any number of values imperatively (rare use, most should use the wrapper)

Flags are also removed where they're not needed.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rainbow-me/rainbow/pull/7765?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

