### PR TITLE
fix(CASH): Allow to go to OTP screen again, while resend is blocked

### DIFF
--- a/src/features/cash/screens/cash-deposit-setup/setupAction.test.ts
+++ b/src/features/cash/screens/cash-deposit-setup/setupAction.test.ts
@@ -1,0 +1,56 @@
+import { createBaseStore } from '@storesjs/stores';
+
+import Routes from '@/navigation/routesNames';
+
+import { useCashSetupSessionStore } from '../../stores/cashSetupSessionStore';
+import { CashDepositSetupNavigation } from './cashDepositSetupNavigator';
+import { createSetupActionStore } from './setupAction';
+import { completeSetupStep } from './setupNavigation';
+import { useSubmitPhoneFlowStore } from './steps/useSubmitPhoneFlow';
+
+jest.mock('./setupNavigation', () => ({
+  completeSetupStep: jest.fn(),
+  goBackInSetup: jest.fn(),
+}));
+
+jest.mock('../../stores/cardLinkFlowStore', () => ({
+  useCardLinkFlowStore: {},
+}));
+
+jest.mock('./steps/useAddPasskeyFlow', () => ({
+  useAddPasskeyFlowStore: {},
+}));
+
+jest.mock('./steps/useSubmitKycFlow', () => ({
+  useSubmitKycFlowStore: {},
+}));
+
+const DIGITS = '4155550100';
+const mockCompleteSetupStep = completeSetupStep as jest.Mock;
+
+const useActionStore = createSetupActionStore(
+  jest.fn() as never,
+  createBaseStore(() => ({ isReady: false }))
+);
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  CashDepositSetupNavigation.resetNavigationState();
+  useCashSetupSessionStore.getState().reset();
+  useSubmitPhoneFlowStore.setState({ state: 'entry', digits: DIGITS });
+  mockCompleteSetupStep.mockImplementation(() => CashDepositSetupNavigation.navigate(Routes.CASH_SETUP_CONFIRM_PHONE));
+});
+
+it('advances only once when a pending-code re-entry is submitted twice', async () => {
+  useCashSetupSessionStore.getState().setPhoneSubmitted({
+    challenge: { kind: 'signup', userId: 'user-1' },
+    phoneNationalNumber: DIGITS,
+    resendAfter: 1_750_000_030_000,
+  });
+  const { onPress } = useActionStore.getState();
+
+  await Promise.all([onPress(), onPress()]);
+
+  expect(mockCompleteSetupStep).toHaveBeenCalledTimes(1);
+  expect(CashDepositSetupNavigation.getActiveRoute()).toBe(Routes.CASH_SETUP_CONFIRM_PHONE);
+});

--- a/src/features/cash/screens/cash-deposit-setup/setupAction.ts
+++ b/src/features/cash/screens/cash-deposit-setup/setupAction.ts
@@ -10,7 +10,7 @@ import { CardBrand } from '../../services/rampClient';
 import { useCardLinkFlowStore } from '../../stores/cardLinkFlowStore';
 import { useCashSetupSessionStore } from '../../stores/cashSetupSessionStore';
 import { NATIONAL_NUMBER_LENGTH } from '../../utils/phoneNumber';
-import { useCashDepositSetupNavigationStore } from './cashDepositSetupNavigator';
+import { CashDepositSetupNavigation, useCashDepositSetupNavigationStore } from './cashDepositSetupNavigator';
 import { completeSetupStep, goBackInSetup } from './setupNavigation';
 import { isSetupEditDetour } from './steps';
 import { useAddPasskeyFlowStore } from './steps/useAddPasskeyFlow';
@@ -26,7 +26,10 @@ type SetupAction = {
 };
 
 async function submitPhone(): Promise<void> {
-  if (await useSubmitPhoneFlowStore.getState().submit()) completeSetupStep();
+  if (!CashDepositSetupNavigation.isRouteActive(Routes.CASH_SETUP_PHONE)) return;
+  if ((await useSubmitPhoneFlowStore.getState().submit()) && CashDepositSetupNavigation.isRouteActive(Routes.CASH_SETUP_PHONE)) {
+    completeSetupStep();
+  }
 }
 
 export async function submitPhoneCode(): Promise<void> {

--- a/src/features/cash/screens/cash-deposit-setup/steps/useSubmitPhoneFlow.test.ts
+++ b/src/features/cash/screens/cash-deposit-setup/steps/useSubmitPhoneFlow.test.ts
@@ -176,6 +176,41 @@ describe('useSubmitPhoneFlowStore.submit', () => {
     expect(flow().digits).toBe('415');
   });
 
+  it('advances without re-sending when a code is already out for the same number', async () => {
+    flow().setDigits(DIGITS);
+    await flow().submit();
+    const pending = session();
+    useVerifyPhoneFlowStore.setState({ state: 'error' });
+    jest.clearAllMocks();
+
+    await expect(flow().submit()).resolves.toBe(true);
+
+    expect(mockCreateUserWithPhone).not.toHaveBeenCalled();
+    expect(mockStartSignupResume).not.toHaveBeenCalled();
+    expect(session()).toBe(pending);
+    expect(track).not.toHaveBeenCalled();
+    expect(useVerifyPhoneFlowStore.getState().state).toBe('entry');
+  });
+
+  it('sends a new code when the number is edited after a submit', async () => {
+    const OTHER_DIGITS = '4155550199';
+    flow().setDigits(DIGITS);
+    await flow().submit();
+    jest.clearAllMocks();
+    mockCreateUserWithPhone.mockResolvedValue({ ...RESPONSE, userId: 'user-2' });
+
+    flow().setDigits(OTHER_DIGITS);
+    await expect(flow().submit()).resolves.toBe(true);
+
+    expect(mockCreateUserWithPhone).toHaveBeenCalledWith({ nationalNumber: OTHER_DIGITS });
+    expect(session()).toEqual({
+      status: 'phoneSubmitted',
+      challenge: { kind: 'signup', userId: 'user-2' },
+      phoneNationalNumber: OTHER_DIGITS,
+      resendAfter: RESPONSE.resendAfter,
+    });
+  });
+
   it('ignores an incomplete number', async () => {
     flow().setDigits('415555010');
 

--- a/src/features/cash/screens/cash-deposit-setup/steps/useSubmitPhoneFlow.ts
+++ b/src/features/cash/screens/cash-deposit-setup/steps/useSubmitPhoneFlow.ts
@@ -43,6 +43,14 @@ export const useSubmitPhoneFlowStore = createBaseStore<SubmitPhoneFlowStore>((se
     const { digits, state } = get();
     if (digits.length !== NATIONAL_NUMBER_LENGTH || state === 'submitting') return false;
 
+    // A code is already out for this number, so advance to let the user enter it.
+    // Re-submitting would send a second one, which the resend cooldown forbids.
+    const { session } = useCashSetupSessionStore.getState();
+    if (session.status === 'phoneSubmitted' && session.phoneNationalNumber === digits) {
+      useVerifyPhoneFlowStore.getState().reset();
+      return true;
+    }
+
     clearPhoneAlreadyRegistered();
     set({ state: 'submitting' });
     try {


### PR DESCRIPTION
Fixed: APP-4003

## Description

Backing out of the code screen and pressing Next again re-submitted the phone number, which sent a second SMS while the first one's resend cooldown was still running. The user ends up holding two codes where only the newest works, and that send bypasses the cooldown rather than being refused by it — in the very same second, the Resend button is correctly told "too soon".

While a code is already pending for the number on screen, Next now advances to the code screen instead of submitting, so the user just enters the code they already have. Editing the number submits as before, and Resend is untouched and still gated by the cooldown.

The ticket originally asked for a countdown and a disabled button here instead. That would hold the user on the phone screen for 30s with a perfectly good code already in their inbox; ticket updated with the reasoning.

## Testing

1. Add Cash → enter a phone number → Next → wait for the SMS.
2. Back out to the phone screen, then press Next again with the same number: should go straight to the code screen, with no second SMS and no error.
3. Enter the code from step 1 — it should verify.
4. Repeat, but edit the number before pressing Next: should send a code to the new number.
