### PR TITLE
chore(CASH): update Bivo SDK to 0.0.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -160,7 +160,7 @@
   },
   "dependencies": {
     "@bankify/react-native-animate-number": "0.2.1",
-    "@bivoglobal/payment-react-native": "0.0.6",
+    "@bivoglobal/payment-react-native": "0.0.7",
     "@bradgarropy/use-countdown": "1.4.1",
     "@candlefinance/faster-image": "1.6.2",
     "@capsizecss/core": "3.0.0",

--- a/src/features/cash/screens/cash-deposit-setup/steps/CardDetailsStep.tsx
+++ b/src/features/cash/screens/cash-deposit-setup/steps/CardDetailsStep.tsx
@@ -1,4 +1,4 @@
-import React, { memo, useCallback, useMemo } from 'react';
+import React, { memo, useCallback, useEffect, useMemo } from 'react';
 import { Image, Platform, StyleSheet, View } from 'react-native';
 
 import { BivoCardInput, BivoCVCInput, BivoTextInput } from '@bivoglobal/payment-react-native';
@@ -9,7 +9,9 @@ import { CashStatusHalfSheet } from '@/features/cash/components/CashStatusHalfSh
 import { useSetupInputTextStyle } from '@/features/cash/components/useSetupInputTextStyle';
 import { useCardLinkFlowStore } from '@/features/cash/stores/cardLinkFlowStore';
 import * as i18n from '@/languages';
+import Routes from '@/navigation/routesNames';
 
+import { useCashDepositSetupNavigationStore } from '../cashDepositSetupNavigator';
 import { SetupStepLayout } from '../components/SetupStepLayout';
 import { CARD_FIELD, useSetupContext } from '../setupContext';
 import { goBackInSetup } from '../setupNavigation';
@@ -21,6 +23,7 @@ export const CardDetailsStep = memo(function CardLinkForm() {
 
   const isError = useCardLinkFlowStore(s => s.state === 'submitError');
   const isSubmitting = useCardLinkFlowStore(s => s.state === 'submitting');
+  const isCardStepActive = useCashDepositSetupNavigationStore(s => s.activeRoute === Routes.CASH_SETUP_CARD_DETAILS);
   const isVisa = useCardFormStore(s => s.isVisa);
 
   const bivoStore = getCardForm();
@@ -38,6 +41,15 @@ export const CardDetailsStep = memo(function CardLinkForm() {
   );
 
   const cardNumberTextStyle = useMemo(() => ({ ...textStyle, paddingRight: 60 }), [textStyle]);
+
+  useEffect(() => {
+    if (!isCardStepActive) {
+      useCardFormStore.setState(state => (state.isReady || state.isVisa ? { isReady: false, isVisa: false } : state));
+      return;
+    }
+
+    return () => bivoStore.clearFields();
+  }, [bivoStore, isCardStepActive, useCardFormStore]);
 
   const cancel = useCallback(() => {
     reset();
@@ -57,6 +69,7 @@ export const CardDetailsStep = memo(function CardLinkForm() {
               onStateChange={refreshCardFormReadiness}
               placeholder={i18n.t(l.card_number)}
               required
+              allowContextMenu
               textStyle={cardNumberTextStyle}
             />
             {isVisa ? (

--- a/src/features/cash/services/cardLinkService.test.ts
+++ b/src/features/cash/services/cardLinkService.test.ts
@@ -46,7 +46,7 @@ describe('linkCardWithVault', () => {
 
     expect(order).toEqual(['session', 'submit', 'complete']);
     expect(mockStart).toHaveBeenCalledWith(abortController);
-    expect(mockSubmit).toHaveBeenCalledWith(SESSION.linkUrl, SESSION.token);
+    expect(mockSubmit).toHaveBeenCalledWith(SESSION.token);
     expect(mockComplete).toHaveBeenCalledWith({ brand: CARD_BRAND, providerCardId: 'provider-card-1' }, abortController);
   });
 

--- a/src/features/cash/services/cardLinkService.ts
+++ b/src/features/cash/services/cardLinkService.ts
@@ -35,7 +35,7 @@ export async function linkCardWithVault(
   }
 
   const session = await startCardLinkSession(abortController);
-  const result = await withTimeout(bivoStore.submit(session.linkUrl, session.token), BIVO_SUBMIT_TIMEOUT, 'Bivo vault submit timed out');
+  const result = await withTimeout(bivoStore.submit(session.token), BIVO_SUBMIT_TIMEOUT, 'Bivo vault submit timed out');
   // bivo SDK does not have a way to pass abort controller, so we check here manually
   throwIfAborted(abortController);
   if (!isBivoSubmitResult(result)) throw new Error('Bivo vault returned an unexpected response');

--- a/yarn.lock
+++ b/yarn.lock
@@ -1799,15 +1799,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@bivoglobal/payment-react-native@npm:0.0.6":
-  version: 0.0.6
-  resolution: "@bivoglobal/payment-react-native@npm:0.0.6"
+"@bivoglobal/payment-react-native@npm:0.0.7":
+  version: 0.0.7
+  resolution: "@bivoglobal/payment-react-native@npm:0.0.7"
   dependencies:
     react-native-device-info: "npm:^15.0.2"
   peerDependencies:
     react: "*"
     react-native: "*"
-  checksum: 10c0/619212a5ae151d6a4abb135ae866c70b37814821e4947eccd2f860fbb8aa491988bba64ec02c985f11556457381d8639dcaaed76617cf08384797a8495101b46
+  checksum: 10c0/ff24bcf2487b072047fb1b0351ab04c81e321b714e2dd72501a4fc20a0649dd027ea40579147be12fc52cd090a7356895e1ee57d34ddbef0d6fa42c5a8375625
   languageName: node
   linkType: hard
 
@@ -9058,7 +9058,7 @@ __metadata:
     "@babel/plugin-transform-runtime": "npm:^7.25.0"
     "@babel/runtime": "npm:^7.25.0"
     "@bankify/react-native-animate-number": "npm:0.2.1"
-    "@bivoglobal/payment-react-native": "npm:0.0.6"
+    "@bivoglobal/payment-react-native": "npm:0.0.7"
     "@bradgarropy/use-countdown": "npm:1.4.1"
     "@candlefinance/faster-image": "npm:1.6.2"
     "@capsizecss/core": "npm:3.0.0"


### PR DESCRIPTION
Fixed: APP-4009

## Why?

Bivo `0.0.7` takes over the card-data destination: the SDK builds the URL itself from the `sandbox` / `live` environment we construct it with, and throws if you pass one. So `submit(linkUrl, token)` becomes `submit(token)` — card linking breaks on this version otherwise.

It also adds a way to clear card data, which we use to wipe the store when the card screen goes away. The rest is theirs: hardened inputs, typed errors, CVV cleared after every attempt.

## Testing

Sandbox card-link flow:

- Link a card — should work as before.
- Fail a submit: the CVV box empties by design (number, expiry and ZIP stay), action disabled until it's re-entered.
- Card fields no longer offer paste or autofill — new SDK default, say if you want paste back.
- Leave the card step and come back: the form is empty.
