### PR TITLE
fix(dapps): fetch dapps sentry noise

### DIFF
--- a/src/features/dapp/stores/dappsStore.ts
+++ b/src/features/dapp/stores/dappsStore.ts
@@ -3,7 +3,6 @@ import { createQueryStore } from '@storesjs/stores';
 import { formatUrl } from '@/features/dapp-browser/utils/browserUtils';
 import { time } from '@/framework/core/utils/time';
 import { metadataClient } from '@/graphql';
-import { logger, RainbowError } from '@/logger';
 
 export type Dapp = {
   colors: {
@@ -50,39 +49,30 @@ export const useDappsStore = createQueryStore<Dapp[], never, DappsState>(
 );
 
 async function fetchDapps(): Promise<Dapp[]> {
-  try {
-    const response = await metadataClient.getdApps();
+  const response = await metadataClient.getdApps();
 
-    if (!response || !response.dApps) return [];
+  if (!response || !response.dApps) return [];
 
-    return response.dApps
-      .filter(dapp => dapp && dapp.status !== 'SCAM')
-      .map(dapp =>
-        dapp
-          ? {
-              colors: { primary: dapp.colors.primary, fallback: dapp.colors.fallback, shadow: dapp.colors.shadow },
-              iconUrl: dapp.iconURL,
-              name: dapp.name,
-              report: { url: dapp.report.url },
-              search: {
-                normalizedName: dapp.name.toLowerCase().split(' ').filter(Boolean).join(' '),
-                normalizedNameTokens: dapp.name.toLowerCase().split(' ').filter(Boolean),
-                normalizedUrlTokens: dapp.url
-                  .toLowerCase()
-                  .replace(/(^\w+:|^)\/\//, '') // Remove protocol from URL
-                  .split(/\/|\?|&|=|\./) // Split the URL into tokens
-                  .filter(Boolean),
-              },
-              shortName: dapp.shortName,
-              status: dapp.status,
-              trending: dapp.trending || false,
-              url: dapp.url,
-              urlDisplay: formatUrl(dapp.url),
-            }
-          : ({} as Dapp)
-      );
-  } catch (e: unknown) {
-    logger.error(new RainbowError('[dapps]: Failed to fetch dApps'), { message: e instanceof Error ? e.message : 'Unknown error' });
-    return [];
-  }
+  return response.dApps
+    .filter((dapp): dapp is NonNullable<typeof dapp> => !!dapp && dapp.status !== 'SCAM')
+    .map(dapp => ({
+      colors: { primary: dapp.colors.primary, fallback: dapp.colors.fallback, shadow: dapp.colors.shadow },
+      iconUrl: dapp.iconURL,
+      name: dapp.name,
+      report: { url: dapp.report.url },
+      search: {
+        normalizedName: dapp.name.toLowerCase().split(' ').filter(Boolean).join(' '),
+        normalizedNameTokens: dapp.name.toLowerCase().split(' ').filter(Boolean),
+        normalizedUrlTokens: dapp.url
+          .toLowerCase()
+          .replace(/(^\w+:|^)\/\//, '') // Remove protocol from URL
+          .split(/\/|\?|&|=|\./) // Split the URL into tokens
+          .filter(Boolean),
+      },
+      shortName: dapp.shortName,
+      status: dapp.status,
+      trending: dapp.trending || false,
+      url: dapp.url,
+      urlDisplay: formatUrl(dapp.url),
+    }));
 }


### PR DESCRIPTION
Fixed: APP-4050

## Description

Fetching the dApps list wrapped every failure into a new error and reported it to Sentry. Most of these failures are request timeouts and offline drops — frequently fired while the app is backgrounded — which we already intentionally filter out of Sentry reporting; the wrapping bypassed that filter, producing ~96k noise events from 10k+ users ([RAINBOW-WALLET-3XCF](https://rainbow-me.sentry.io/issues/7315311934/)) with no actionable signal.

The catch also swallowed the error and returned an empty list, which the store treated as a successful fresh fetch — a single failed request wiped the persisted dApps cache and left browser search/trending empty for the 30-minute stale window.

Letting the error propagate fixes both: the store keeps previously cached dApps and retries with exponential backoff, and expected network failures are no longer reported.
