### PR TITLE
feat(CASH_BALANCE): add feature flag gating Cash Balance wallet display

### DIFF
--- a/src/features/cash-balance/hooks/useIsCashBalanceEnabled.ts
+++ b/src/features/cash-balance/hooks/useIsCashBalanceEnabled.ts
@@ -1,0 +1,17 @@
+import { CASH_BALANCE } from '@/features/config/constants/experimental';
+import { useExperimentalFlag } from '@/features/config/hooks/experimentalHooks';
+import { useRemoteConfig } from '@/features/config/stores/remoteConfig';
+
+/**
+ * Cash Balance wallet display is gated by the remote `cash_balance_enabled` flag in
+ * production. The `CASH_BALANCE` experimental flag is an in-app override so it can be
+ * toggled from Developer Settings.
+ *
+ * This is distinct from `useIsCashEnabled`, which gates the separate "Add Cash"
+ * onramp/KYC-buy feature in `@/features/cash`.
+ */
+export function useIsCashBalanceEnabled(): boolean {
+  const { cash_balance_enabled } = useRemoteConfig('cash_balance_enabled');
+  const cashBalanceExperimentalEnabled = useExperimentalFlag(CASH_BALANCE);
+  return cashBalanceExperimentalEnabled || cash_balance_enabled;
+}

--- a/src/features/config/constants/experimental.ts
+++ b/src/features/config/constants/experimental.ts
@@ -30,6 +30,7 @@ export const RAINBOW_TOASTS = 'Rainbow Toasts';
 export const PERPS = 'Perps';
 export const POLYMARKET = 'Polymarket';
 export const CASH = 'Cash';
+export const CASH_BALANCE = 'Cash Balance';
 export const DEFI_POSITIONS_THRESHOLD_FILTER = 'DeFi Minimum Value Filter';
 export const RNBW_REWARDS = 'RNBW Rewards';
 export const RNBW_MEMBERSHIP = 'RNBW Membership';
@@ -70,6 +71,7 @@ const config = {
   [DEFI_POSITIONS_THRESHOLD_FILTER]: { settings: true, value: true },
   [POLYMARKET]: { settings: true, value: false },
   [CASH]: { settings: true, value: false },
+  [CASH_BALANCE]: { settings: true, value: false },
   [RNBW_REWARDS]: { settings: true, value: false },
   [RNBW_MEMBERSHIP]: { settings: true, value: false },
   [DELEGATION]: { settings: true, value: false },

--- a/src/features/config/stores/remoteConfig.ts
+++ b/src/features/config/stores/remoteConfig.ts
@@ -93,6 +93,7 @@ export interface RainbowConfig extends Record<
   perps_enabled: boolean;
   polymarket_enabled: boolean;
   cash_enabled: boolean;
+  cash_balance_enabled: boolean;
   rnbw_rewards_enabled: boolean;
   rnbw_membership_enabled: boolean;
   delegation_enabled: boolean;
@@ -229,6 +230,7 @@ export const DEFAULT_CONFIG = {
   perps_enabled: true,
   polymarket_enabled: true,
   cash_enabled: false,
+  cash_balance_enabled: false,
   dev_section_enabled: IS_DEV,
   rnbw_rewards_enabled: false,
   rnbw_membership_enabled: false,


### PR DESCRIPTION
Adds a cash_balance_enabled remote config flag plus a CASH_BALANCE experimental override. Currently unused flag, but will be used in following PRs. 

Fixes APP-4078