### PR TITLE
fix(logger): original error lost when logger.error gets a non-RainbowError

### DIFF
--- a/src/logger/index.ts
+++ b/src/logger/index.ts
@@ -235,7 +235,7 @@ export class Logger {
     if (error instanceof RainbowError) {
       this.transport(LogLevel.Error, error, metadata);
     } else {
-      this.transport(LogLevel.Error, new RainbowError(`logger.error was not provided a RainbowError`), metadata);
+      this.transport(LogLevel.Error, new RainbowError(`logger.error was not provided a RainbowError`, ensureError(error)), metadata);
     }
   }
 

--- a/src/logger/logger.test.ts
+++ b/src/logger/logger.test.ts
@@ -84,16 +84,18 @@ describe('general functionality', () => {
     logger.warn('message', null);
   });
 
-  test('logger.error expects a RainbowError', () => {
+  test('logger.error keeps a non-RainbowError as the cause', () => {
     const logger = new Logger();
-
     const mockTransport = jest.fn();
-
     logger.addTransport(mockTransport);
 
-    logger.error(new Error());
+    const original = new Error('boom');
+    logger.error(original as unknown as RainbowError);
 
-    expect(mockTransport).toHaveBeenCalledWith(LogLevel.Error, new RainbowError(`logger.error was not provided a RainbowError`), {});
+    const [, reported] = mockTransport.mock.calls[0] as [LogLevel, RainbowError, unknown];
+    expect(reported).toBeInstanceOf(RainbowError);
+    expect(reported.message).toBe('logger.error was not provided a RainbowError');
+    expect(reported.cause).toBe(original);
   });
 
   test('createServiceLogger debug honors context filtering and prefixes messages', () => {


### PR DESCRIPTION
When a caller hands `logger.error` a plain `Error` instead of a `RainbowError`, the logger swaps it for a complaint about the caller and drops the original entirely: no message, no stack, no cause. In Sentry every such call site collapses into one issue that says the caller got the type wrong and nothing about what actually failed.

This change keeps the original as the `cause` of the complaint, so both reach Sentry.

Closes APP-4052.