### PR TITLE
fix(android): builds failing on retired Fabric maven repo

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -17,9 +17,6 @@ buildscript {
     repositories {
         google()
         jcenter()
-         maven {
-            url 'https://maven.fabric.io/public'
-        }
         mavenCentral()
     }
     dependencies {
@@ -29,7 +26,6 @@ buildscript {
         classpath("de.undercouch:gradle-download-task:5.0.1")
         classpath 'com.google.gms:google-services:4.4.4'
         classpath 'com.google.firebase:firebase-crashlytics-gradle:3.0.6'
-        classpath 'io.fabric.tools:gradle:1.28.1'
         classpath("io.sentry:sentry-android-gradle-plugin:5.3.0")
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
`maven.fabric.io` started returning 403 recently as it has been decommed by Google, so Android build fails during root project configuration while resolving `io.fabric.tools:gradle`. Fabric was retired in March 2020 and we never applied the plugin because crash reporting has always run through the Firebase Crashlytics plugin, so this classpath entry has been dead weight anyway since it landed along time ago.

This change drops the entry and the repository to get configuration passing again.