### PR TITLE
fix(logger): a throwing transport silences the transports after it

### DIFF
--- a/src/logger/index.ts
+++ b/src/logger/index.ts
@@ -283,8 +283,13 @@ export class Logger {
 
     const resolvedMetadata = metadata || EMPTY_METADATA;
     for (const transport of this.transports) {
-      // metadata fallback accounts for JS usage
-      transport(level, message, resolvedMetadata);
+      try {
+        // metadata fallback accounts for JS usage
+        transport(level, message, resolvedMetadata);
+      } catch (e) {
+        // A transport that throws must not take the remaining transports or the caller down with it.
+        console.error('[logger]: transport threw', e);
+      }
     }
   }
 }

--- a/src/logger/logger.test.ts
+++ b/src/logger/logger.test.ts
@@ -60,7 +60,7 @@ describe('general functionality', () => {
 
     const mockTransport = jest.fn();
 
-    const remove = logger.addTransport(mockTransport);
+    logger.addTransport(mockTransport);
 
     // @ts-expect-error testing the JS case
     logger.warn('a', null);
@@ -73,15 +73,6 @@ describe('general functionality', () => {
     // @ts-expect-error testing the JS case
     logger.warn('c', 0);
     expect(mockTransport).toHaveBeenCalledWith(LogLevel.Warn, 'c', {});
-
-    remove();
-
-    logger.addTransport((level, message, metadata) => {
-      expect(typeof metadata).toEqual('object');
-    });
-
-    // @ts-expect-error testing the JS case
-    logger.warn('message', null);
   });
 
   test('logger.error expects a RainbowError', () => {

--- a/src/logger/logger.test.ts
+++ b/src/logger/logger.test.ts
@@ -96,6 +96,19 @@ describe('general functionality', () => {
     expect(mockTransport).toHaveBeenCalledWith(LogLevel.Error, new RainbowError(`logger.error was not provided a RainbowError`), {});
   });
 
+  test('a throwing transport does not stop the others or escape to the caller', () => {
+    const logger = new Logger();
+    const throwing = jest.fn(() => {
+      throw new Error('transport exploded');
+    });
+    const next = jest.fn();
+    logger.addTransport(throwing);
+    logger.addTransport(next);
+
+    expect(() => logger.error(new RainbowError('x'))).not.toThrow();
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
   test('createServiceLogger debug honors context filtering and prefixes messages', () => {
     const logger = new Logger({
       debug: 'delegation',


### PR DESCRIPTION
Log transports run in sequence with nothing between them. If one throws, the transports after it never run, so the console line for that log is lost, and the exception escapes into the caller that was only trying to log. A failed report thus becomes a crash at an unrelated site.

This change contains each transport call such that a throwing transport is reported to the console and the remaining transports still run. Logging can no longer fail the code that called it.

Closes APP-4053.