### PR TITLE
fix(sentry): stop reporting handled NFT image failures as issues

### DIFF
--- a/src/components/unique-token/UniqueTokenImage.tsx
+++ b/src/components/unique-token/UniqueTokenImage.tsx
@@ -6,7 +6,6 @@ import { BlurView } from 'react-native-blur-view';
 import { Text, useColorMode } from '@/design-system';
 import { opacity } from '@/framework/ui/utils/opacity';
 import useHiddenTokens from '@/hooks/useHiddenTokens';
-import { logger } from '@/logger';
 import { type Colors } from '@/styles';
 import isLowerCaseMatch from '@/utils/isLowerCaseMatch';
 
@@ -83,13 +82,7 @@ export const UniqueTokenImage = React.memo(function UniqueTokenImage({
   const [errorLoadingImage, setErrorLoadingImage] = useState(false);
 
   const onLoad = useCallback(() => setIsLoading(false), [setIsLoading]);
-  const onError = useCallback(
-    (...args: unknown[]) => {
-      logger.warn(`[UniqueTokenImage] Error loading image: ${args} for ${uniqueId}`);
-      setErrorLoadingImage(true);
-    },
-    [setErrorLoadingImage, uniqueId]
-  );
+  const onError = useCallback(() => setErrorLoadingImage(true), [setErrorLoadingImage]);
 
   const isHiddenToken = useMemo(() => {
     return hiddenTokens.find(token => isLowerCaseMatch(token, uniqueId));


### PR DESCRIPTION
`UniqueTokenImage` currently reports every handled remote image load failure as a warning-level Sentry issue. These events combine expected missing NFT media with other unrelated failures, producing a noisy catch-all that cannot reliably attribute a network breadcrumb to a specific image request.

This change stops reporting these handled failures to Sentry while preserving the existing text fallback behavior. Adding actionable error logging is another task we can take on later if we want.

Ref [RAINBOW-WALLET-3XB5](https://rainbow-me.sentry.io/issues/7315289162/).