### PR TITLE
feat(CASH_BALANCE): add the Cash Balance half sheet

### DIFF
--- a/src/components/asset-list/RecyclerAssetList2/cash/CashBalanceHeader.tsx
+++ b/src/components/asset-list/RecyclerAssetList2/cash/CashBalanceHeader.tsx
@@ -1,4 +1,5 @@
-import React, { memo } from 'react';
+import React, { memo, useCallback } from 'react';
+import { type GestureResponderEvent } from 'react-native';
 
 import { LinearGradient } from 'expo-linear-gradient';
 
@@ -17,8 +18,21 @@ const ADD_BUTTON_HEIGHT = 36;
 
 export const CashBalanceHeader = memo(function CashBalanceHeader() {
   const { balanceDisplay } = useCashBalance();
-  const handleAddPress = useCashBalanceAddPress('cash balance widget');
+  const handleAddCashPress = useCashBalanceAddPress('cash balance widget');
   const handleRowPress = () => Navigation.handleAction(Routes.CASH_BALANCE_HALF_SHEET);
+
+  // The Add button sits inside the row's own ButtonPressAnimation, so its press must stop
+  // propagating or it also fires the row's onPress (see RnbwFeatureCard's DismissButton for the
+  // same nested-button hazard).
+  const handleAddPress = useCallback(
+    (e?: GestureResponderEvent) => {
+      if (e && 'stopPropagation' in e) {
+        e.stopPropagation();
+      }
+      handleAddCashPress();
+    },
+    [handleAddCashPress]
+  );
 
   return (
     <Box paddingHorizontal="12px" justifyContent="center" height={{ custom: CashBalanceHeaderHeight }}>

--- a/src/components/asset-list/RecyclerAssetList2/cash/CashBalanceHeader.tsx
+++ b/src/components/asset-list/RecyclerAssetList2/cash/CashBalanceHeader.tsx
@@ -1,13 +1,10 @@
-import React, { memo, useCallback } from 'react';
-import { type GestureResponderEvent } from 'react-native';
-
-import { LinearGradient } from 'expo-linear-gradient';
+import React, { memo } from 'react';
 
 import ButtonPressAnimation from '@/components/animations/ButtonPressAnimation';
 import { CashBalanceHeaderHeight } from '@/components/asset-list/RecyclerAssetList2/core/ViewDimensions';
 import { Box, Inline, Stack, Text } from '@/design-system';
+import { CashBalanceGradientButton } from '@/features/cash-balance/components/CashBalanceGradientButton';
 import { CashBalanceIcon } from '@/features/cash-balance/components/CashBalanceIcon';
-import { CASH_BALANCE_COLORS } from '@/features/cash-balance/constants';
 import { useCashBalance } from '@/features/cash-balance/hooks/useCashBalance';
 import { useCashBalanceAddPress } from '@/features/cash-balance/hooks/useCashBalanceAddPress';
 import * as i18n from '@/languages';
@@ -18,21 +15,8 @@ const ADD_BUTTON_HEIGHT = 36;
 
 export const CashBalanceHeader = memo(function CashBalanceHeader() {
   const { balanceDisplay } = useCashBalance();
-  const handleAddCashPress = useCashBalanceAddPress('cash balance widget');
+  const handleAddPress = useCashBalanceAddPress('cash balance widget');
   const handleRowPress = () => Navigation.handleAction(Routes.CASH_BALANCE_HALF_SHEET);
-
-  // The Add button sits inside the row's own ButtonPressAnimation, so its press must stop
-  // propagating or it also fires the row's onPress (see RnbwFeatureCard's DismissButton for the
-  // same nested-button hazard).
-  const handleAddPress = useCallback(
-    (e?: GestureResponderEvent) => {
-      if (e && 'stopPropagation' in e) {
-        e.stopPropagation();
-      }
-      handleAddCashPress();
-    },
-    [handleAddCashPress]
-  );
 
   return (
     <Box paddingHorizontal="12px" justifyContent="center" height={{ custom: CashBalanceHeaderHeight }}>
@@ -60,28 +44,27 @@ export const CashBalanceHeader = memo(function CashBalanceHeader() {
               </Text>
             </Stack>
           </Inline>
-
-          <ButtonPressAnimation onPress={handleAddPress} scaleTo={0.94} testID="cash-balance-header-add-button">
-            <Box
-              as={LinearGradient}
-              colors={CASH_BALANCE_COLORS.addButtonGradient}
-              start={{ x: 0, y: 0 }}
-              end={{ x: 0.75, y: 1 }}
-              alignItems="center"
-              justifyContent="center"
-              paddingHorizontal="12px"
-              height={{ custom: ADD_BUTTON_HEIGHT }}
-              borderRadius={ADD_BUTTON_HEIGHT / 2}
-              background="green"
-              shadow="12px green"
-            >
-              <Text color="white" size="17pt" weight="heavy">
-                {i18n.t(i18n.l.button.add)}
-              </Text>
-            </Box>
-          </ButtonPressAnimation>
         </Box>
       </ButtonPressAnimation>
+
+      {/* A true sibling of the row's ButtonPressAnimation, not a descendant — nesting one native
+          button inside another leaves the outer one owning all touches within its bounds on
+          Android, silently swallowing the inner button's presses (see RnbwFeatureCard's
+          DismissButton for the same fix: an absolutely-positioned sibling, not a nested button). */}
+      {/* right accounts for both this row's own 12px horizontal padding and the pill's 16px
+          paddingRight, since an absolutely positioned child ignores its parent's padding. */}
+      <Box position="absolute" right={{ custom: 12 + 16 }} top={{ custom: (CashBalanceHeaderHeight - ADD_BUTTON_HEIGHT) / 2 }}>
+        <CashBalanceGradientButton
+          height={ADD_BUTTON_HEIGHT}
+          onPress={handleAddPress}
+          paddingHorizontal="12px"
+          testID="cash-balance-header-add-button"
+        >
+          <Text color="white" size="17pt" weight="heavy">
+            {i18n.t(i18n.l.button.add)}
+          </Text>
+        </CashBalanceGradientButton>
+      </Box>
     </Box>
   );
 });

--- a/src/components/asset-list/RecyclerAssetList2/cash/CashBalanceHeader.tsx
+++ b/src/components/asset-list/RecyclerAssetList2/cash/CashBalanceHeader.tsx
@@ -1,82 +1,73 @@
-import React, { memo, useCallback } from 'react';
+import React, { memo } from 'react';
 
 import { LinearGradient } from 'expo-linear-gradient';
 
-import { analytics } from '@/analytics';
 import ButtonPressAnimation from '@/components/animations/ButtonPressAnimation';
 import { CashBalanceHeaderHeight } from '@/components/asset-list/RecyclerAssetList2/core/ViewDimensions';
 import { Box, Inline, Stack, Text } from '@/design-system';
 import { CashBalanceIcon } from '@/features/cash-balance/components/CashBalanceIcon';
 import { CASH_BALANCE_COLORS } from '@/features/cash-balance/constants';
 import { useCashBalance } from '@/features/cash-balance/hooks/useCashBalance';
-import { useAddCashRoute } from '@/features/cash/navigation/useAddCashRoute';
-import useNavigationForNonReadOnlyWallets from '@/hooks/useNavigationForNonReadOnlyWallets';
+import { useCashBalanceAddPress } from '@/features/cash-balance/hooks/useCashBalanceAddPress';
 import * as i18n from '@/languages';
+import Navigation from '@/navigation/Navigation';
 import Routes from '@/navigation/routesNames';
-import { getIsDamagedWallet } from '@/state/wallets/walletsStore';
 
 const ADD_BUTTON_HEIGHT = 36;
 
 export const CashBalanceHeader = memo(function CashBalanceHeader() {
-  const balanceDisplay = useCashBalance();
-  const navigate = useNavigationForNonReadOnlyWallets();
-  const { route: addCashRoute } = useAddCashRoute();
-
-  const handleAddPress = useCallback(() => {
-    if (getIsDamagedWallet()) {
-      navigate(Routes.WALLET_ERROR_SHEET);
-      return;
-    }
-    navigate(addCashRoute);
-    analytics.track(analytics.event.navigationAddCash, { category: 'cash balance widget' });
-  }, [addCashRoute, navigate]);
+  const { balanceDisplay } = useCashBalance();
+  const handleAddPress = useCashBalanceAddPress('cash balance widget');
+  const handleRowPress = () => Navigation.handleAction(Routes.CASH_BALANCE_HALF_SHEET);
 
   return (
     <Box paddingHorizontal="12px" justifyContent="center" height={{ custom: CashBalanceHeaderHeight }}>
-      <Box
-        background="surfaceSecondaryElevated"
-        borderRadius={32}
-        height={{ custom: CashBalanceHeaderHeight - 8 }}
-        paddingLeft="8px"
-        paddingRight="16px"
-        flexDirection="row"
-        alignItems="center"
-        justifyContent="space-between"
-        shadow="12px"
-        testID="cash-balance-header"
-      >
-        <Inline alignVertical="center" horizontalSpace="12px" wrap={false}>
-          <CashBalanceIcon />
-          <Stack space="12px">
-            <Text color="labelQuaternary" size="15pt" weight="semibold">
-              {i18n.t(i18n.l.account.tab_cash)}
-            </Text>
-            <Text color="label" size="17pt" weight="bold">
-              {balanceDisplay}
-            </Text>
-          </Stack>
-        </Inline>
+      <ButtonPressAnimation onPress={handleRowPress} scaleTo={0.98} testID="cash-balance-header-row-button">
+        <Box
+          background="surfaceSecondaryElevated"
+          borderRadius={32}
+          height={{ custom: CashBalanceHeaderHeight - 8 }}
+          paddingLeft="8px"
+          paddingRight="16px"
+          flexDirection="row"
+          alignItems="center"
+          justifyContent="space-between"
+          shadow="12px"
+          testID="cash-balance-header"
+        >
+          <Inline alignVertical="center" horizontalSpace="12px" wrap={false}>
+            <CashBalanceIcon />
+            <Stack space="12px">
+              <Text color="labelQuaternary" size="15pt" weight="semibold">
+                {i18n.t(i18n.l.account.tab_cash)}
+              </Text>
+              <Text color="label" size="17pt" weight="bold">
+                {balanceDisplay}
+              </Text>
+            </Stack>
+          </Inline>
 
-        <ButtonPressAnimation onPress={handleAddPress} scaleTo={0.94} testID="cash-balance-header-add-button">
-          <Box
-            as={LinearGradient}
-            colors={CASH_BALANCE_COLORS.addButtonGradient}
-            start={{ x: 0, y: 0 }}
-            end={{ x: 0.75, y: 1 }}
-            alignItems="center"
-            justifyContent="center"
-            paddingHorizontal="12px"
-            height={{ custom: ADD_BUTTON_HEIGHT }}
-            borderRadius={ADD_BUTTON_HEIGHT / 2}
-            background="green"
-            shadow="12px green"
-          >
-            <Text color="white" size="17pt" weight="heavy">
-              {i18n.t(i18n.l.button.add)}
-            </Text>
-          </Box>
-        </ButtonPressAnimation>
-      </Box>
+          <ButtonPressAnimation onPress={handleAddPress} scaleTo={0.94} testID="cash-balance-header-add-button">
+            <Box
+              as={LinearGradient}
+              colors={CASH_BALANCE_COLORS.addButtonGradient}
+              start={{ x: 0, y: 0 }}
+              end={{ x: 0.75, y: 1 }}
+              alignItems="center"
+              justifyContent="center"
+              paddingHorizontal="12px"
+              height={{ custom: ADD_BUTTON_HEIGHT }}
+              borderRadius={ADD_BUTTON_HEIGHT / 2}
+              background="green"
+              shadow="12px green"
+            >
+              <Text color="white" size="17pt" weight="heavy">
+                {i18n.t(i18n.l.button.add)}
+              </Text>
+            </Box>
+          </ButtonPressAnimation>
+        </Box>
+      </ButtonPressAnimation>
     </Box>
   );
 });

--- a/src/features/cash-balance/components/CashBalanceGradientButton.tsx
+++ b/src/features/cash-balance/components/CashBalanceGradientButton.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { type GestureResponderEvent } from 'react-native';
+
+import { LinearGradient } from 'expo-linear-gradient';
+
+import ButtonPressAnimation from '@/components/animations/ButtonPressAnimation';
+import { Box, type BoxProps } from '@/design-system';
+import { CASH_BALANCE_COLORS } from '@/features/cash-balance/constants';
+
+// The green gradient CTA shared by the wallet row's Add button and the half sheet's Add/Withdraw/Send buttons.
+export function CashBalanceGradientButton({
+  children,
+  height,
+  onPress,
+  paddingHorizontal,
+  scaleTo = 0.94,
+  testID,
+  width,
+}: {
+  children: React.ReactNode;
+  height: number;
+  onPress: (event?: GestureResponderEvent) => void;
+  paddingHorizontal?: BoxProps['paddingHorizontal'];
+  scaleTo?: number;
+  testID: string;
+  width?: BoxProps['width'];
+}) {
+  return (
+    <ButtonPressAnimation onPress={onPress} scaleTo={scaleTo} testID={testID}>
+      <Box
+        as={LinearGradient}
+        alignItems="center"
+        background="green"
+        borderRadius={height / 2}
+        colors={CASH_BALANCE_COLORS.addButtonGradient}
+        end={{ x: 0.75, y: 1 }}
+        height={{ custom: height }}
+        justifyContent="center"
+        paddingHorizontal={paddingHorizontal}
+        shadow="12px green"
+        start={{ x: 0, y: 0 }}
+        width={width}
+      >
+        {children}
+      </Box>
+    </ButtonPressAnimation>
+  );
+}

--- a/src/features/cash-balance/hooks/useCashBalance.ts
+++ b/src/features/cash-balance/hooks/useCashBalance.ts
@@ -1,8 +1,10 @@
+import { type ParsedSearchAsset } from '@/__swaps__/types/assets';
 import { CASH_BALANCE_USDC_BY_CHAIN_ID } from '@/features/cash-balance/constants';
 import { convertAmountAndPriceToNativeDisplay, convertAmountToNativeDisplay } from '@/features/currency/utils/nativeDisplay';
 import { ChainId } from '@/features/network/types/backendNetworks';
 import { useUserAssetsStore } from '@/state/assets/userAssets';
 import { userAssetsStoreManager } from '@/state/assets/userAssetsStoreManager';
+import { shallowEqual } from '@/worklets/comparisons';
 
 const CASH_BALANCE_ASSET = CASH_BALANCE_USDC_BY_CHAIN_ID[ChainId.base];
 // Lowercased once here since nothing guarantees userAssetsStore's own keys are lowercased —
@@ -10,7 +12,7 @@ const CASH_BALANCE_ASSET = CASH_BALANCE_USDC_BY_CHAIN_ID[ChainId.base];
 // its map keys, so an exact-casing key lookup could silently miss a checksummed match.
 const CASH_BALANCE_ADDRESS = CASH_BALANCE_ASSET?.address.toLowerCase();
 
-export function useCashBalance(): string {
+export function useCashBalance(): { asset: ParsedSearchAsset | undefined; balanceDisplay: string; hasBalance: boolean } {
   const nativeCurrency = userAssetsStoreManager(state => state.currency);
   return useUserAssetsStore(state => {
     const asset = CASH_BALANCE_ADDRESS
@@ -21,8 +23,9 @@ export function useCashBalance(): string {
     // Recomputed from amount + price rather than reading asset.native.balance.display, which is
     // cached from the last fetch and can still reflect the previous nativeCurrency while a
     // currency-change refetch is in flight (userAssetsStore uses keepPreviousData).
-    return asset
+    const balanceDisplay = asset
       ? convertAmountAndPriceToNativeDisplay(asset.balance.amount, asset.price?.value ?? 0, nativeCurrency).display
       : convertAmountToNativeDisplay(0, nativeCurrency);
-  });
+    return { asset, balanceDisplay, hasBalance: Number(asset?.balance.amount ?? 0) > 0 };
+  }, shallowEqual);
 }

--- a/src/features/cash-balance/hooks/useCashBalanceAddPress.ts
+++ b/src/features/cash-balance/hooks/useCashBalanceAddPress.ts
@@ -1,0 +1,25 @@
+import { useCallback } from 'react';
+
+import { analytics } from '@/analytics';
+import { useAddCashRoute } from '@/features/cash/navigation/useAddCashRoute';
+import useNavigationForNonReadOnlyWallets from '@/hooks/useNavigationForNonReadOnlyWallets';
+import Routes from '@/navigation/routesNames';
+import { getIsDamagedWallet } from '@/state/wallets/walletsStore';
+
+/**
+ * Shared Add Cash entry point for the wallet row and the half sheet, so both stay in sync on
+ * the damaged-wallet redirect and analytics category.
+ */
+export function useCashBalanceAddPress(category: string) {
+  const navigate = useNavigationForNonReadOnlyWallets();
+  const { route: addCashRoute } = useAddCashRoute();
+
+  return useCallback(() => {
+    if (getIsDamagedWallet()) {
+      navigate(Routes.WALLET_ERROR_SHEET);
+      return;
+    }
+    navigate(addCashRoute);
+    analytics.track(analytics.event.navigationAddCash, { category });
+  }, [addCashRoute, category, navigate]);
+}

--- a/src/features/cash-balance/screens/CashBalanceHalfSheet.tsx
+++ b/src/features/cash-balance/screens/CashBalanceHalfSheet.tsx
@@ -5,7 +5,6 @@ import { LinearGradient } from 'expo-linear-gradient';
 import Animated, { FadeIn, FadeOut, SlideInDown, SlideOutDown } from 'react-native-reanimated';
 
 import { type ParsedSearchAsset } from '@/__swaps__/types/assets';
-import { AbsolutePortal, AbsolutePortalRoot } from '@/components/AbsolutePortal';
 import ButtonPressAnimation from '@/components/animations/ButtonPressAnimation';
 import RainbowCoinIcon from '@/components/coin-icon/RainbowCoinIcon';
 import { PanelSheet } from '@/components/PanelSheet/PanelSheet';
@@ -127,34 +126,32 @@ function CashBalanceActionButton({
 }
 
 // Popped up over the half sheet when Withdraw is pressed, matching the Figma mini sheet — no
-// action button, dismissed by tapping anywhere on it.
+// action button, dismissed by tapping anywhere on it. Rendered as a sibling of the half sheet's
+// own PanelSheet (not a child of it) so it isn't clipped by that panel's rounded bounds; a shared
+// AbsolutePortal would also work but double-renders here since this screen is its own modal layer
+// and the app-level AbsolutePortalRoot underneath it stays mounted too.
 const WITHDRAW_SHEET_ENTERING_ANIMATION = SlideInDown.springify().damping(70).mass(0.8).stiffness(500);
 const WITHDRAW_SHEET_EXITING_ANIMATION = SlideOutDown.springify().damping(70).mass(0.8).stiffness(500);
 
-// Memoized so the live-ticking balance re-rendering CashBalanceHalfSheet doesn't recreate this
-// element on every tick — AbsolutePortal re-adds its children whenever that reference changes,
-// which otherwise thrashes the portaled node before it ever gets a chance to paint.
 const CashBalanceWithdrawComingSoonSheet = memo(function CashBalanceWithdrawComingSoonSheet({ onDismiss }: { onDismiss: () => void }) {
   return (
-    <AbsolutePortal>
-      <TouchableWithoutFeedback onPress={onDismiss}>
-        <View accessibilityViewIsModal style={styles.overlay} testID="cash-balance-withdraw-coming-soon-overlay">
-          <Animated.View entering={FadeIn.duration(200)} exiting={FadeOut.duration(200)} style={styles.backdrop} />
-          <Animated.View entering={WITHDRAW_SHEET_ENTERING_ANIMATION} exiting={WITHDRAW_SHEET_EXITING_ANIMATION} style={styles.panelHost}>
-            <PanelSheet showTapToDismiss={false}>
-              <Box paddingBottom="32px" paddingHorizontal="32px" paddingTop="52px">
-                <CashBalanceIcon size={52} />
-                <Box paddingTop="16px">
-                  <Text color="label" size="26pt" weight="heavy">
-                    {i18n.t(i18n.l.cash_balance.half_sheet.withdraw_coming_soon)}
-                  </Text>
-                </Box>
+    <TouchableWithoutFeedback onPress={onDismiss}>
+      <View accessibilityViewIsModal style={styles.overlay} testID="cash-balance-withdraw-coming-soon-overlay">
+        <Animated.View entering={FadeIn.duration(200)} exiting={FadeOut.duration(200)} style={styles.backdrop} />
+        <Animated.View entering={WITHDRAW_SHEET_ENTERING_ANIMATION} exiting={WITHDRAW_SHEET_EXITING_ANIMATION} style={styles.panelHost}>
+          <PanelSheet showTapToDismiss={false}>
+            <Box paddingBottom="32px" paddingHorizontal="32px" paddingTop="52px">
+              <CashBalanceIcon size={52} />
+              <Box paddingTop="16px">
+                <Text color="label" size="26pt" weight="heavy">
+                  {i18n.t(i18n.l.cash_balance.half_sheet.withdraw_coming_soon)}
+                </Text>
               </Box>
-            </PanelSheet>
-          </Animated.View>
-        </View>
-      </TouchableWithoutFeedback>
-    </AbsolutePortal>
+            </Box>
+          </PanelSheet>
+        </Animated.View>
+      </View>
+    </TouchableWithoutFeedback>
   );
 });
 
@@ -183,54 +180,51 @@ export const CashBalanceHalfSheet = memo(function CashBalanceHalfSheet() {
   }, [asset, navigate]);
 
   return (
-    <PanelSheet>
-      <Box paddingBottom="20px" paddingHorizontal="20px" paddingTop="20px">
-        <CashBalanceHalfSheetHeader />
+    <>
+      <PanelSheet>
+        <Box paddingBottom="20px" paddingHorizontal="20px" paddingTop="20px">
+          <CashBalanceHalfSheetHeader />
 
-        <Box paddingTop={{ custom: 64 }}>
-          <Text align="center" color="label" size="44pt" weight="heavy">
-            {balanceDisplay}
-          </Text>
-        </Box>
+          <Box paddingTop={{ custom: 64 }}>
+            <Text align="center" color="label" size="44pt" weight="heavy">
+              {balanceDisplay}
+            </Text>
+          </Box>
 
-        <Box alignItems={hasBalance ? 'center' : undefined} paddingTop={{ custom: hasBalance ? 52 : 64 }}>
-          {hasBalance ? <CashBalanceBadge asset={asset} /> : <CashBalanceSubLabel asset={asset} />}
-        </Box>
+          <Box alignItems={hasBalance ? 'center' : undefined} paddingTop={{ custom: hasBalance ? 52 : 64 }}>
+            {hasBalance ? <CashBalanceBadge asset={asset} /> : <CashBalanceSubLabel asset={asset} />}
+          </Box>
 
-        <Box paddingTop={{ custom: hasBalance ? 20 : 16 }}>
-          <Columns space="8px">
-            <CashBalanceActionButton onPress={handleAddPress} testID="cash-balance-half-sheet-add-button">
-              <Text color="white" size="20pt" weight="heavy">
-                {i18n.t(i18n.l.button.add)}
-              </Text>
-            </CashBalanceActionButton>
-            {hasBalance && (
-              <CashBalanceActionButton onPress={handleWithdrawPress} testID="cash-balance-half-sheet-withdraw-button">
+          <Box paddingTop={{ custom: hasBalance ? 20 : 16 }}>
+            <Columns space="8px">
+              <CashBalanceActionButton onPress={handleAddPress} testID="cash-balance-half-sheet-add-button">
                 <Text color="white" size="20pt" weight="heavy">
-                  {i18n.t(i18n.l.button.withdraw)}
+                  {i18n.t(i18n.l.button.add)}
                 </Text>
               </CashBalanceActionButton>
-            )}
-            {hasBalance && asset && (
-              <Column width="content">
-                <CashBalanceActionButton circular onPress={handleSendPress} testID="cash-balance-half-sheet-send-button">
-                  <Text color="white" size="icon 20px" weight="heavy">
-                    {SEND_ICON}
+              {hasBalance && (
+                <CashBalanceActionButton onPress={handleWithdrawPress} testID="cash-balance-half-sheet-withdraw-button">
+                  <Text color="white" size="20pt" weight="heavy">
+                    {i18n.t(i18n.l.button.withdraw)}
                   </Text>
                 </CashBalanceActionButton>
-              </Column>
-            )}
-          </Columns>
+              )}
+              {hasBalance && asset && (
+                <Column width="content">
+                  <CashBalanceActionButton circular onPress={handleSendPress} testID="cash-balance-half-sheet-send-button">
+                    <Text color="white" size="icon 20px" weight="heavy">
+                      {SEND_ICON}
+                    </Text>
+                  </CashBalanceActionButton>
+                </Column>
+              )}
+            </Columns>
+          </Box>
         </Box>
-      </Box>
+      </PanelSheet>
 
       {showWithdrawComingSoon && <CashBalanceWithdrawComingSoonSheet onDismiss={handleDismissWithdrawComingSoon} />}
-
-      {/* This screen is presented as its own native modal layer, so the app-level
-          AbsolutePortalRoot (rendered underneath it) can't paint the sheet above — mount a
-          scoped one here too, matching PaymentMethodsSheet/CashDepositSetupScreen/Swap. */}
-      <AbsolutePortalRoot style={styles.portal} />
-    </PanelSheet>
+    </>
   );
 });
 
@@ -241,11 +235,10 @@ const styles = StyleSheet.create({
   },
   overlay: {
     ...StyleSheet.absoluteFillObject,
+    // Above the half sheet's own PanelSheet (zIndex 30000).
+    zIndex: 30001,
   },
   panelHost: {
     ...StyleSheet.absoluteFillObject,
-  },
-  portal: {
-    zIndex: 30001,
   },
 });

--- a/src/features/cash-balance/screens/CashBalanceHalfSheet.tsx
+++ b/src/features/cash-balance/screens/CashBalanceHalfSheet.tsx
@@ -1,14 +1,11 @@
 import React, { memo, useCallback, useMemo } from 'react';
 
-import { LinearGradient } from 'expo-linear-gradient';
-
 import { type ParsedSearchAsset } from '@/__swaps__/types/assets';
-import ButtonPressAnimation from '@/components/animations/ButtonPressAnimation';
 import RainbowCoinIcon from '@/components/coin-icon/RainbowCoinIcon';
 import { PanelSheet } from '@/components/PanelSheet/PanelSheet';
 import { Box, Column, Columns, Inline, Stack, Text, useForegroundColor } from '@/design-system';
+import { CashBalanceGradientButton } from '@/features/cash-balance/components/CashBalanceGradientButton';
 import { CashBalanceIcon } from '@/features/cash-balance/components/CashBalanceIcon';
-import { CASH_BALANCE_COLORS } from '@/features/cash-balance/constants';
 import { useCashBalance } from '@/features/cash-balance/hooks/useCashBalance';
 import { useCashBalanceAddPress } from '@/features/cash-balance/hooks/useCashBalanceAddPress';
 import { ChainId } from '@/features/network/types/backendNetworks';
@@ -92,38 +89,6 @@ function CashBalanceSubLabel({ asset }: { asset: ParsedSearchAsset | undefined }
   );
 }
 
-function CashBalanceActionButton({
-  children,
-  circular,
-  onPress,
-  testID,
-}: {
-  children: React.ReactNode;
-  circular?: boolean;
-  onPress: () => void;
-  testID: string;
-}) {
-  return (
-    <ButtonPressAnimation onPress={onPress} scaleTo={0.94} testID={testID}>
-      <Box
-        as={LinearGradient}
-        alignItems="center"
-        background="green"
-        borderRadius={BUTTON_HEIGHT / 2}
-        colors={CASH_BALANCE_COLORS.addButtonGradient}
-        end={{ x: 0.75, y: 1 }}
-        height={{ custom: BUTTON_HEIGHT }}
-        justifyContent="center"
-        shadow="12px green"
-        start={{ x: 0, y: 0 }}
-        width={circular ? { custom: BUTTON_HEIGHT } : 'full'}
-      >
-        {children}
-      </Box>
-    </ButtonPressAnimation>
-  );
-}
-
 export const CashBalanceHalfSheet = memo(function CashBalanceHalfSheet() {
   const { asset, balanceDisplay, hasBalance } = useCashBalance();
   const { navigate } = useNavigation();
@@ -155,25 +120,40 @@ export const CashBalanceHalfSheet = memo(function CashBalanceHalfSheet() {
 
         <Box paddingTop={{ custom: hasBalance ? 20 : 16 }}>
           <Columns space="8px">
-            <CashBalanceActionButton onPress={handleAddPress} testID="cash-balance-half-sheet-add-button">
+            <CashBalanceGradientButton
+              height={BUTTON_HEIGHT}
+              onPress={handleAddPress}
+              testID="cash-balance-half-sheet-add-button"
+              width="full"
+            >
               <Text color="white" size="20pt" weight="heavy">
                 {i18n.t(i18n.l.button.add)}
               </Text>
-            </CashBalanceActionButton>
+            </CashBalanceGradientButton>
             {hasBalance && (
-              <CashBalanceActionButton onPress={handleWithdrawPress} testID="cash-balance-half-sheet-withdraw-button">
+              <CashBalanceGradientButton
+                height={BUTTON_HEIGHT}
+                onPress={handleWithdrawPress}
+                testID="cash-balance-half-sheet-withdraw-button"
+                width="full"
+              >
                 <Text color="white" size="20pt" weight="heavy">
                   {i18n.t(i18n.l.button.withdraw)}
                 </Text>
-              </CashBalanceActionButton>
+              </CashBalanceGradientButton>
             )}
             {hasBalance && asset && (
               <Column width="content">
-                <CashBalanceActionButton circular onPress={handleSendPress} testID="cash-balance-half-sheet-send-button">
+                <CashBalanceGradientButton
+                  height={BUTTON_HEIGHT}
+                  onPress={handleSendPress}
+                  testID="cash-balance-half-sheet-send-button"
+                  width={{ custom: BUTTON_HEIGHT }}
+                >
                   <Text color="white" size="icon 20px" weight="heavy">
                     {SEND_ICON}
                   </Text>
-                </CashBalanceActionButton>
+                </CashBalanceGradientButton>
               </Column>
             )}
           </Columns>

--- a/src/features/cash-balance/screens/CashBalanceHalfSheet.tsx
+++ b/src/features/cash-balance/screens/CashBalanceHalfSheet.tsx
@@ -1,9 +1,11 @@
-import React, { memo, useCallback } from 'react';
-import { Platform } from 'react-native';
+import React, { memo, useCallback, useState } from 'react';
+import { Platform, StyleSheet, TouchableWithoutFeedback, View } from 'react-native';
 
 import { LinearGradient } from 'expo-linear-gradient';
+import Animated, { FadeIn, FadeOut, SlideInDown, SlideOutDown } from 'react-native-reanimated';
 
 import { type ParsedSearchAsset } from '@/__swaps__/types/assets';
+import { AbsolutePortal, AbsolutePortalRoot } from '@/components/AbsolutePortal';
 import ButtonPressAnimation from '@/components/animations/ButtonPressAnimation';
 import RainbowCoinIcon from '@/components/coin-icon/RainbowCoinIcon';
 import { PanelSheet } from '@/components/PanelSheet/PanelSheet';
@@ -14,7 +16,6 @@ import { CASH_BALANCE_COLORS } from '@/features/cash-balance/constants';
 import { useCashBalance } from '@/features/cash-balance/hooks/useCashBalance';
 import { useCashBalanceAddPress } from '@/features/cash-balance/hooks/useCashBalanceAddPress';
 import { ChainId } from '@/features/network/types/backendNetworks';
-import { WrappedAlert as Alert } from '@/helpers/alert';
 import useNavigationForNonReadOnlyWallets from '@/hooks/useNavigationForNonReadOnlyWallets';
 import * as i18n from '@/languages';
 import Routes from '@/navigation/routesNames';
@@ -125,13 +126,50 @@ function CashBalanceActionButton({
   );
 }
 
+// Popped up over the half sheet when Withdraw is pressed, matching the Figma mini sheet — no
+// action button, dismissed by tapping anywhere on it.
+const WITHDRAW_SHEET_ENTERING_ANIMATION = SlideInDown.springify().damping(70).mass(0.8).stiffness(500);
+const WITHDRAW_SHEET_EXITING_ANIMATION = SlideOutDown.springify().damping(70).mass(0.8).stiffness(500);
+
+// Memoized so the live-ticking balance re-rendering CashBalanceHalfSheet doesn't recreate this
+// element on every tick — AbsolutePortal re-adds its children whenever that reference changes,
+// which otherwise thrashes the portaled node before it ever gets a chance to paint.
+const CashBalanceWithdrawComingSoonSheet = memo(function CashBalanceWithdrawComingSoonSheet({ onDismiss }: { onDismiss: () => void }) {
+  return (
+    <AbsolutePortal>
+      <TouchableWithoutFeedback onPress={onDismiss}>
+        <View accessibilityViewIsModal style={styles.overlay} testID="cash-balance-withdraw-coming-soon-overlay">
+          <Animated.View entering={FadeIn.duration(200)} exiting={FadeOut.duration(200)} style={styles.backdrop} />
+          <Animated.View entering={WITHDRAW_SHEET_ENTERING_ANIMATION} exiting={WITHDRAW_SHEET_EXITING_ANIMATION} style={styles.panelHost}>
+            <PanelSheet showTapToDismiss={false}>
+              <Box paddingBottom="32px" paddingHorizontal="32px" paddingTop="52px">
+                <CashBalanceIcon size={52} />
+                <Box paddingTop="16px">
+                  <Text color="label" size="26pt" weight="heavy">
+                    {i18n.t(i18n.l.cash_balance.half_sheet.withdraw_coming_soon)}
+                  </Text>
+                </Box>
+              </Box>
+            </PanelSheet>
+          </Animated.View>
+        </View>
+      </TouchableWithoutFeedback>
+    </AbsolutePortal>
+  );
+});
+
 export const CashBalanceHalfSheet = memo(function CashBalanceHalfSheet() {
   const { asset, balanceDisplay, hasBalance } = useCashBalance();
   const navigate = useNavigationForNonReadOnlyWallets();
   const handleAddPress = useCashBalanceAddPress('cash balance half sheet');
+  const [showWithdrawComingSoon, setShowWithdrawComingSoon] = useState(false);
 
   const handleWithdrawPress = useCallback(() => {
-    Alert.alert(i18n.t(i18n.l.cash_balance.half_sheet.withdraw_coming_soon));
+    setShowWithdrawComingSoon(true);
+  }, []);
+
+  const handleDismissWithdrawComingSoon = useCallback(() => {
+    setShowWithdrawComingSoon(false);
   }, []);
 
   const handleSendPress = useCallback(() => {
@@ -185,6 +223,29 @@ export const CashBalanceHalfSheet = memo(function CashBalanceHalfSheet() {
           </Columns>
         </Box>
       </Box>
+
+      {showWithdrawComingSoon && <CashBalanceWithdrawComingSoonSheet onDismiss={handleDismissWithdrawComingSoon} />}
+
+      {/* This screen is presented as its own native modal layer, so the app-level
+          AbsolutePortalRoot (rendered underneath it) can't paint the sheet above — mount a
+          scoped one here too, matching PaymentMethodsSheet/CashDepositSetupScreen/Swap. */}
+      <AbsolutePortalRoot style={styles.portal} />
     </PanelSheet>
   );
+});
+
+const styles = StyleSheet.create({
+  backdrop: {
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: 'rgba(0, 0, 0, 0.44)',
+  },
+  overlay: {
+    ...StyleSheet.absoluteFillObject,
+  },
+  panelHost: {
+    ...StyleSheet.absoluteFillObject,
+  },
+  portal: {
+    zIndex: 30001,
+  },
 });

--- a/src/features/cash-balance/screens/CashBalanceHalfSheet.tsx
+++ b/src/features/cash-balance/screens/CashBalanceHalfSheet.tsx
@@ -18,10 +18,15 @@ import { WrappedAlert as Alert } from '@/helpers/alert';
 import useNavigationForNonReadOnlyWallets from '@/hooks/useNavigationForNonReadOnlyWallets';
 import * as i18n from '@/languages';
 import Routes from '@/navigation/routesNames';
+import { USDC_ADDRESS } from '@/references/constants';
+import getUrlForTrustIconFallback from '@/utils/getUrlForTrustIconFallback';
 
 // Matches the arrow used by the send button elsewhere (wallet screen / expanded asset sheet)
 const SEND_ICON = '􀈟';
 const BUTTON_HEIGHT = 48;
+// Shown when there's no held Base USDC asset to source an icon from — same fallback pattern
+// used by the perps and Add Cash USDC icons.
+const USDC_ICON_URL = getUrlForTrustIconFallback(USDC_ADDRESS, ChainId.mainnet) ?? undefined;
 
 function CashBalanceHalfSheetHeader() {
   return (
@@ -39,7 +44,7 @@ function CashBalanceSubLabelIcon({ asset, size }: { asset: ParsedSearchAsset | u
     <RainbowCoinIcon
       chainId={ChainId.base}
       color={asset?.colors?.primary}
-      icon={asset?.icon_url}
+      icon={asset?.icon_url ?? USDC_ICON_URL}
       showBadge={false}
       size={size}
       symbol={asset?.symbol ?? 'USDC'}

--- a/src/features/cash-balance/screens/CashBalanceHalfSheet.tsx
+++ b/src/features/cash-balance/screens/CashBalanceHalfSheet.tsx
@@ -1,0 +1,185 @@
+import React, { memo, useCallback } from 'react';
+import { Platform } from 'react-native';
+
+import { LinearGradient } from 'expo-linear-gradient';
+
+import { type ParsedSearchAsset } from '@/__swaps__/types/assets';
+import ButtonPressAnimation from '@/components/animations/ButtonPressAnimation';
+import RainbowCoinIcon from '@/components/coin-icon/RainbowCoinIcon';
+import { PanelSheet } from '@/components/PanelSheet/PanelSheet';
+import { Box, Column, Columns, Inline, Stack, Text, useForegroundColor } from '@/design-system';
+import type { ParsedAddressAsset } from '@/entities/tokens';
+import { CashBalanceIcon } from '@/features/cash-balance/components/CashBalanceIcon';
+import { CASH_BALANCE_COLORS } from '@/features/cash-balance/constants';
+import { useCashBalance } from '@/features/cash-balance/hooks/useCashBalance';
+import { useCashBalanceAddPress } from '@/features/cash-balance/hooks/useCashBalanceAddPress';
+import { ChainId } from '@/features/network/types/backendNetworks';
+import { WrappedAlert as Alert } from '@/helpers/alert';
+import useNavigationForNonReadOnlyWallets from '@/hooks/useNavigationForNonReadOnlyWallets';
+import * as i18n from '@/languages';
+import Routes from '@/navigation/routesNames';
+
+// Matches the arrow used by the send button elsewhere (wallet screen / expanded asset sheet)
+const SEND_ICON = '􀈟';
+const BUTTON_HEIGHT = 48;
+
+function CashBalanceHalfSheetHeader() {
+  return (
+    <Inline alignVertical="center" horizontalSpace="12px" wrap={false}>
+      <CashBalanceIcon />
+      <Text color="label" size="22pt" weight="heavy">
+        {i18n.t(i18n.l.cash_balance.half_sheet.title)}
+      </Text>
+    </Inline>
+  );
+}
+
+function CashBalanceSubLabelIcon({ asset, size }: { asset: ParsedSearchAsset | undefined; size: number }) {
+  return (
+    <RainbowCoinIcon
+      chainId={ChainId.base}
+      color={asset?.colors?.primary}
+      icon={asset?.icon_url}
+      showBadge={false}
+      size={size}
+      symbol={asset?.symbol ?? 'USDC'}
+    />
+  );
+}
+
+// Shown once there's a Base USDC balance to describe: a floating pill, matching the Figma
+// "has balance" half sheet.
+function CashBalanceBadge({ asset }: { asset: ParsedSearchAsset | undefined }) {
+  return (
+    <Box
+      alignItems="center"
+      background="surfaceSecondaryElevated"
+      borderRadius={20}
+      flexDirection="row"
+      gap={6}
+      height={{ custom: 40 }}
+      paddingLeft="10px"
+      paddingRight="12px"
+      shadow="12px"
+    >
+      <CashBalanceSubLabelIcon asset={asset} size={20} />
+      <Text color="labelTertiary" size="15pt" weight="bold">
+        {i18n.t(i18n.l.cash_balance.half_sheet.subtitle)}
+      </Text>
+    </Box>
+  );
+}
+
+// Shown before there's any Base USDC balance, matching the Figma "Add only" half sheet: a plain
+// caption under a hairline divider instead of the floating pill.
+function CashBalanceSubLabel({ asset }: { asset: ParsedSearchAsset | undefined }) {
+  const separatorColor = useForegroundColor('separatorSecondary');
+
+  return (
+    <Stack alignHorizontal="center" space="16px">
+      <Box backgroundColor={separatorColor} height={{ custom: 1 }} width="full" />
+      <Inline alignVertical="center" horizontalSpace="6px" wrap={false}>
+        <CashBalanceSubLabelIcon asset={asset} size={16} />
+        <Text color="labelQuaternary" size="15pt" weight="semibold">
+          {i18n.t(i18n.l.cash_balance.half_sheet.subtitle)}
+        </Text>
+      </Inline>
+    </Stack>
+  );
+}
+
+function CashBalanceActionButton({
+  children,
+  circular,
+  onPress,
+  testID,
+}: {
+  children: React.ReactNode;
+  circular?: boolean;
+  onPress: () => void;
+  testID: string;
+}) {
+  return (
+    <ButtonPressAnimation onPress={onPress} scaleTo={0.94} testID={testID}>
+      <Box
+        as={LinearGradient}
+        alignItems="center"
+        background="green"
+        borderRadius={BUTTON_HEIGHT / 2}
+        colors={CASH_BALANCE_COLORS.addButtonGradient}
+        end={{ x: 0.75, y: 1 }}
+        height={{ custom: BUTTON_HEIGHT }}
+        justifyContent="center"
+        shadow="12px green"
+        start={{ x: 0, y: 0 }}
+        width={circular ? { custom: BUTTON_HEIGHT } : 'full'}
+      >
+        {children}
+      </Box>
+    </ButtonPressAnimation>
+  );
+}
+
+export const CashBalanceHalfSheet = memo(function CashBalanceHalfSheet() {
+  const { asset, balanceDisplay, hasBalance } = useCashBalance();
+  const navigate = useNavigationForNonReadOnlyWallets();
+  const handleAddPress = useCashBalanceAddPress('cash balance half sheet');
+
+  const handleWithdrawPress = useCallback(() => {
+    Alert.alert(i18n.t(i18n.l.cash_balance.half_sheet.withdraw_coming_soon));
+  }, []);
+
+  const handleSendPress = useCallback(() => {
+    if (!asset) return;
+    const sendAsset = asset as unknown as ParsedAddressAsset;
+    if (Platform.OS === 'ios') {
+      navigate(Routes.SEND_FLOW, { screen: Routes.SEND_SHEET, params: { asset: sendAsset } });
+    } else {
+      navigate(Routes.SEND_FLOW, { asset: sendAsset });
+    }
+  }, [asset, navigate]);
+
+  return (
+    <PanelSheet>
+      <Box paddingBottom="20px" paddingHorizontal="20px" paddingTop="20px">
+        <CashBalanceHalfSheetHeader />
+
+        <Box paddingTop={{ custom: 64 }}>
+          <Text align="center" color="label" size="44pt" weight="heavy">
+            {balanceDisplay}
+          </Text>
+        </Box>
+
+        <Box alignItems={hasBalance ? 'center' : undefined} paddingTop={{ custom: hasBalance ? 52 : 64 }}>
+          {hasBalance ? <CashBalanceBadge asset={asset} /> : <CashBalanceSubLabel asset={asset} />}
+        </Box>
+
+        <Box paddingTop={{ custom: hasBalance ? 20 : 16 }}>
+          <Columns space="8px">
+            <CashBalanceActionButton onPress={handleAddPress} testID="cash-balance-half-sheet-add-button">
+              <Text color="white" size="20pt" weight="heavy">
+                {i18n.t(i18n.l.button.add)}
+              </Text>
+            </CashBalanceActionButton>
+            {hasBalance && (
+              <CashBalanceActionButton onPress={handleWithdrawPress} testID="cash-balance-half-sheet-withdraw-button">
+                <Text color="white" size="20pt" weight="heavy">
+                  {i18n.t(i18n.l.button.withdraw)}
+                </Text>
+              </CashBalanceActionButton>
+            )}
+            {hasBalance && asset && (
+              <Column width="content">
+                <CashBalanceActionButton circular onPress={handleSendPress} testID="cash-balance-half-sheet-send-button">
+                  <Text color="white" size="icon 20px" weight="heavy">
+                    {SEND_ICON}
+                  </Text>
+                </CashBalanceActionButton>
+              </Column>
+            )}
+          </Columns>
+        </Box>
+      </Box>
+    </PanelSheet>
+  );
+});

--- a/src/features/cash-balance/screens/CashBalanceHalfSheet.tsx
+++ b/src/features/cash-balance/screens/CashBalanceHalfSheet.tsx
@@ -1,5 +1,4 @@
-import React, { memo, useCallback } from 'react';
-import { Platform } from 'react-native';
+import React, { memo, useCallback, useMemo } from 'react';
 
 import { LinearGradient } from 'expo-linear-gradient';
 
@@ -8,17 +7,17 @@ import ButtonPressAnimation from '@/components/animations/ButtonPressAnimation';
 import RainbowCoinIcon from '@/components/coin-icon/RainbowCoinIcon';
 import { PanelSheet } from '@/components/PanelSheet/PanelSheet';
 import { Box, Column, Columns, Inline, Stack, Text, useForegroundColor } from '@/design-system';
-import type { ParsedAddressAsset } from '@/entities/tokens';
 import { CashBalanceIcon } from '@/features/cash-balance/components/CashBalanceIcon';
 import { CASH_BALANCE_COLORS } from '@/features/cash-balance/constants';
 import { useCashBalance } from '@/features/cash-balance/hooks/useCashBalance';
 import { useCashBalanceAddPress } from '@/features/cash-balance/hooks/useCashBalanceAddPress';
 import { ChainId } from '@/features/network/types/backendNetworks';
-import useNavigationForNonReadOnlyWallets from '@/hooks/useNavigationForNonReadOnlyWallets';
+import { useNavigateToSend } from '@/features/transfer/hooks/useNavigateToSend';
 import * as i18n from '@/languages';
 import { useNavigation } from '@/navigation/Navigation';
 import Routes from '@/navigation/routesNames';
 import { USDC_ADDRESS } from '@/references/constants';
+import { parsedSearchAssetToParsedAddressAsset } from '@/state/assets/utils';
 import getUrlForTrustIconFallback from '@/utils/getUrlForTrustIconFallback';
 
 // Matches the arrow used by the send button elsewhere (wallet screen / expanded asset sheet)
@@ -128,7 +127,6 @@ function CashBalanceActionButton({
 export const CashBalanceHalfSheet = memo(function CashBalanceHalfSheet() {
   const { asset, balanceDisplay, hasBalance } = useCashBalance();
   const { navigate } = useNavigation();
-  const navigateForNonReadOnlyWallet = useNavigationForNonReadOnlyWallets();
   const handleAddPress = useCashBalanceAddPress('cash balance half sheet');
 
   // A real route stacked on top, not an inline overlay, so it gets its own independent native
@@ -137,15 +135,8 @@ export const CashBalanceHalfSheet = memo(function CashBalanceHalfSheet() {
     navigate(Routes.CASH_BALANCE_WITHDRAW_COMING_SOON_SHEET);
   }, [navigate]);
 
-  const handleSendPress = useCallback(() => {
-    if (!asset) return;
-    const sendAsset = asset as unknown as ParsedAddressAsset;
-    if (Platform.OS === 'ios') {
-      navigateForNonReadOnlyWallet(Routes.SEND_FLOW, { screen: Routes.SEND_SHEET, params: { asset: sendAsset } });
-    } else {
-      navigateForNonReadOnlyWallet(Routes.SEND_FLOW, { asset: sendAsset });
-    }
-  }, [asset, navigateForNonReadOnlyWallet]);
+  const sendAsset = useMemo(() => (asset ? parsedSearchAssetToParsedAddressAsset(asset) : undefined), [asset]);
+  const handleSendPress = useNavigateToSend(sendAsset);
 
   return (
     <PanelSheet>

--- a/src/features/cash-balance/screens/CashBalanceHalfSheet.tsx
+++ b/src/features/cash-balance/screens/CashBalanceHalfSheet.tsx
@@ -1,8 +1,7 @@
-import React, { memo, useCallback, useState } from 'react';
-import { Platform, StyleSheet, TouchableWithoutFeedback, View } from 'react-native';
+import React, { memo, useCallback } from 'react';
+import { Platform } from 'react-native';
 
 import { LinearGradient } from 'expo-linear-gradient';
-import Animated, { FadeIn, FadeOut, SlideInDown, SlideOutDown } from 'react-native-reanimated';
 
 import { type ParsedSearchAsset } from '@/__swaps__/types/assets';
 import ButtonPressAnimation from '@/components/animations/ButtonPressAnimation';
@@ -17,6 +16,7 @@ import { useCashBalanceAddPress } from '@/features/cash-balance/hooks/useCashBal
 import { ChainId } from '@/features/network/types/backendNetworks';
 import useNavigationForNonReadOnlyWallets from '@/hooks/useNavigationForNonReadOnlyWallets';
 import * as i18n from '@/languages';
+import { useNavigation } from '@/navigation/Navigation';
 import Routes from '@/navigation/routesNames';
 import { USDC_ADDRESS } from '@/references/constants';
 import getUrlForTrustIconFallback from '@/utils/getUrlForTrustIconFallback';
@@ -125,120 +125,69 @@ function CashBalanceActionButton({
   );
 }
 
-// Popped up over the half sheet when Withdraw is pressed, matching the Figma mini sheet — no
-// action button, dismissed by tapping anywhere on it. Rendered as a sibling of the half sheet's
-// own PanelSheet (not a child of it) so it isn't clipped by that panel's rounded bounds; a shared
-// AbsolutePortal would also work but double-renders here since this screen is its own modal layer
-// and the app-level AbsolutePortalRoot underneath it stays mounted too.
-const WITHDRAW_SHEET_ENTERING_ANIMATION = SlideInDown.springify().damping(70).mass(0.8).stiffness(500);
-const WITHDRAW_SHEET_EXITING_ANIMATION = SlideOutDown.springify().damping(70).mass(0.8).stiffness(500);
-
-const CashBalanceWithdrawComingSoonSheet = memo(function CashBalanceWithdrawComingSoonSheet({ onDismiss }: { onDismiss: () => void }) {
-  return (
-    <TouchableWithoutFeedback onPress={onDismiss}>
-      <View accessibilityViewIsModal style={styles.overlay} testID="cash-balance-withdraw-coming-soon-overlay">
-        <Animated.View entering={FadeIn.duration(200)} exiting={FadeOut.duration(200)} style={styles.backdrop} />
-        <Animated.View entering={WITHDRAW_SHEET_ENTERING_ANIMATION} exiting={WITHDRAW_SHEET_EXITING_ANIMATION} style={styles.panelHost}>
-          <PanelSheet showTapToDismiss={false}>
-            <Box paddingBottom="32px" paddingHorizontal="32px" paddingTop="52px">
-              <CashBalanceIcon size={52} />
-              <Box paddingTop="16px">
-                <Text color="label" size="26pt" weight="heavy">
-                  {i18n.t(i18n.l.cash_balance.half_sheet.withdraw_coming_soon)}
-                </Text>
-              </Box>
-            </Box>
-          </PanelSheet>
-        </Animated.View>
-      </View>
-    </TouchableWithoutFeedback>
-  );
-});
-
 export const CashBalanceHalfSheet = memo(function CashBalanceHalfSheet() {
   const { asset, balanceDisplay, hasBalance } = useCashBalance();
-  const navigate = useNavigationForNonReadOnlyWallets();
+  const { navigate } = useNavigation();
+  const navigateForNonReadOnlyWallet = useNavigationForNonReadOnlyWallets();
   const handleAddPress = useCashBalanceAddPress('cash balance half sheet');
-  const [showWithdrawComingSoon, setShowWithdrawComingSoon] = useState(false);
 
+  // A real route stacked on top, not an inline overlay, so it gets its own independent native
+  // dismiss gesture instead of dragging this half sheet along with it.
   const handleWithdrawPress = useCallback(() => {
-    setShowWithdrawComingSoon(true);
-  }, []);
-
-  const handleDismissWithdrawComingSoon = useCallback(() => {
-    setShowWithdrawComingSoon(false);
-  }, []);
+    navigate(Routes.CASH_BALANCE_WITHDRAW_COMING_SOON_SHEET);
+  }, [navigate]);
 
   const handleSendPress = useCallback(() => {
     if (!asset) return;
     const sendAsset = asset as unknown as ParsedAddressAsset;
     if (Platform.OS === 'ios') {
-      navigate(Routes.SEND_FLOW, { screen: Routes.SEND_SHEET, params: { asset: sendAsset } });
+      navigateForNonReadOnlyWallet(Routes.SEND_FLOW, { screen: Routes.SEND_SHEET, params: { asset: sendAsset } });
     } else {
-      navigate(Routes.SEND_FLOW, { asset: sendAsset });
+      navigateForNonReadOnlyWallet(Routes.SEND_FLOW, { asset: sendAsset });
     }
-  }, [asset, navigate]);
+  }, [asset, navigateForNonReadOnlyWallet]);
 
   return (
-    <>
-      <PanelSheet>
-        <Box paddingBottom="20px" paddingHorizontal="20px" paddingTop="20px">
-          <CashBalanceHalfSheetHeader />
+    <PanelSheet>
+      <Box paddingBottom="20px" paddingHorizontal="20px" paddingTop="20px">
+        <CashBalanceHalfSheetHeader />
 
-          <Box paddingTop={{ custom: 64 }}>
-            <Text align="center" color="label" size="44pt" weight="heavy">
-              {balanceDisplay}
-            </Text>
-          </Box>
+        <Box paddingTop={{ custom: 64 }}>
+          <Text align="center" color="label" size="44pt" weight="heavy">
+            {balanceDisplay}
+          </Text>
+        </Box>
 
-          <Box alignItems={hasBalance ? 'center' : undefined} paddingTop={{ custom: hasBalance ? 52 : 64 }}>
-            {hasBalance ? <CashBalanceBadge asset={asset} /> : <CashBalanceSubLabel asset={asset} />}
-          </Box>
+        <Box alignItems={hasBalance ? 'center' : undefined} paddingTop={{ custom: hasBalance ? 52 : 64 }}>
+          {hasBalance ? <CashBalanceBadge asset={asset} /> : <CashBalanceSubLabel asset={asset} />}
+        </Box>
 
-          <Box paddingTop={{ custom: hasBalance ? 20 : 16 }}>
-            <Columns space="8px">
-              <CashBalanceActionButton onPress={handleAddPress} testID="cash-balance-half-sheet-add-button">
+        <Box paddingTop={{ custom: hasBalance ? 20 : 16 }}>
+          <Columns space="8px">
+            <CashBalanceActionButton onPress={handleAddPress} testID="cash-balance-half-sheet-add-button">
+              <Text color="white" size="20pt" weight="heavy">
+                {i18n.t(i18n.l.button.add)}
+              </Text>
+            </CashBalanceActionButton>
+            {hasBalance && (
+              <CashBalanceActionButton onPress={handleWithdrawPress} testID="cash-balance-half-sheet-withdraw-button">
                 <Text color="white" size="20pt" weight="heavy">
-                  {i18n.t(i18n.l.button.add)}
+                  {i18n.t(i18n.l.button.withdraw)}
                 </Text>
               </CashBalanceActionButton>
-              {hasBalance && (
-                <CashBalanceActionButton onPress={handleWithdrawPress} testID="cash-balance-half-sheet-withdraw-button">
-                  <Text color="white" size="20pt" weight="heavy">
-                    {i18n.t(i18n.l.button.withdraw)}
+            )}
+            {hasBalance && asset && (
+              <Column width="content">
+                <CashBalanceActionButton circular onPress={handleSendPress} testID="cash-balance-half-sheet-send-button">
+                  <Text color="white" size="icon 20px" weight="heavy">
+                    {SEND_ICON}
                   </Text>
                 </CashBalanceActionButton>
-              )}
-              {hasBalance && asset && (
-                <Column width="content">
-                  <CashBalanceActionButton circular onPress={handleSendPress} testID="cash-balance-half-sheet-send-button">
-                    <Text color="white" size="icon 20px" weight="heavy">
-                      {SEND_ICON}
-                    </Text>
-                  </CashBalanceActionButton>
-                </Column>
-              )}
-            </Columns>
-          </Box>
+              </Column>
+            )}
+          </Columns>
         </Box>
-      </PanelSheet>
-
-      {showWithdrawComingSoon && <CashBalanceWithdrawComingSoonSheet onDismiss={handleDismissWithdrawComingSoon} />}
-    </>
+      </Box>
+    </PanelSheet>
   );
-});
-
-const styles = StyleSheet.create({
-  backdrop: {
-    ...StyleSheet.absoluteFillObject,
-    backgroundColor: 'rgba(0, 0, 0, 0.44)',
-  },
-  overlay: {
-    ...StyleSheet.absoluteFillObject,
-    // Above the half sheet's own PanelSheet (zIndex 30000).
-    zIndex: 30001,
-  },
-  panelHost: {
-    ...StyleSheet.absoluteFillObject,
-  },
 });

--- a/src/features/cash-balance/screens/CashBalanceWithdrawComingSoonSheet.tsx
+++ b/src/features/cash-balance/screens/CashBalanceWithdrawComingSoonSheet.tsx
@@ -1,0 +1,24 @@
+import React, { memo } from 'react';
+
+import { PanelSheet } from '@/components/PanelSheet/PanelSheet';
+import { Box, Text } from '@/design-system';
+import { CashBalanceIcon } from '@/features/cash-balance/components/CashBalanceIcon';
+import * as i18n from '@/languages';
+
+// Stacked on top of CashBalanceHalfSheet when Withdraw is pressed, matching the Figma mini
+// sheet. A real route (rather than an inline overlay) so it gets its own independent native
+// dismiss gesture instead of dragging the half sheet underneath it along with it.
+export const CashBalanceWithdrawComingSoonSheet = memo(function CashBalanceWithdrawComingSoonSheet() {
+  return (
+    <PanelSheet>
+      <Box paddingBottom="32px" paddingHorizontal="32px" paddingTop="52px">
+        <CashBalanceIcon size={52} />
+        <Box paddingTop="16px">
+          <Text color="label" size="26pt" weight="heavy">
+            {i18n.t(i18n.l.cash_balance.half_sheet.withdraw_coming_soon)}
+          </Text>
+        </Box>
+      </Box>
+    </PanelSheet>
+  );
+});

--- a/src/features/transfer/components/SendActionButton.tsx
+++ b/src/features/transfer/components/SendActionButton.tsx
@@ -1,13 +1,11 @@
-import React, { useCallback } from 'react';
-import { Platform } from 'react-native';
+import React from 'react';
 
 import SheetActionButton, { type SheetActionButtonProps } from '@/components/sheet/sheet-action-buttons/SheetActionButton';
 import { Text, TextIcon } from '@/design-system';
 import type { ParsedAddressAsset, RainbowToken } from '@/entities/tokens';
 import type { UniqueAsset } from '@/entities/uniqueAssets';
-import useNavigationForNonReadOnlyWallets from '@/hooks/useNavigationForNonReadOnlyWallets';
+import { useNavigateToSend } from '@/features/transfer/hooks/useNavigateToSend';
 import * as i18n from '@/languages';
-import Routes from '@/navigation/routesNames';
 import { colors } from '@/styles';
 
 type SendActionButtonProps = Omit<SheetActionButtonProps, 'icon'> & {
@@ -18,15 +16,7 @@ type SendActionButtonProps = Omit<SheetActionButtonProps, 'icon'> & {
 
 function SendActionButtonComponent({ asset, color: givenColor, icon, size, textColor, ...props }: SendActionButtonProps) {
   const color = givenColor || colors.paleBlue;
-  const navigate = useNavigationForNonReadOnlyWallets();
-
-  const handlePress = useCallback(() => {
-    if (Platform.OS === 'ios') {
-      navigate(Routes.SEND_FLOW, { screen: Routes.SEND_SHEET, params: { asset } });
-    } else {
-      navigate(Routes.SEND_FLOW, { asset });
-    }
-  }, [asset, navigate]);
+  const handlePress = useNavigateToSend(asset);
 
   return (
     <SheetActionButton

--- a/src/features/transfer/hooks/useNavigateToSend.ts
+++ b/src/features/transfer/hooks/useNavigateToSend.ts
@@ -1,0 +1,24 @@
+import { useCallback } from 'react';
+import { Platform } from 'react-native';
+
+import type { ParsedAddressAsset, RainbowToken } from '@/entities/tokens';
+import type { UniqueAsset } from '@/entities/uniqueAssets';
+import useNavigationForNonReadOnlyWallets from '@/hooks/useNavigationForNonReadOnlyWallets';
+import Routes from '@/navigation/routesNames';
+
+/**
+ * Shared Send entry point so every asset-detail surface (SendActionButton, the Cash Balance
+ * half sheet, ...) dispatches the same iOS/Android route shape instead of re-deriving it.
+ */
+export function useNavigateToSend(asset: RainbowToken | UniqueAsset | ParsedAddressAsset | undefined) {
+  const navigate = useNavigationForNonReadOnlyWallets();
+
+  return useCallback(() => {
+    if (!asset) return;
+    if (Platform.OS === 'ios') {
+      navigate(Routes.SEND_FLOW, { screen: Routes.SEND_SHEET, params: { asset } });
+    } else {
+      navigate(Routes.SEND_FLOW, { asset });
+    }
+  }, [asset, navigate]);
+}

--- a/src/languages/en_US.json
+++ b/src/languages/en_US.json
@@ -312,6 +312,7 @@
       "unhide": "Unhide",
       "unpin": "Unpin",
       "view": "View",
+      "withdraw": "Withdraw",
       "hidden": "Hidden",
       "claim": "Claim"
     },
@@ -1692,6 +1693,13 @@
           "continue": "Continue Setup",
           "confirm": "Cancel Setup"
         }
+      }
+    },
+    "cash_balance": {
+      "half_sheet": {
+        "title": "Cash Balance",
+        "subtitle": "Cash is your USDC on Base",
+        "withdraw_coming_soon": "Cash withdrawals are coming soon."
       }
     },
     "points": {

--- a/src/languages/en_US.json
+++ b/src/languages/en_US.json
@@ -1699,7 +1699,7 @@
       "half_sheet": {
         "title": "Cash Balance",
         "subtitle": "Cash is your USDC on Base",
-        "withdraw_coming_soon": "Cash withdrawals are coming soon."
+        "withdraw_coming_soon": "Cash withdrawals\nare coming soon"
       }
     },
     "points": {

--- a/src/navigation/Routes.android.tsx
+++ b/src/navigation/Routes.android.tsx
@@ -9,6 +9,7 @@ import WalletErrorSheet from '@/components/wallet-error/WalletErrorSheet';
 import { AppIconUnlockSheet } from '@/features/app-icon/screens/AppIconUnlockSheet';
 import BackupSheet from '@/features/backup/components/BackupSheet';
 import { CashBalanceHalfSheet } from '@/features/cash-balance/screens/CashBalanceHalfSheet';
+import { CashBalanceWithdrawComingSoonSheet } from '@/features/cash-balance/screens/CashBalanceWithdrawComingSoonSheet';
 import { AddCashSheet } from '@/features/cash/screens/add-cash-sheet/AddCashSheet';
 import { AddWalletSheet } from '@/features/cash/screens/add-wallet-sheet/AddWalletSheet';
 import { CashDepositIntroPanel } from '@/features/cash/screens/cash-deposit-intro-panel/CashDepositIntroPanel';
@@ -298,6 +299,7 @@ function BSNavigator() {
       <BSStack.Screen component={AddCashSheet} name={Routes.ADD_CASH_SHEET} />
       <BSStack.Screen component={AddWalletSheet} name={Routes.CASH_ADD_WALLET_SHEET} />
       <BSStack.Screen component={CashBalanceHalfSheet} name={Routes.CASH_BALANCE_HALF_SHEET} />
+      <BSStack.Screen component={CashBalanceWithdrawComingSoonSheet} name={Routes.CASH_BALANCE_WITHDRAW_COMING_SOON_SHEET} />
       <BSStack.Screen component={PaymentMethodsSheet} name={Routes.CASH_PAYMENT_METHODS_SHEET} />
       <BSStack.Screen component={PerpsTradeDetailsSheet} name={Routes.PERPS_TRADE_DETAILS_SHEET} />
       <BSStack.Screen component={PolymarketEventScreen} name={Routes.POLYMARKET_EVENT_SCREEN} />

--- a/src/navigation/Routes.android.tsx
+++ b/src/navigation/Routes.android.tsx
@@ -8,6 +8,7 @@ import { SwapScreen } from '@/__swaps__/screens/Swap/Swap';
 import WalletErrorSheet from '@/components/wallet-error/WalletErrorSheet';
 import { AppIconUnlockSheet } from '@/features/app-icon/screens/AppIconUnlockSheet';
 import BackupSheet from '@/features/backup/components/BackupSheet';
+import { CashBalanceHalfSheet } from '@/features/cash-balance/screens/CashBalanceHalfSheet';
 import { AddCashSheet } from '@/features/cash/screens/add-cash-sheet/AddCashSheet';
 import { AddWalletSheet } from '@/features/cash/screens/add-wallet-sheet/AddWalletSheet';
 import { CashDepositIntroPanel } from '@/features/cash/screens/cash-deposit-intro-panel/CashDepositIntroPanel';
@@ -296,6 +297,7 @@ function BSNavigator() {
       <BSStack.Screen component={CashSignInScreen} name={Routes.CASH_SIGN_IN_SCREEN} options={cashDepositSetupSheetPreset} />
       <BSStack.Screen component={AddCashSheet} name={Routes.ADD_CASH_SHEET} />
       <BSStack.Screen component={AddWalletSheet} name={Routes.CASH_ADD_WALLET_SHEET} />
+      <BSStack.Screen component={CashBalanceHalfSheet} name={Routes.CASH_BALANCE_HALF_SHEET} />
       <BSStack.Screen component={PaymentMethodsSheet} name={Routes.CASH_PAYMENT_METHODS_SHEET} />
       <BSStack.Screen component={PerpsTradeDetailsSheet} name={Routes.PERPS_TRADE_DETAILS_SHEET} />
       <BSStack.Screen component={PolymarketEventScreen} name={Routes.POLYMARKET_EVENT_SCREEN} />

--- a/src/navigation/Routes.ios.tsx
+++ b/src/navigation/Routes.ios.tsx
@@ -9,6 +9,7 @@ import WalletErrorSheet from '@/components/wallet-error/WalletErrorSheet';
 import { AppIconUnlockSheet } from '@/features/app-icon/screens/AppIconUnlockSheet';
 import BackupSheet from '@/features/backup/components/BackupSheet';
 import { CashBalanceHalfSheet } from '@/features/cash-balance/screens/CashBalanceHalfSheet';
+import { CashBalanceWithdrawComingSoonSheet } from '@/features/cash-balance/screens/CashBalanceWithdrawComingSoonSheet';
 import { AddCashSheet } from '@/features/cash/screens/add-cash-sheet/AddCashSheet';
 import { AddWalletSheet } from '@/features/cash/screens/add-wallet-sheet/AddWalletSheet';
 import { CashDepositIntroPanel } from '@/features/cash/screens/cash-deposit-intro-panel/CashDepositIntroPanel';
@@ -324,6 +325,11 @@ function NativeStackNavigator() {
       <NativeStack.Screen component={AddWalletSheet} name={Routes.CASH_ADD_WALLET_SHEET} {...panelConfig} />
       <NativeStack.Screen component={PaymentMethodsSheet} name={Routes.CASH_PAYMENT_METHODS_SHEET} {...panelConfig} />
       <NativeStack.Screen component={CashBalanceHalfSheet} name={Routes.CASH_BALANCE_HALF_SHEET} {...panelConfig} />
+      <NativeStack.Screen
+        component={CashBalanceWithdrawComingSoonSheet}
+        name={Routes.CASH_BALANCE_WITHDRAW_COMING_SOON_SHEET}
+        {...panelConfig}
+      />
       <NativeStack.Screen
         component={PerpsTradeDetailsSheet}
         name={Routes.PERPS_TRADE_DETAILS_SHEET}

--- a/src/navigation/Routes.ios.tsx
+++ b/src/navigation/Routes.ios.tsx
@@ -8,6 +8,7 @@ import { SwapScreen } from '@/__swaps__/screens/Swap/Swap';
 import WalletErrorSheet from '@/components/wallet-error/WalletErrorSheet';
 import { AppIconUnlockSheet } from '@/features/app-icon/screens/AppIconUnlockSheet';
 import BackupSheet from '@/features/backup/components/BackupSheet';
+import { CashBalanceHalfSheet } from '@/features/cash-balance/screens/CashBalanceHalfSheet';
 import { AddCashSheet } from '@/features/cash/screens/add-cash-sheet/AddCashSheet';
 import { AddWalletSheet } from '@/features/cash/screens/add-wallet-sheet/AddWalletSheet';
 import { CashDepositIntroPanel } from '@/features/cash/screens/cash-deposit-intro-panel/CashDepositIntroPanel';
@@ -322,6 +323,7 @@ function NativeStackNavigator() {
       <NativeStack.Screen component={AddCashSheet} name={Routes.ADD_CASH_SHEET} {...panelConfig} />
       <NativeStack.Screen component={AddWalletSheet} name={Routes.CASH_ADD_WALLET_SHEET} {...panelConfig} />
       <NativeStack.Screen component={PaymentMethodsSheet} name={Routes.CASH_PAYMENT_METHODS_SHEET} {...panelConfig} />
+      <NativeStack.Screen component={CashBalanceHalfSheet} name={Routes.CASH_BALANCE_HALF_SHEET} {...panelConfig} />
       <NativeStack.Screen
         component={PerpsTradeDetailsSheet}
         name={Routes.PERPS_TRADE_DETAILS_SHEET}

--- a/src/navigation/routesNames.ts
+++ b/src/navigation/routesNames.ts
@@ -78,6 +78,7 @@ const Routes = {
   CASH_ADD_WALLET_SHEET: 'CashAddWalletSheet',
   CASH_PAYMENT_METHODS_SHEET: 'CashPaymentMethodsSheet',
   CASH_BALANCE_HALF_SHEET: 'CashBalanceHalfSheet',
+  CASH_BALANCE_WITHDRAW_COMING_SOON_SHEET: 'CashBalanceWithdrawComingSoonSheet',
   RECEIVE_MODAL: 'ReceiveModal',
   REGISTER_ENS_NAVIGATOR: 'RegisterEnsNavigator',
   CHOOSE_BACKUP_SHEET: 'ChooseBackupSheet',

--- a/src/navigation/routesNames.ts
+++ b/src/navigation/routesNames.ts
@@ -77,6 +77,7 @@ const Routes = {
   CASH_SETUP_CARD_ADDED: 'CashSetupCardAdded',
   CASH_ADD_WALLET_SHEET: 'CashAddWalletSheet',
   CASH_PAYMENT_METHODS_SHEET: 'CashPaymentMethodsSheet',
+  CASH_BALANCE_HALF_SHEET: 'CashBalanceHalfSheet',
   RECEIVE_MODAL: 'ReceiveModal',
   REGISTER_ENS_NAVIGATOR: 'RegisterEnsNavigator',
   CHOOSE_BACKUP_SHEET: 'ChooseBackupSheet',


### PR DESCRIPTION
Fixes APP-4081

* Tapping the Cash Balance wallet row now opens a half sheet
* Add mirrors the row's existing Add Cash entry point
* If you have a balance: Withdraw shows a "coming soon" alert
* If you have a balance: Send opens the send flow pre-populated with Base USDC
* Withdraw and Send only appear once there's an actual Base USDC balance; otherwise the sheet matches the Figma "Add only" empty state.

Not included:
* "coming soon" is just an alert instead of a little sheet as of now
* settings in the top right corner of the half sheet (will be done in a separate ticket pending design)

## What changed (plus any additional context for devs)

## Screen recordings / screenshots
Please see screenshots in Linear ticket: https://linear.app/rainbow/issue/APP-3972/cash-balance-half-sheet