### PR TITLE
fix(browser): correct handling of `blob:`, `data:`, `file:` URLs

### DIFF
--- a/src/features/dapp-browser/components/search/Search.tsx
+++ b/src/features/dapp-browser/components/search/Search.tsx
@@ -6,7 +6,6 @@ import Animated, { runOnJS, useAnimatedStyle, withSpring } from 'react-native-re
 
 import { SPRING_CONFIGS } from '@/components/animations/animationConfigs';
 import { useColorMode } from '@/design-system';
-import { HTTPS_PREFIX, isMissingValidProtocolWorklet, isValidWebUrlWorklet } from '@/framework/core/utils/url';
 import { useSharedValueState } from '@/hooks/reanimated/useSharedValueState';
 import { useSyncSharedValue } from '@/hooks/reanimated/useSyncSharedValue';
 import useKeyboardHeight from '@/hooks/useKeyboardHeight';
@@ -20,6 +19,7 @@ import { useBrowserWorkletsContext } from '../../context/BrowserWorkletsContext'
 import { useSearchContext } from '../../context/SearchContext';
 import { useTabSwitchGestures } from '../../hooks/useTabSwitchGestures';
 import { TabViewGestureStates } from '../../types';
+import { normalizeUrlWorklet } from '../../utils/browserUtils';
 import { AccountIcon } from '../search-input/AccountIcon';
 import { SearchInput } from '../search-input/SearchInput';
 import { TabButton } from '../search-input/TabButton';
@@ -107,11 +107,7 @@ export const Search = () => {
         newUrl = searchResults.value[0].url;
       }
 
-      if (!isValidWebUrlWorklet(newUrl)) {
-        newUrl = GOOGLE_SEARCH_URL + newUrl;
-      } else if (isMissingValidProtocolWorklet(newUrl)) {
-        newUrl = HTTPS_PREFIX + newUrl;
-      }
+      newUrl = normalizeUrlWorklet(newUrl) ?? GOOGLE_SEARCH_URL + newUrl;
 
       if (shouldBlur) inputRef.current?.blur();
       goToUrl(newUrl);

--- a/src/features/dapp-browser/context/BrowserContext.tsx
+++ b/src/features/dapp-browser/context/BrowserContext.tsx
@@ -28,7 +28,7 @@ import {
   type BrowserContextType,
   type BrowserTabBarContextType,
 } from '../types';
-import { isRestorableUrlWorklet, normalizeUrlWorklet } from '../utils/browserUtils';
+import { normalizeUrlWorklet } from '../utils/browserUtils';
 import { addReferralToDappBrowserUrl } from '../utils/dappReferrals';
 import { calculateTabViewBorderRadius } from '../utils/layoutUtils';
 
@@ -164,10 +164,11 @@ export const BrowserContextProvider = ({ children }: { children: React.ReactNode
     (originalUrl: string, tabId?: string) => {
       const { url: activeTabUrl } = activeTabInfo.value;
       const tabIdToUse = tabId || activeTabId.value;
-      const url = addReferralToDappBrowserUrl(originalUrl);
-      if (!isRestorableUrlWorklet(url)) return;
+      const normalizedUrl = normalizeUrlWorklet(originalUrl);
+      if (!normalizedUrl) return;
+      const url = addReferralToDappBrowserUrl(normalizedUrl);
 
-      if (normalizeUrlWorklet(url) === normalizeUrlWorklet(activeTabUrl)) {
+      if (url === activeTabUrl) {
         refreshPage();
       } else {
         goToPage(url, tabIdToUse);
@@ -175,7 +176,7 @@ export const BrowserContextProvider = ({ children }: { children: React.ReactNode
 
       runOnUI(() => {
         const tabIdToUse = tabId || activeTabId.value;
-        animatedTabUrls.modify(urls => ({ ...urls, [tabIdToUse]: normalizeUrlWorklet(url) }));
+        animatedTabUrls.modify(urls => ({ ...urls, [tabIdToUse]: url }));
       })();
     },
     [activeTabId, activeTabInfo, animatedTabUrls, goToPage, refreshPage]

--- a/src/features/dapp-browser/context/BrowserContext.tsx
+++ b/src/features/dapp-browser/context/BrowserContext.tsx
@@ -28,7 +28,7 @@ import {
   type BrowserContextType,
   type BrowserTabBarContextType,
 } from '../types';
-import { normalizeUrlWorklet } from '../utils/browserUtils';
+import { isRestorableUrlWorklet, normalizeUrlWorklet } from '../utils/browserUtils';
 import { addReferralToDappBrowserUrl } from '../utils/dappReferrals';
 import { calculateTabViewBorderRadius } from '../utils/layoutUtils';
 
@@ -165,6 +165,7 @@ export const BrowserContextProvider = ({ children }: { children: React.ReactNode
       const { url: activeTabUrl } = activeTabInfo.value;
       const tabIdToUse = tabId || activeTabId.value;
       const url = addReferralToDappBrowserUrl(originalUrl);
+      if (!isRestorableUrlWorklet(url)) return;
 
       if (normalizeUrlWorklet(url) === normalizeUrlWorklet(activeTabUrl)) {
         refreshPage();

--- a/src/features/dapp-browser/context/BrowserWorkletsContext.tsx
+++ b/src/features/dapp-browser/context/BrowserWorkletsContext.tsx
@@ -9,7 +9,7 @@ import { generateUniqueId } from '@/worklets/strings';
 import { RAINBOW_HOME } from '../constants/constants';
 import { useBrowserStore } from '../stores/browserStore';
 import { TabViewGestureStates, type BrowserWorkletsContextType, type ScreenshotType, type TabOperation } from '../types';
-import { normalizeUrlWorklet } from '../utils/browserUtils';
+import { isRestorableUrlWorklet, normalizeUrlWorklet } from '../utils/browserUtils';
 import { useBrowserContext, useBrowserTabBarContext } from './BrowserContext';
 
 export const BrowserWorkletsContext = createContext<BrowserWorkletsContextType | undefined>(undefined);
@@ -99,6 +99,7 @@ export const BrowserWorkletsContextProvider = ({ children }: { children: React.R
   const updateTabUrlWorklet = useCallback(
     ({ tabId, url }: { tabId: string; url: string }) => {
       'worklet';
+      if (!isRestorableUrlWorklet(url)) return;
       animatedTabUrls.modify(urls => ({ ...urls, [tabId]: normalizeUrlWorklet(url) }));
     },
     [animatedTabUrls]

--- a/src/features/dapp-browser/context/BrowserWorkletsContext.tsx
+++ b/src/features/dapp-browser/context/BrowserWorkletsContext.tsx
@@ -9,7 +9,7 @@ import { generateUniqueId } from '@/worklets/strings';
 import { RAINBOW_HOME } from '../constants/constants';
 import { useBrowserStore } from '../stores/browserStore';
 import { TabViewGestureStates, type BrowserWorkletsContextType, type ScreenshotType, type TabOperation } from '../types';
-import { isRestorableUrlWorklet, normalizeUrlWorklet } from '../utils/browserUtils';
+import { normalizeUrlWorklet } from '../utils/browserUtils';
 import { useBrowserContext, useBrowserTabBarContext } from './BrowserContext';
 
 export const BrowserWorkletsContext = createContext<BrowserWorkletsContextType | undefined>(undefined);
@@ -99,8 +99,9 @@ export const BrowserWorkletsContextProvider = ({ children }: { children: React.R
   const updateTabUrlWorklet = useCallback(
     ({ tabId, url }: { tabId: string; url: string }) => {
       'worklet';
-      if (!isRestorableUrlWorklet(url)) return;
-      animatedTabUrls.modify(urls => ({ ...urls, [tabId]: normalizeUrlWorklet(url) }));
+      const normalizedUrl = normalizeUrlWorklet(url);
+      if (!normalizedUrl) return;
+      animatedTabUrls.modify(urls => ({ ...urls, [tabId]: normalizedUrl }));
     },
     [animatedTabUrls]
   );

--- a/src/features/dapp-browser/hooks/useWebViewHandlers.ts
+++ b/src/features/dapp-browser/hooks/useWebViewHandlers.ts
@@ -21,7 +21,7 @@ import { handleProviderRequestApp } from '../services/handleProviderRequest';
 import { type BrowserHistoryStore } from '../stores/browserHistoryStore';
 import { useBrowserStore, type BrowserState } from '../stores/browserStore';
 import { type TabId } from '../types';
-import { isValidAppStoreUrl } from '../utils/browserUtils';
+import { isValidAppStoreUrl, normalizeUrlWorklet } from '../utils/browserUtils';
 import { addReferralToDappBrowserUrl } from '../utils/dappReferrals';
 
 interface UseWebViewHandlersParams {
@@ -211,10 +211,13 @@ export function useWebViewHandlers({
         return;
       }
 
-      const currentUrl = useBrowserStore.getState().getTabUrl(tabId);
-      if (currentUrl === targetUrl) return;
+      const newTabUrl = normalizeUrlWorklet(targetUrl);
+      if (!newTabUrl) return;
 
-      Navigation.setParams<typeof Routes.DAPP_BROWSER_SCREEN>({ url: targetUrl });
+      const currentUrl = useBrowserStore.getState().getTabUrl(tabId);
+      if (currentUrl === newTabUrl) return;
+
+      Navigation.setParams<typeof Routes.DAPP_BROWSER_SCREEN>({ url: newTabUrl });
     },
     [tabId]
   );

--- a/src/features/dapp-browser/screens/DappBrowser.tsx
+++ b/src/features/dapp-browser/screens/DappBrowser.tsx
@@ -33,7 +33,7 @@ import { useScreenshotAndScrollTriggers } from '../hooks/useScreenshotAndScrollT
 import { useBrowserHistoryStore } from '../stores/browserHistoryStore';
 import { useBrowserStore } from '../stores/browserStore';
 import { TabViewGestureStates, type AnimatedTabUrls } from '../types';
-import { isRestorableUrlWorklet } from '../utils/browserUtils';
+import { normalizeUrlWorklet } from '../utils/browserUtils';
 import { addReferralToDappBrowserUrl } from '../utils/dappReferrals';
 import { schedulePruneScreenshots } from '../utils/screenshots';
 
@@ -76,7 +76,13 @@ const NewTabTrigger = () => {
 
   const route = useRoute<RouteProp<RootStackParamList, typeof Routes.DAPP_BROWSER_SCREEN>>();
   const requestedUrl = route.params?.url;
-  const newTabUrl = isRestorableUrlWorklet(requestedUrl) ? addReferralToDappBrowserUrl(requestedUrl) : undefined;
+  const normalizedUrl = normalizeUrlWorklet(requestedUrl);
+  const newTabUrl = normalizedUrl ? addReferralToDappBrowserUrl(normalizedUrl) : undefined;
+  const shouldClearRequestedUrl = Boolean(requestedUrl && !newTabUrl);
+
+  useEffect(() => {
+    if (shouldClearRequestedUrl) setParams<typeof Routes.DAPP_BROWSER_SCREEN>({ url: undefined });
+  }, [shouldClearRequestedUrl]);
 
   useAnimatedReaction(
     () => newTabUrl,

--- a/src/features/dapp-browser/screens/DappBrowser.tsx
+++ b/src/features/dapp-browser/screens/DappBrowser.tsx
@@ -33,6 +33,7 @@ import { useScreenshotAndScrollTriggers } from '../hooks/useScreenshotAndScrollT
 import { useBrowserHistoryStore } from '../stores/browserHistoryStore';
 import { useBrowserStore } from '../stores/browserStore';
 import { TabViewGestureStates, type AnimatedTabUrls } from '../types';
+import { isRestorableUrlWorklet } from '../utils/browserUtils';
 import { addReferralToDappBrowserUrl } from '../utils/dappReferrals';
 import { schedulePruneScreenshots } from '../utils/screenshots';
 
@@ -74,7 +75,8 @@ const NewTabTrigger = () => {
   const { newTabWorklet } = useBrowserWorkletsContext();
 
   const route = useRoute<RouteProp<RootStackParamList, typeof Routes.DAPP_BROWSER_SCREEN>>();
-  const newTabUrl = route.params?.url ? addReferralToDappBrowserUrl(route.params.url) : undefined;
+  const requestedUrl = route.params?.url;
+  const newTabUrl = isRestorableUrlWorklet(requestedUrl) ? addReferralToDappBrowserUrl(requestedUrl) : undefined;
 
   useAnimatedReaction(
     () => newTabUrl,

--- a/src/features/dapp-browser/stores/browserStore.ts
+++ b/src/features/dapp-browser/stores/browserStore.ts
@@ -30,6 +30,10 @@ const lazyPersist = debounce(
   { leading: false, trailing: true, maxWait: PERSIST_RATE_LIMIT_MS }
 );
 
+export function flushBrowserStorePersistence(): void {
+  lazyPersist.flush();
+}
+
 function partialize(state: BrowserState | PersistedState): PersistedState {
   return {
     activeTabIndex: state.activeTabIndex,
@@ -75,9 +79,10 @@ function deserializePersistedState(serializedState: string): { state: PersistedS
 
   const originalTabIds = state.tabIds;
   const activeTabId = originalTabIds[Math.abs(state.activeTabIndex)];
+  const persistedTabUrls = state.persistedTabUrls;
 
   // Filter out inactive homepage tabs
-  const tabIds = originalTabIds.filter(tabId => tabsData.get(tabId)?.url !== RAINBOW_HOME || tabId === activeTabId);
+  const tabIds = originalTabIds.filter(tabId => persistedTabUrls[tabId] !== RAINBOW_HOME || tabId === activeTabId);
 
   // Remove entries from tabsData that don't have a corresponding tabId in tabIds
   const tabIdsSet = new Set(tabIds);
@@ -91,7 +96,6 @@ function deserializePersistedState(serializedState: string): { state: PersistedS
   }
 
   // Restore persisted tab URLs and prune URL entries for non-existent tabs
-  const persistedTabUrls = state.persistedTabUrls;
   for (const [tabId, persistedUrl] of Object.entries(persistedTabUrls)) {
     if (tabIdsSet.has(tabId)) {
       const tabData = tabsData.get(tabId);

--- a/src/features/dapp-browser/stores/browserStore.ts
+++ b/src/features/dapp-browser/stores/browserStore.ts
@@ -191,15 +191,16 @@ export const useBrowserStore = createWithEqualityFn<BrowserState>()(
           set(state => {
             const tabIdToUse = tabId || state.getActiveTabId();
             const existingTabData = state.getTabData(tabIdToUse);
+            const urlToSet = normalizeUrlWorklet(url);
+            if (!urlToSet) return state;
 
-            const isGoingHome = existingTabData?.url && url === RAINBOW_HOME;
+            const isGoingHome = existingTabData?.url && urlToSet === RAINBOW_HOME;
             const canGoBack = isGoingHome ? false : existingTabData?.canGoBack || false;
             const canGoForward = isGoingHome ? false : existingTabData?.canGoForward || false;
             const newTabsData = new Map(state.tabsData);
 
             const existingUrl = existingTabData?.url || '';
             const persistedUrl = state.persistedTabUrls[tabIdToUse] || '';
-            const urlToSet = normalizeUrlWorklet(url);
             const shouldForceUrlUpdate = !isGoingHome && existingUrl === urlToSet && persistedUrl !== existingUrl;
 
             /**

--- a/src/features/dapp-browser/utils/browserUtils.test.ts
+++ b/src/features/dapp-browser/utils/browserUtils.test.ts
@@ -1,0 +1,29 @@
+import { normalizeUrlWorklet } from './browserUtils';
+
+jest.mock('../constants/constants', () => ({
+  APP_STORE_URL_PREFIXES: [],
+  RAINBOW_HOME: 'RAINBOW_HOME',
+}));
+
+describe('normalizeUrlWorklet', () => {
+  it.each<[string | undefined, string | undefined]>([
+    [undefined, undefined],
+    ['', undefined],
+    ['RAINBOW_HOME', 'RAINBOW_HOME'],
+    ['https://example.com', 'https://example.com'],
+    ['https://example.com/market', 'https://example.com/market'],
+    ['https://example.com/market#offers', 'https://example.com/market#offers'],
+    ['app.uniswap.org', 'https://app.uniswap.org'],
+    ['example.com:3000', 'https://example.com:3000'],
+    ['http://localhost:3000', 'http://localhost:3000'],
+  ])('normalizes %p to %p', (url, expected) => {
+    expect(normalizeUrlWorklet(url)).toBe(expected);
+  });
+
+  it.each(['blob:https://example.com/id', 'data:text/plain,hello', 'file:///tmp/file', 'file:123', 'rainbow://wallet', 'rainbow:123'])(
+    'rejects %p',
+    url => {
+      expect(normalizeUrlWorklet(url)).toBeUndefined();
+    }
+  );
+});

--- a/src/features/dapp-browser/utils/browserUtils.ts
+++ b/src/features/dapp-browser/utils/browserUtils.ts
@@ -2,7 +2,7 @@ import { Share } from 'react-native';
 
 import { type WebViewNavigationEvent } from 'react-native-webview/lib/RNCWebViewNativeComponent';
 
-import { HTTPS_PREFIX, isMissingValidProtocolWorklet } from '@/framework/core/utils/url';
+import { HTTPS_PREFIX, isMissingValidProtocolWorklet, isValidWebUrlWorklet } from '@/framework/core/utils/url';
 import { ensureError, logger, RainbowError } from '@/logger';
 
 import { APP_STORE_URL_PREFIXES, RAINBOW_HOME } from '../constants/constants';
@@ -11,29 +11,17 @@ export function isValidAppStoreUrl(url: string): boolean {
   return APP_STORE_URL_PREFIXES.some(prefix => url.startsWith(prefix));
 }
 
-export function isRestorableUrlWorklet(url: string | undefined): url is string {
+export const normalizeUrlWorklet = (url: string | undefined): string | undefined => {
   'worklet';
-  if (!url) return false;
-  return url === RAINBOW_HOME || !isMissingValidProtocolWorklet(url);
-}
+  let normalizedUrl = url?.trim();
+  if (!normalizedUrl) return undefined;
+  if (normalizedUrl === RAINBOW_HOME) return normalizedUrl;
 
-export const normalizeUrlWorklet = (url: string): string => {
-  'worklet';
-  if (!url) {
-    return '';
-  }
-
-  if (url === RAINBOW_HOME || url.startsWith('blob:') || url.startsWith('data:')) {
-    return url;
-  }
-
-  let normalizedUrl = url;
   if (isMissingValidProtocolWorklet(normalizedUrl)) {
+    if (!isValidWebUrlWorklet(normalizedUrl)) return undefined;
     normalizedUrl = HTTPS_PREFIX + normalizedUrl;
   }
-  if (!normalizedUrl.endsWith('/') && !normalizedUrl.includes('?')) {
-    normalizedUrl += '/';
-  }
+
   return normalizedUrl;
 };
 

--- a/src/features/dapp-browser/utils/browserUtils.ts
+++ b/src/features/dapp-browser/utils/browserUtils.ts
@@ -11,6 +11,12 @@ export function isValidAppStoreUrl(url: string): boolean {
   return APP_STORE_URL_PREFIXES.some(prefix => url.startsWith(prefix));
 }
 
+export function isRestorableUrlWorklet(url: string | undefined): url is string {
+  'worklet';
+  if (!url) return false;
+  return url === RAINBOW_HOME || !isMissingValidProtocolWorklet(url);
+}
+
 export const normalizeUrlWorklet = (url: string): string => {
   'worklet';
   if (!url) {

--- a/src/migrations/index.ts
+++ b/src/migrations/index.ts
@@ -18,6 +18,7 @@ import { migratePersistedQueriesToMMKV } from './migrations/migratePersistedQuer
 import { migratePinnedAndHiddenTokenUniqueIds } from './migrations/migratePinnedAndHiddenTokenUniqueIds';
 import { migrateUnlockableAppIconStorage } from './migrations/migrateUnlockableAppIconStorage';
 import { purgeWcConnectionsWithoutAccounts } from './migrations/purgeWcConnectionsWithoutAccounts';
+import { repairBrowserTabUrls } from './migrations/repairBrowserTabUrls';
 
 /**
  * Local storage for migrations only. Should not be exported.
@@ -48,6 +49,7 @@ const migrations: (() => Migration)[] = [
   migrateNotificationSettingsToV3,
   healEip55KeychainAddresses,
   migrateExperimentalFlags,
+  repairBrowserTabUrls,
 ];
 
 /**

--- a/src/migrations/migrations/repairBrowserTabUrls.ts
+++ b/src/migrations/migrations/repairBrowserTabUrls.ts
@@ -1,0 +1,33 @@
+import { RAINBOW_HOME } from '@/features/dapp-browser/constants/constants';
+import { flushBrowserStorePersistence, useBrowserStore } from '@/features/dapp-browser/stores/browserStore';
+import { isRestorableUrlWorklet } from '@/features/dapp-browser/utils/browserUtils';
+import { MigrationName, type Migration } from '@/migrations/types';
+
+export function repairBrowserTabUrls(): Migration {
+  return {
+    name: MigrationName.repairBrowserTabUrls,
+    async migrate(): Promise<void> {
+      const browserState = useBrowserStore.getState();
+      const hasInvalidTab = browserState.tabIds.some(tabId => !isRestorableUrlWorklet(browserState.persistedTabUrls[tabId]));
+
+      if (!hasInvalidTab) return;
+
+      useBrowserStore.setState(state => {
+        const activeTabId = state.getActiveTabId();
+        const tabIds = state.tabIds.filter(tabId => tabId === activeTabId || isRestorableUrlWorklet(state.persistedTabUrls[tabId]));
+        const persistedTabUrls = Object.fromEntries(
+          tabIds.map(tabId => [tabId, isRestorableUrlWorklet(state.persistedTabUrls[tabId]) ? state.persistedTabUrls[tabId] : RAINBOW_HOME])
+        );
+
+        return {
+          activeTabIndex: tabIds.indexOf(activeTabId),
+          persistedTabUrls,
+          tabIds,
+          tabsData: new Map(tabIds.map(tabId => [tabId, { ...state.getTabData(tabId), url: persistedTabUrls[tabId] }])),
+        };
+      });
+
+      flushBrowserStorePersistence();
+    },
+  };
+}

--- a/src/migrations/migrations/repairBrowserTabUrls.ts
+++ b/src/migrations/migrations/repairBrowserTabUrls.ts
@@ -1,6 +1,7 @@
 import { RAINBOW_HOME } from '@/features/dapp-browser/constants/constants';
+import { useBrowserHistoryStore } from '@/features/dapp-browser/stores/browserHistoryStore';
 import { flushBrowserStorePersistence, useBrowserStore } from '@/features/dapp-browser/stores/browserStore';
-import { isRestorableUrlWorklet } from '@/features/dapp-browser/utils/browserUtils';
+import { normalizeUrlWorklet } from '@/features/dapp-browser/utils/browserUtils';
 import { MigrationName, type Migration } from '@/migrations/types';
 
 export function repairBrowserTabUrls(): Migration {
@@ -8,16 +9,26 @@ export function repairBrowserTabUrls(): Migration {
     name: MigrationName.repairBrowserTabUrls,
     async migrate(): Promise<void> {
       const browserState = useBrowserStore.getState();
-      const hasInvalidTab = browserState.tabIds.some(tabId => !isRestorableUrlWorklet(browserState.persistedTabUrls[tabId]));
+      const needsTabRepair = browserState.tabIds.some(tabId => {
+        const url = browserState.persistedTabUrls[tabId];
+        return !url || normalizeUrlWorklet(url) !== url;
+      });
 
-      if (!hasInvalidTab) return;
+      useBrowserHistoryStore.setState(state => {
+        const recents = state.recents.filter(recent => normalizeUrlWorklet(recent.url));
+        return recents.length === state.recents.length ? state : { recents };
+      });
+
+      if (!needsTabRepair) return;
 
       useBrowserStore.setState(state => {
         const activeTabId = state.getActiveTabId();
-        const tabIds = state.tabIds.filter(tabId => tabId === activeTabId || isRestorableUrlWorklet(state.persistedTabUrls[tabId]));
-        const persistedTabUrls = Object.fromEntries(
-          tabIds.map(tabId => [tabId, isRestorableUrlWorklet(state.persistedTabUrls[tabId]) ? state.persistedTabUrls[tabId] : RAINBOW_HOME])
+        const normalizedTabUrls = Object.fromEntries(
+          state.tabIds.map(tabId => [tabId, normalizeUrlWorklet(state.persistedTabUrls[tabId])])
         );
+
+        const tabIds = state.tabIds.filter(tabId => tabId === activeTabId || normalizedTabUrls[tabId]);
+        const persistedTabUrls = Object.fromEntries(tabIds.map(tabId => [tabId, normalizedTabUrls[tabId] ?? RAINBOW_HOME]));
 
         return {
           activeTabIndex: tabIds.indexOf(activeTabId),

--- a/src/migrations/types.ts
+++ b/src/migrations/types.ts
@@ -23,6 +23,7 @@ export enum MigrationName {
   migrateNotificationSettingsToVersion3 = 'migration_migrateNotificationSettingsToVersion3',
   healEip55KeychainAddresses = 'migration_healEip55KeychainAddresses',
   migrateExperimentalFlags = 'migration_migrateExperimentalFlags',
+  repairBrowserTabUrls = 'migration_repairBrowserTabUrls',
 }
 
 export type Migration = {


### PR DESCRIPTION
Fixes APP-3486

## What changed (plus any additional context for devs)
- `normalizeUrlWorklet` now applies consistent URL normalization, preventing `blob:`, `data:`, and `file:` URLs from being saved and persisted to tab state
- Adds a one-time migration to clean already-persisted bad URLs from browser state
- Adds basic test coverage for browser URL handling

## Screen recordings / screenshots

## What to test
