### PR TITLE
chore(CASH): Harden Order submission

### DIFF
--- a/src/features/cash/constants.ts
+++ b/src/features/cash/constants.ts
@@ -9,6 +9,7 @@ export const USDC_SYMBOL = 'USDC';
 export const USDC_DECIMALS = 6;
 
 export const ORDER_POLL_INTERVAL_MS = time.seconds(2);
+export const ORDER_SUBMISSION_RETRY_BASE_DELAY_MS = time.seconds(1);
 
 /** Each platform admits exactly one destination: production `usdc/base`, staging `usdc/arbitrum_testnet`. */
 export const CASH_BUY_DESTINATION_ASSET: RampAsset = {

--- a/src/features/cash/screens/add-cash-sheet/AddCashSheet.tsx
+++ b/src/features/cash/screens/add-cash-sheet/AddCashSheet.tsx
@@ -12,7 +12,7 @@ import { HoldToActivateButton } from '@/components/hold-to-activate-button/HoldT
 import { NumberPad } from '@/components/number-pad/NumberPad';
 import { DEFAULT_HANDLE_COLOR_DARK, DEFAULT_HANDLE_COLOR_LIGHT, PanelSheet } from '@/components/PanelSheet/PanelSheet';
 import { Box, Inline, Text, useColorMode, useForegroundColor } from '@/design-system';
-import { ORDER_POLL_INTERVAL_MS } from '@/features/cash/constants';
+import { ORDER_POLL_INTERVAL_MS, ORDER_SUBMISSION_RETRY_BASE_DELAY_MS } from '@/features/cash/constants';
 import { isPasskeyCancellation } from '@/features/cash/services/cashPasskeyService';
 import { checkWalletLink } from '@/features/cash/services/walletLinkService';
 import { cashBuyOrderActions, selectCashBuyPhase, useCashBuyOrderStore, useCashBuyPhase } from '@/features/cash/stores/cashBuyOrderStore';
@@ -337,6 +337,7 @@ export const AddCashSheet = memo(function AddCashSheet() {
   const phase = useCashBuyPhase();
   const previousPhase = usePrevious(phase);
   const errorCode = useCashBuyOrderStore(state => (state.status.step === 'error' ? state.status.errorCode : null));
+  const isSubmitting = useCashBuyOrderStore(state => state.status.step === 'submitting');
   const isPolling = useCashBuyOrderStore(state => state.status.step === 'polling');
   const submittedAt = useCashBuyOrderStore(state =>
     state.status.step === 'submitting' || state.status.step === 'polling' ? state.status.submittedAt : null
@@ -372,15 +373,16 @@ export const AddCashSheet = memo(function AddCashSheet() {
     };
   }, []);
 
-  // On open, replay a submit interrupted before an order id came back; otherwise clear the settled
-  // previous run so the sheet starts fresh.
+  // Keep recovered in-flight state; otherwise clear the settled previous run so the sheet starts fresh.
   useEffect(() => {
-    if (selectCashBuyPhase(useCashBuyOrderStore.getState()) === 'pending') {
-      cashBuyOrderActions.resumePendingSubmission();
-    } else {
-      cashBuyOrderActions.reset();
-    }
+    if (selectCashBuyPhase(useCashBuyOrderStore.getState()) !== 'pending') cashBuyOrderActions.reset();
   }, []);
+
+  useWatcher({
+    enabled: isSubmitting,
+    interval: ORDER_SUBMISSION_RETRY_BASE_DELAY_MS,
+    watchFunction: cashBuyOrderActions.resumePendingSubmission,
+  });
 
   useWatcher({
     enabled: isPolling,
@@ -481,6 +483,7 @@ export const AddCashSheet = memo(function AddCashSheet() {
       layoutAnimation={PANEL_LAYOUT}
       panelStyle={isKeypad ? styles.fullScreenPanel : undefined}
       showHandle={!isKeypad}
+      showTapToDismiss={!isProcessing}
     >
       <Box background="surfaceSecondary" style={isKeypad ? styles.fullScreenContent : undefined}>
         {view === 'pending' ? (

--- a/src/features/cash/screens/add-wallet-sheet/AddWalletSheet.tsx
+++ b/src/features/cash/screens/add-wallet-sheet/AddWalletSheet.tsx
@@ -100,9 +100,10 @@ export const AddWalletSheet = memo(function AddWalletSheet() {
   }
 
   const isError = state === 'error';
+  const isLinking = state === 'linking' || state === 'linked';
 
   return (
-    <PanelSheet>
+    <PanelSheet showTapToDismiss={!isLinking}>
       <Box paddingBottom="20px" paddingHorizontal="20px" paddingTop="52px">
         <Stack space="32px">
           <Box paddingHorizontal="12px">
@@ -123,7 +124,7 @@ export const AddWalletSheet = memo(function AddWalletSheet() {
           </Box>
           <CashActionButton
             label={i18n.t(isError ? i18n.l.cash.add_wallet.retry : i18n.l.cash.add_wallet.confirm)}
-            loading={state === 'linking' || state === 'linked'}
+            loading={isLinking}
             onPress={confirm}
             testID="cash-deposit-add-wallet-confirm"
           />

--- a/src/features/cash/services/rampClient.test.ts
+++ b/src/features/cash/services/rampClient.test.ts
@@ -8,6 +8,7 @@ import {
   completeCardLinkSession,
   createBuyOrder,
   getOrder,
+  isDefinitiveRejection,
   OrderStatus,
   RampCryptoAsset,
   RampNetwork,
@@ -143,5 +144,23 @@ describe('buy orders', () => {
       abortController,
       headers: { Authorization: 'Bearer jwt-1' },
     });
+  });
+});
+
+// Callers use this to decide whether a failed write may still have taken effect, so every status
+// answered `true` here is one whose retry is allowed to create a second order.
+describe('isDefinitiveRejection', () => {
+  const cases: { error: unknown; expected: boolean; label: string }[] = [
+    { label: '400', error: fetchError(400, 'bad request'), expected: true },
+    { label: '404', error: fetchError(404, 'not found'), expected: true },
+    { label: '408', error: fetchError(408, 'request timeout'), expected: false },
+    { label: '422', error: fetchError(422, 'unprocessable'), expected: true },
+    { label: '429', error: fetchError(429, 'too many requests'), expected: false },
+    { label: '500', error: fetchError(500, 'server error'), expected: false },
+    { label: 'a transport error with no response', error: new Error('network down'), expected: false },
+  ];
+
+  it.each(cases)('answers $expected for $label', ({ error, expected }) => {
+    expect(isDefinitiveRejection(error)).toBe(expected);
   });
 });

--- a/src/features/cash/services/rampClient.ts
+++ b/src/features/cash/services/rampClient.ts
@@ -135,10 +135,16 @@ export function isNotFoundError(error: unknown): boolean {
   return error instanceof RainbowFetchError && error.response?.status === 404;
 }
 
-/** The backend answered and refused, so the request definitively took no effect. Transport failures and 5xx stay ambiguous. */
+// A refusal to answer rather than an answer: the request may still have taken effect upstream.
+const AMBIGUOUS_4XX = new Set([408, 429]);
+
+/**
+ * The backend answered and refused, so the request definitively took no effect. Transport failures,
+ * 5xx and the 4xx in `AMBIGUOUS_4XX` stay ambiguous.
+ */
 export function isDefinitiveRejection(error: unknown): boolean {
   const status = error instanceof RainbowFetchError ? error.response?.status : undefined;
-  return status !== undefined && status >= 400 && status < 500;
+  return status !== undefined && status >= 400 && status < 500 && !AMBIGUOUS_4XX.has(status);
 }
 
 // The user JWT replaces the shared app key on these calls. On 401 the cached

--- a/src/features/cash/stores/cashBuyOrderStore.test.ts
+++ b/src/features/cash/stores/cashBuyOrderStore.test.ts
@@ -128,17 +128,21 @@ beforeEach(() => {
 
 describe('submitBuyOrder', () => {
   it('rounds the amount before tracking a submitted order', async () => {
-    createBuyOrder.mockResolvedValue(CREATED_PENDING_ORDER);
-
     await getState().submitBuyOrder({ ...SUBMIT_INPUT, depositAmount: '123.456789' });
 
     expect(track).toHaveBeenCalledWith(analytics.event.cashBuyOrderSubmitted, { amount: 123 });
+    expect(createBuyOrder).not.toHaveBeenCalled();
   });
 
-  it('builds a spec, creates the order, and surfaces the created order id as pending', async () => {
+  it('builds a spec for the watcher to submit', async () => {
     createBuyOrder.mockResolvedValue(CREATED_PENDING_ORDER);
 
     await getState().submitBuyOrder(SUBMIT_INPUT);
+
+    expect(createBuyOrder).not.toHaveBeenCalled();
+    expect(getState().status).toEqual({ step: 'submitting', spec: SPEC, submittedAt: expect.any(Number) });
+
+    await getState().resumePendingSubmission();
 
     expect(createBuyOrder).toHaveBeenCalledWith({ ...SPEC, cryptoAsset: CASH_BUY_DESTINATION_ASSET });
     expect(getState().status).toEqual({ step: 'polling', orderId: SPEC.id, order: null, submittedAt: expect.any(Number) });
@@ -150,6 +154,7 @@ describe('submitBuyOrder', () => {
     getOrder.mockResolvedValue(COMPLETED_ORDER);
 
     await getState().submitBuyOrder(SUBMIT_INPUT);
+    await getState().resumePendingSubmission();
 
     expect(phase()).toBe('pending');
     expect(addPendingTransaction).not.toHaveBeenCalled();
@@ -161,65 +166,80 @@ describe('submitBuyOrder', () => {
     expect(phase()).toBe('success');
   });
 
-  it('surfaces a GENERIC error when order creation throws', async () => {
-    createBuyOrder.mockRejectedValue(new Error('network down'));
+  it('surfaces a GENERIC error when the backend definitively rejects order creation', async () => {
+    createBuyOrder.mockRejectedValue(fetchError(422));
 
     await getState().submitBuyOrder(SUBMIT_INPUT);
+    await getState().resumePendingSubmission();
 
     expect(logger.error).toHaveBeenCalled();
-    expect(getState().status).toEqual({ step: 'error', errorCode: 'GENERIC', order: null, spec: SPEC });
+    expect(getState().status).toEqual({ step: 'error', errorCode: 'GENERIC', order: null });
     expect(phase()).toBe('error');
   });
 
-  // An ambiguous failure (transport error, 5xx) leaves it unknown whether the order was created, so
-  // a retry with the same inputs must replay the same id — the backend then returns the existing
-  // order instead of creating a second one.
-  it('replays the same order id when retrying after an ambiguous failure', async () => {
+  it('replays the same order id when resuming after an ambiguous failure', async () => {
     createBuyOrder.mockRejectedValueOnce(new Error('network down')).mockResolvedValueOnce(CREATED_PENDING_ORDER);
 
     await getState().submitBuyOrder(SUBMIT_INPUT);
-    await getState().submitBuyOrder(SUBMIT_INPUT);
+    await expect(getState().resumePendingSubmission()).rejects.toThrow('network down');
+
+    expect(getOrder).not.toHaveBeenCalled();
+    expect(createBuyOrder).toHaveBeenCalledTimes(1);
+    expect(getState().status).toEqual({ step: 'submitting', spec: SPEC, submittedAt: expect.any(Number) });
+
+    await getState().resumePendingSubmission();
 
     expect(createBuyOrder).toHaveBeenCalledTimes(2);
     expect(createBuyOrder.mock.calls[1][0].id).toBe(SPEC.id);
     expect(getState().status).toEqual({ step: 'polling', orderId: SPEC.id, order: null, submittedAt: expect.any(Number) });
   });
 
+  it('keeps the submission pending when a resumed replay also fails ambiguously', async () => {
+    createBuyOrder.mockRejectedValue(new Error('network down'));
+
+    await getState().submitBuyOrder(SUBMIT_INPUT);
+    await expect(getState().resumePendingSubmission()).rejects.toThrow('network down');
+    await expect(cashBuyOrderActions.resumePendingSubmission()).rejects.toThrow('network down');
+
+    expect(createBuyOrder).toHaveBeenCalledTimes(2);
+    expect(getState().status).toEqual({ step: 'submitting', spec: SPEC, submittedAt: expect.any(Number) });
+    expect(track).not.toHaveBeenCalledWith(analytics.event.cashBuyOrderFailed, expect.anything());
+    expect(phase()).toBe('pending');
+  });
+
   it('generates a fresh order id when retrying after a definitive backend rejection', async () => {
     createBuyOrder.mockRejectedValueOnce(fetchError(422)).mockResolvedValueOnce({ ...CREATED_PENDING_ORDER, id: 'order-2' });
 
     await getState().submitBuyOrder(SUBMIT_INPUT);
-    expect(getState().status).toEqual({ step: 'error', errorCode: 'GENERIC', order: null, spec: undefined });
+    await getState().resumePendingSubmission();
+    expect(getState().status).toEqual({ step: 'error', errorCode: 'GENERIC', order: null });
 
     await getState().submitBuyOrder(SUBMIT_INPUT);
+    await getState().resumePendingSubmission();
     expect(createBuyOrder.mock.calls[1][0].id).toBe('order-2');
-  });
-
-  it('generates a fresh order id when the retried inputs differ from the retained spec', async () => {
-    createBuyOrder.mockRejectedValueOnce(new Error('network down')).mockResolvedValueOnce({ ...CREATED_PENDING_ORDER, id: 'order-2' });
-
-    await getState().submitBuyOrder(SUBMIT_INPUT);
-    await getState().submitBuyOrder({ ...SUBMIT_INPUT, depositAmount: '100' });
-
-    expect(createBuyOrder.mock.calls[1][0]).toMatchObject({ id: 'order-2', depositAmount: '100' });
   });
 
   // A 404 is the only handle the ramp surface gives on "the wallet you named is not linked", so it
   // is the one failure that invalidates the cache. Every other failure leaves it alone.
-  const cacheOutcomes: { label: string; failure: unknown; cleared: boolean }[] = [
-    { label: 'a 404', failure: fetchError(404), cleared: true },
-    { label: 'a 500', failure: fetchError(500), cleared: false },
-    { label: 'a transport error with no response', failure: new Error('network down'), cleared: false },
+  const cacheOutcomes: { label: string; failure: unknown; cleared: boolean; expectedPhase: 'error' | 'pending' }[] = [
+    { label: 'a 404', failure: fetchError(404), cleared: true, expectedPhase: 'error' },
+    { label: 'a 408', failure: fetchError(408), cleared: false, expectedPhase: 'pending' },
+    { label: 'a 429', failure: fetchError(429), cleared: false, expectedPhase: 'pending' },
+    { label: 'a 500', failure: fetchError(500), cleared: false, expectedPhase: 'pending' },
+    { label: 'a transport error with no response', failure: new Error('network down'), cleared: false, expectedPhase: 'pending' },
   ];
 
-  it.each(cacheOutcomes)('$label leaves the linked-wallet cache cleared=$cleared', async ({ failure, cleared }) => {
+  it.each(cacheOutcomes)('$label leaves the linked-wallet cache cleared=$cleared', async ({ failure, cleared, expectedPhase }) => {
     useCashWalletStore.setState({ linkedWallets: [LINKED_WALLET] });
     createBuyOrder.mockRejectedValue(failure);
 
     await getState().submitBuyOrder(SUBMIT_INPUT);
+    await getState()
+      .resumePendingSubmission()
+      .catch(() => undefined);
 
     expect(useCashWalletStore.getState().linkedWallets).toEqual(cleared ? [] : [LINKED_WALLET]);
-    expect(phase()).toBe('error');
+    expect(phase()).toBe(expectedPhase);
   });
 
   it('keeps the linked-wallet cache when the order is created', async () => {
@@ -227,6 +247,7 @@ describe('submitBuyOrder', () => {
     createBuyOrder.mockResolvedValue(CREATED_PENDING_ORDER);
 
     await getState().submitBuyOrder(SUBMIT_INPUT);
+    await getState().resumePendingSubmission();
 
     expect(useCashWalletStore.getState().linkedWallets).toEqual([LINKED_WALLET]);
   });
@@ -239,7 +260,8 @@ describe('submitBuyOrder', () => {
       })
     );
 
-    const inFlight = getState().submitBuyOrder(SUBMIT_INPUT); // sets 'submitting' → pending, then awaits createBuyOrder
+    await getState().submitBuyOrder(SUBMIT_INPUT);
+    const inFlight = getState().resumePendingSubmission();
     await getState().submitBuyOrder(SUBMIT_INPUT); // guard sees 'pending' and returns immediately
 
     expect(createBuyOrder).toHaveBeenCalledTimes(1);
@@ -419,58 +441,82 @@ describe('resumePendingSubmission', () => {
     expect(phase()).toBe('pending');
   });
 
+  it('returns to idle when the passkey prompt is cancelled', async () => {
+    store.setState({ status: { step: 'submitting', spec: SPEC, submittedAt: SUBMITTED_AT } });
+    createBuyOrder.mockRejectedValue(new Error('UserCancelled'));
+
+    await getState().resumePendingSubmission();
+
+    expect(logger.error).not.toHaveBeenCalled();
+    expect(track).not.toHaveBeenCalledWith(analytics.event.cashBuyOrderFailed, expect.anything());
+    expect(getState().status).toEqual({ step: 'idle' });
+  });
+
   it('is a no-op when there is no pending spec', async () => {
     await getState().resumePendingSubmission(); // idle from beforeEach
     expect(createBuyOrder).not.toHaveBeenCalled();
   });
 });
 
-// A dismiss/reopen replays the persisted spec while the original POST may still be in flight, so
-// two requests for the same order id can settle in either order. The first result wins; the
-// straggler must not clobber it.
-describe('concurrent submissions of the same spec', () => {
-  it('drops a late failure once a replay has already reached polling', async () => {
-    let rejectOriginal: (error: Error) => void = () => undefined;
-    createBuyOrder
-      .mockReturnValueOnce(
-        new Promise((_resolve, reject) => {
-          rejectOriginal = reject;
-        })
-      )
-      .mockResolvedValueOnce(CREATED_PENDING_ORDER);
+describe('an in-flight submission', () => {
+  it('drops a result that lands after the submission was reset', async () => {
+    let resolveCreate: (created: CreatedBuyOrder) => void = () => undefined;
+    createBuyOrder.mockReturnValueOnce(
+      new Promise<CreatedBuyOrder>(resolve => {
+        resolveCreate = resolve;
+      })
+    );
 
-    const original = getState().submitBuyOrder(SUBMIT_INPUT); // hangs in flight
-    await getState().resumePendingSubmission(); // reopen replays the same spec and resolves first
+    await getState().submitBuyOrder(SUBMIT_INPUT);
+    const inFlight = getState().resumePendingSubmission();
+    getState().reset();
+    resolveCreate(CREATED_PENDING_ORDER);
+    await inFlight;
 
-    expect(getState().status).toEqual({ step: 'polling', orderId: SPEC.id, order: null, submittedAt: expect.any(Number) });
-
-    rejectOriginal(new Error('timeout'));
-    await original;
-
-    expect(getState().status).toEqual({ step: 'polling', orderId: SPEC.id, order: null, submittedAt: expect.any(Number) });
-    expect(phase()).toBe('pending');
+    expect(getState().status).toEqual({ step: 'idle' });
   });
 
-  it('drops a late success once polling has already advanced past submission', async () => {
-    let resolveOriginal: (created: CreatedBuyOrder) => void = () => undefined;
+  it('drops a late success after a concurrent resume has advanced to polling', async () => {
+    let resolveFirstCreate: (created: CreatedBuyOrder) => void = () => undefined;
     createBuyOrder
       .mockReturnValueOnce(
         new Promise<CreatedBuyOrder>(resolve => {
-          resolveOriginal = resolve;
+          resolveFirstCreate = resolve;
         })
       )
       .mockResolvedValueOnce(CREATED_PENDING_ORDER);
+    store.setState({ status: { step: 'submitting', spec: SPEC, submittedAt: SUBMITTED_AT } });
 
-    const original = getState().submitBuyOrder(SUBMIT_INPUT);
+    const firstResume = getState().resumePendingSubmission();
     await getState().resumePendingSubmission();
     getOrder.mockResolvedValue(PENDING_ORDER);
     await getState().syncActiveOrder();
 
-    resolveOriginal(CREATED_PENDING_ORDER);
-    await original;
+    resolveFirstCreate(CREATED_PENDING_ORDER);
+    await firstResume;
 
-    // The late success must not rewind `order` to null.
-    expect(getState().status).toEqual({ step: 'polling', orderId: SPEC.id, order: PENDING_ORDER, submittedAt: expect.any(Number) });
+    expect(getState().status).toEqual({ step: 'polling', orderId: SPEC.id, order: PENDING_ORDER, submittedAt: SUBMITTED_AT });
+  });
+
+  it('drops a late failure after a concurrent resume has advanced to polling', async () => {
+    let rejectFirstCreate: (error: RainbowFetchError) => void = () => undefined;
+    createBuyOrder
+      .mockReturnValueOnce(
+        new Promise<CreatedBuyOrder>((_resolve, reject) => {
+          rejectFirstCreate = reject;
+        })
+      )
+      .mockResolvedValueOnce(CREATED_PENDING_ORDER);
+    store.setState({ status: { step: 'submitting', spec: SPEC, submittedAt: SUBMITTED_AT } });
+
+    const firstResume = getState().resumePendingSubmission();
+    await getState().resumePendingSubmission();
+
+    rejectFirstCreate(fetchError(422));
+    await firstResume;
+
+    expect(getState().status).toEqual({ step: 'polling', orderId: SPEC.id, order: null, submittedAt: SUBMITTED_AT });
+    expect(track).not.toHaveBeenCalledWith(analytics.event.cashBuyOrderFailed, expect.anything());
   });
 });
 

--- a/src/features/cash/stores/cashBuyOrderStore.ts
+++ b/src/features/cash/stores/cashBuyOrderStore.ts
@@ -8,6 +8,7 @@ import { logger, RainbowError } from '@/logger';
 import { pendingTransactionsActions } from '@/state/pendingTransactions';
 
 import { CASH_BUY_DESTINATION_ASSET } from '../constants';
+import { isPasskeyCancellation } from '../services/cashPasskeyService';
 import {
   createBuyOrder,
   getOrder,
@@ -47,12 +48,6 @@ export type CashBuyStatus =
       step: 'error';
       errorCode: CashBuyErrorCode;
       order: Extract<BuyOrder, { status: OrderStatus.Failed }> | null;
-      /**
-       * Retained when the submit failed ambiguously (the order may still exist under this id), so a
-       * retry with the same inputs replays the same id instead of risking a second order. Absent when
-       * the backend definitively rejected the create or the order itself reached a terminal failure.
-       */
-      spec?: BuyOrderSpec;
     };
 
 type CashBuyOrderState = {
@@ -113,29 +108,40 @@ export const useCashBuyOrderStore = createBaseStore<CashBuyOrderState>(
       }
     }
 
-    // The same spec can be in flight more than once (a reopen replays it while the original POST
-    // still runs), so a result only lands while the store is still submitting that spec — whichever
-    // settles first wins, the straggler is dropped.
+    // A result only lands while the store is still submitting that spec — if the submission is reset
+    // mid-flight, a chain that settles afterward must not resurrect it.
     function isCurrentSubmission(spec: BuyOrderSpec): boolean {
       const current = get().status;
       return current.step === 'submitting' && current.spec.id === spec.id;
     }
 
-    async function submitBuyOrderSpec({ spec, submittedAt }: { spec: BuyOrderSpec; submittedAt: number }): Promise<void> {
+    function failSubmission(orderId: string): void {
+      analytics.track(analytics.event.cashBuyOrderFailed, { orderId, failureReason: null, errorCode: 'GENERIC' });
+      set({ status: { step: 'error', errorCode: 'GENERIC', order: null } });
+    }
+
+    async function submitBuyOrderSpec(spec: BuyOrderSpec, submittedAt: number): Promise<void> {
       try {
         const created = await createBuyOrder({ ...spec, cryptoAsset: CASH_BUY_DESTINATION_ASSET });
         if (!isCurrentSubmission(spec)) return;
         set({ status: { step: 'polling', orderId: created.id, order: null, submittedAt } });
       } catch (error) {
         if (!isCurrentSubmission(spec)) return;
+        if (isPasskeyCancellation(error)) {
+          set({ status: { step: 'idle' } });
+          return;
+        }
         logger.error(new RainbowError('[cashBuyOrderStore] createBuyOrder failed', error));
-        analytics.track(analytics.event.cashBuyOrderFailed, { orderId: spec.id, failureReason: null, errorCode: 'GENERIC' });
-        set({ status: { step: 'error', errorCode: 'GENERIC', order: null, spec: isDefinitiveRejection(error) ? undefined : spec } });
         // A 404 says the backend did not recognise something this order named, and the linked wallet
         // is the part of that we cache — persisted, so a stale entry would fail every retry. Dropping
         // it costs the next attempt one GET and lets that attempt gate on the truth; absence only
         // ever means "ask the server".
         if (isNotFoundError(error)) useCashWalletStore.getState().clear();
+        if (isDefinitiveRejection(error)) {
+          failSubmission(spec.id);
+          return;
+        }
+        throw error;
       }
     }
 
@@ -148,22 +154,12 @@ export const useCashBuyOrderStore = createBaseStore<CashBuyOrderState>(
 
         analytics.track(analytics.event.cashBuyOrderSubmitted, { amount: toAnalyticsAmount(depositAmount) });
 
-        // decides whether the new submission should reuse the order id
-        // from a previous failed attempt with not definitive rejection
-        const retained =
-          status.step === 'error' &&
-          status.spec?.cardId === cardId &&
-          status.spec.depositAmount === depositAmount &&
-          status.spec.walletAddress === walletAddress
-            ? status.spec
-            : null;
         const submitting = {
           step: 'submitting',
-          spec: retained ?? { cardId, depositAmount, walletAddress, id: uuidv4() },
+          spec: { cardId, depositAmount, walletAddress, id: uuidv4() },
           submittedAt: Date.now(),
         } as const;
         set({ status: submitting });
-        await submitBuyOrderSpec(submitting);
       },
 
       syncActiveOrder: async abortController => {
@@ -198,7 +194,7 @@ export const useCashBuyOrderStore = createBaseStore<CashBuyOrderState>(
 
       resumePendingSubmission: async () => {
         const { status } = get();
-        if (status.step === 'submitting') await submitBuyOrderSpec(status);
+        if (status.step === 'submitting') await submitBuyOrderSpec(status.spec, status.submittedAt);
       },
 
       reset: () => set({ status: { step: 'idle' } }),


### PR DESCRIPTION
Fixed: APP-4030

## Why?

An order-creation timeout, transport failure, or 5xx does not tell us whether the backend accepted the deposit. Treating that unknown outcome as a failure lets the next attempt use a new order ID, potentially creating a second order after the original charge succeeded.

The submission intent also needs to survive sheet dismissal and app restart. Without durable recovery, the app can lose the only ID that safely identifies the charge in progress.

408 and 429 responses were also treated as definitive refusals even though the write outcome can remain unknown. The same classification affects card removal recovery.

Finally, an accidental backdrop tap could dismiss Add Cash during submission or Add Wallet during signing, abandoning the active flow.

## Approach

Persist the client-generated order ID and complete submission intent before sending the request. A single watcher owns order submission: it posts immediately and, after an ambiguous failure, retries the same ID and payload with backoff. Once a POST succeeds, the app switches to normal order polling. Definitive backend refusals still fail immediately, while passkey cancellation returns to idle without reporting a deposit failure.

Recovered submissions resume with the same ID after dismissal or restart. The retry path replays the POST directly rather than probing with a GET because the POST is the idempotent convergence operation.

Disable backdrop-tap dismissal while a deposit or wallet signature is in progress. The handle, drag gesture, and back action remain available.
