### PR TITLE
chore: add dep cruiser checks for UI runtime and store libs

### DIFF
--- a/.dependency-cruiser.cjs
+++ b/.dependency-cruiser.cjs
@@ -132,9 +132,9 @@ const sourceRules = [
     name: 'layer-core-has-no-state',
     severity: 'error',
     comment:
-      'core/ knows domain models and pure rules only; it never creates or reads stores, whether via the store library or the legacy state and query layers. Reading state from core/ makes the pure layer depend on IO and load order; the read belongs in data/ (a derived store) or at the call site.',
+      'core/ knows domain models and pure rules only; it never creates or reads stores, whether via the store library or the legacy state, query and redux layers. Reading state from core/ makes the pure layer depend on IO and load order; the read belongs in data/ (a derived store) or at the call site.',
     from: { path: `^${LAYERED_MODULE}/core/` },
-    to: { path: '^(node_modules/@storesjs/stores/|src/(state|react-query)/)' },
+    to: { path: '^(node_modules/@storesjs/stores/|src/(state|react-query|redux)/)' },
   },
 ];
 

--- a/.dependency-cruiser.cjs
+++ b/.dependency-cruiser.cjs
@@ -98,6 +98,11 @@ const runtimeRules = [
 // name out of scope.
 const LAYERED_MODULE = '(src/features/[^/]+|src/framework)';
 
+// The packages that make a file UI-runtime code. Matched as whole package
+// directories so react-prefixed packages that are not the runtime (mmkv, svg,
+// ...) are not caught.
+const UI_RUNTIME_PACKAGES = '^node_modules/(react|react-native|react-native-reanimated)/';
+
 const sourceRules = [
   {
     name: 'layer-core-is-a-leaf',
@@ -114,6 +119,30 @@ const sourceRules = [
       'data/ holds stores, API clients and transforms and imports nothing from any ui/ layer. Rendering depends on state and IO, never the other way round; a store that needs something from a component is a store holding UI runtime concerns that belong in a ui/ hook.',
     from: { path: `^${LAYERED_MODULE}/data/` },
     to: { path: `^${LAYERED_MODULE}/ui/` },
+  },
+  {
+    name: 'layer-ui-runtime-only-in-ui',
+    severity: 'error',
+    comment:
+      'Only ui/ may import the UI runtime (React, React Native, Reanimated). core/ and data/ are framework-agnostic by definition: stores work as hooks and imperatively via getState(), and domain logic runs in tests without a renderer. A React import outside ui/ is code that belongs in a ui/ hook or component.',
+    from: { path: `^${LAYERED_MODULE}/(core|data)/` },
+    to: { path: UI_RUNTIME_PACKAGES },
+  },
+  {
+    name: 'layer-core-has-no-state',
+    severity: 'error',
+    comment:
+      'core/ knows domain models and pure rules only; it never creates or reads stores, whether via the store library or the legacy state and query layers. Reading state from core/ makes the pure layer depend on IO and load order; the read belongs in data/ (a derived store) or at the call site.',
+    from: { path: `^${LAYERED_MODULE}/core/` },
+    to: { path: '^(node_modules/@storesjs/stores/|src/(state|react-query)/)' },
+  },
+  {
+    name: 'stores-hold-plain-values',
+    severity: 'error',
+    comment:
+      'Store files never import the UI runtime. A store holds plain serialisable values: no animation shared values, no timer or subscription handles, no imperative UI calls in actions. Bridging to the UI runtime is a ui/ hook. This is the deterministic slice of that rule; what a store puts in its state is still a review question. Scoped to layered data/stores/ directories: a Level 1 stores/ folder makes no layer claim yet.',
+    from: { path: `^${LAYERED_MODULE}/data/stores/` },
+    to: { path: UI_RUNTIME_PACKAGES },
   },
 ];
 

--- a/.dependency-cruiser.cjs
+++ b/.dependency-cruiser.cjs
@@ -136,14 +136,6 @@ const sourceRules = [
     from: { path: `^${LAYERED_MODULE}/core/` },
     to: { path: '^(node_modules/@storesjs/stores/|src/(state|react-query)/)' },
   },
-  {
-    name: 'stores-hold-plain-values',
-    severity: 'error',
-    comment:
-      'Store files never import the UI runtime. A store holds plain serialisable values: no animation shared values, no timer or subscription handles, no imperative UI calls in actions. Bridging to the UI runtime is a ui/ hook. This is the deterministic slice of that rule; what a store puts in its state is still a review question. Scoped to layered data/stores/ directories: a Level 1 stores/ folder makes no layer claim yet.',
-    from: { path: `^${LAYERED_MODULE}/data/stores/` },
-    to: { path: UI_RUNTIME_PACKAGES },
-  },
 ];
 
 const sharedOptions = {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -92,13 +92,6 @@ const allowedBarrelFiles = [
   'src/framework/ui/styled-thing/index.tsx',
 ];
 
-// Import `Platform` directly from 'react-native' so platform shaking can constant-fold `Platform.OS`
-// checks at build time. Re-imports from wrapper modules break the optimization (https://docs.expo.dev/guides/tree-shaking/#platform-shaking).
-const platformImportRestriction = {
-  selector: "ImportDeclaration[source.value!='react-native'] > ImportSpecifier[imported.name='Platform'][local.name='Platform']",
-  message: "Import `Platform` directly from 'react-native'. Re-importing from a wrapper breaks platform shaking optimization.",
-};
-
 module.exports = {
   root: true,
   extends: ['rainbow', 'plugin:yml/standard'],
@@ -128,24 +121,6 @@ module.exports = {
             selector: 'Program',
             message:
               'Test files must be colocated next to the source file they test (e.g., foo.test.ts next to foo.ts). Do not place tests in __tests__/ or tests/ directories.',
-          },
-        ],
-      },
-    },
-    {
-      // The ui/data/core layer rules (.dependency-cruiser.cjs) forbid core/ and
-      // data/ from importing the UI runtime, but JSX compiles to react/jsx-runtime
-      // without an import edge the dependency graph can see. Forbid the syntax
-      // itself here instead.
-      files: ['src/features/*/core/**/*', 'src/features/*/data/**/*', 'src/framework/core/**/*', 'src/framework/data/**/*'],
-      rules: {
-        'no-restricted-syntax': [
-          'error',
-          platformImportRestriction,
-          {
-            selector: 'JSXElement, JSXFragment',
-            message:
-              'core/ and data/ are framework-agnostic layers; JSX belongs in ui/. Rendering built here means this code belongs in a ui/ component or hook.',
           },
         ],
       },
@@ -194,7 +169,15 @@ module.exports = {
         ],
       },
     ],
-    'no-restricted-syntax': ['error', platformImportRestriction],
+    'no-restricted-syntax': [
+      'error',
+      {
+        // Import `Platform` directly from 'react-native' so platform shaking can constant-fold `Platform.OS`
+        // checks at build time. Re-imports from wrapper modules break the optimization (https://docs.expo.dev/guides/tree-shaking/#platform-shaking).
+        selector: "ImportDeclaration[source.value!='react-native'] > ImportSpecifier[imported.name='Platform'][local.name='Platform']",
+        message: "Import `Platform` directly from 'react-native'. Re-importing from a wrapper breaks platform shaking optimization.",
+      },
+    ],
     'jest/expect-expect': 'off',
     'jest/no-disabled-tests': 'off',
     'no-await-in-loop': 'off',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -92,6 +92,13 @@ const allowedBarrelFiles = [
   'src/framework/ui/styled-thing/index.tsx',
 ];
 
+// Import `Platform` directly from 'react-native' so platform shaking can constant-fold `Platform.OS`
+// checks at build time. Re-imports from wrapper modules break the optimization (https://docs.expo.dev/guides/tree-shaking/#platform-shaking).
+const platformImportRestriction = {
+  selector: "ImportDeclaration[source.value!='react-native'] > ImportSpecifier[imported.name='Platform'][local.name='Platform']",
+  message: "Import `Platform` directly from 'react-native'. Re-importing from a wrapper breaks platform shaking optimization.",
+};
+
 module.exports = {
   root: true,
   extends: ['rainbow', 'plugin:yml/standard'],
@@ -121,6 +128,24 @@ module.exports = {
             selector: 'Program',
             message:
               'Test files must be colocated next to the source file they test (e.g., foo.test.ts next to foo.ts). Do not place tests in __tests__/ or tests/ directories.',
+          },
+        ],
+      },
+    },
+    {
+      // The ui/data/core layer rules (.dependency-cruiser.cjs) forbid core/ and
+      // data/ from importing the UI runtime, but JSX compiles to react/jsx-runtime
+      // without an import edge the dependency graph can see. Forbid the syntax
+      // itself here instead.
+      files: ['src/features/*/core/**/*', 'src/features/*/data/**/*', 'src/framework/core/**/*', 'src/framework/data/**/*'],
+      rules: {
+        'no-restricted-syntax': [
+          'error',
+          platformImportRestriction,
+          {
+            selector: 'JSXElement, JSXFragment',
+            message:
+              'core/ and data/ are framework-agnostic layers; JSX belongs in ui/. Rendering built here means this code belongs in a ui/ component or hook.',
           },
         ],
       },
@@ -169,15 +194,7 @@ module.exports = {
         ],
       },
     ],
-    'no-restricted-syntax': [
-      'error',
-      {
-        // Import `Platform` directly from 'react-native' so platform shaking can constant-fold `Platform.OS`
-        // checks at build time. Re-imports from wrapper modules break the optimization (https://docs.expo.dev/guides/tree-shaking/#platform-shaking).
-        selector: "ImportDeclaration[source.value!='react-native'] > ImportSpecifier[imported.name='Platform'][local.name='Platform']",
-        message: "Import `Platform` directly from 'react-native'. Re-importing from a wrapper breaks platform shaking optimization.",
-      },
-    ],
+    'no-restricted-syntax': ['error', platformImportRestriction],
     'jest/expect-expect': 'off',
     'jest/no-disabled-tests': 'off',
     'no-await-in-loop': 'off',

--- a/tools/deps-check/config.test.ts
+++ b/tools/deps-check/config.test.ts
@@ -186,6 +186,7 @@ describe('.dependency-cruiser.cjs', () => {
         expect('node_modules/@storesjs/stores/dist/index.js').toMatch(to);
         expect('src/state/wallets/walletsStore.ts').toMatch(to);
         expect('src/react-query/queryClient.ts').toMatch(to);
+        expect('src/redux/store.ts').toMatch(to);
       });
     });
   });

--- a/tools/deps-check/config.test.ts
+++ b/tools/deps-check/config.test.ts
@@ -147,5 +147,71 @@ describe('.dependency-cruiser.cjs', () => {
         expect('src/features/wallet/core/walletLibrary.ts').not.toMatch(to);
       });
     });
+    describe('layer-ui-runtime-only-in-ui', () => {
+      const { from, to } = rule('source', 'layer-ui-runtime-only-in-ui');
+
+      it('applies to core/ and data/ of layered modules', () => {
+        expect('src/features/token/core/services/erc20Calldata.ts').toMatch(from);
+        expect('src/features/wallet/data/stores/walletStore.ts').toMatch(from);
+        expect('src/framework/data/http/x.ts').toMatch(from);
+      });
+
+      it('does not apply to ui/ or to legacy directories', () => {
+        expect('src/features/token/ui/x.tsx').not.toMatch(from);
+        expect('src/components/x/core/y.ts').not.toMatch(from);
+      });
+
+      it('forbids the UI runtime packages', () => {
+        expect('node_modules/react/index.js').toMatch(to);
+        expect('node_modules/react-native/index.js').toMatch(to);
+        expect('node_modules/react-native-reanimated/src/index.ts').toMatch(to);
+      });
+
+      it('leaves unrelated packages alone, including react-prefixed ones', () => {
+        expect('node_modules/react-native-mmkv/lib/index.js').not.toMatch(to);
+        expect('node_modules/viem/index.ts').not.toMatch(to);
+      });
+    });
+
+    describe('layer-core-has-no-state', () => {
+      const { from, to } = rule('source', 'layer-core-has-no-state');
+
+      it('applies to core/ of layered modules only', () => {
+        expect('src/features/token/core/services/erc20Calldata.ts').toMatch(from);
+        expect('src/framework/core/safeMath.ts').toMatch(from);
+        expect('src/features/token/data/api/erc20Read.ts').not.toMatch(from);
+      });
+
+      it('forbids store creators and the legacy state and query layers', () => {
+        expect('node_modules/@storesjs/stores/dist/index.js').toMatch(to);
+        expect('src/state/wallets/walletsStore.ts').toMatch(to);
+        expect('src/react-query/queryClient.ts').toMatch(to);
+      });
+
+      it('allows domain models from other modules', () => {
+        expect('src/features/wallet/core/walletLibrary.ts').not.toMatch(to);
+      });
+    });
+
+    describe('stores-hold-plain-values', () => {
+      const { from, to } = rule('source', 'stores-hold-plain-values');
+
+      it('applies to layered store directories', () => {
+        expect('src/features/wallet/data/stores/walletStore.ts').toMatch(from);
+        expect('src/framework/data/stores/x.ts').toMatch(from);
+      });
+
+      it('does not apply to Level 1 stores, the legacy state dir, or other layers', () => {
+        expect('src/features/perps/stores/perpsStore.ts').not.toMatch(from);
+        expect('src/state/wallets/walletsStore.ts').not.toMatch(from);
+        expect('src/features/wallet/data/api/x.ts').not.toMatch(from);
+        expect('src/features/wallet/ui/x.tsx').not.toMatch(from);
+      });
+
+      it('forbids the UI runtime packages', () => {
+        expect('node_modules/react-native/index.js').toMatch(to);
+        expect('node_modules/react-native-reanimated/src/index.ts').toMatch(to);
+      });
+    });
   });
 });

--- a/tools/deps-check/config.test.ts
+++ b/tools/deps-check/config.test.ts
@@ -187,31 +187,6 @@ describe('.dependency-cruiser.cjs', () => {
         expect('src/state/wallets/walletsStore.ts').toMatch(to);
         expect('src/react-query/queryClient.ts').toMatch(to);
       });
-
-      it('allows domain models from other modules', () => {
-        expect('src/features/wallet/core/walletLibrary.ts').not.toMatch(to);
-      });
-    });
-
-    describe('stores-hold-plain-values', () => {
-      const { from, to } = rule('source', 'stores-hold-plain-values');
-
-      it('applies to layered store directories', () => {
-        expect('src/features/wallet/data/stores/walletStore.ts').toMatch(from);
-        expect('src/framework/data/stores/x.ts').toMatch(from);
-      });
-
-      it('does not apply to Level 1 stores, the legacy state dir, or other layers', () => {
-        expect('src/features/perps/stores/perpsStore.ts').not.toMatch(from);
-        expect('src/state/wallets/walletsStore.ts').not.toMatch(from);
-        expect('src/features/wallet/data/api/x.ts').not.toMatch(from);
-        expect('src/features/wallet/ui/x.tsx').not.toMatch(from);
-      });
-
-      it('forbids the UI runtime packages', () => {
-        expect('node_modules/react-native/index.js').toMatch(to);
-        expect('node_modules/react-native-reanimated/src/index.ts').toMatch(to);
-      });
     });
   });
 });


### PR DESCRIPTION
Follows #7782, which added the type-aware source graph and the first layer-direction rules. Those only constrain edges between our own layer directories, however, and right now a `core/` file can still pull in React or a store and stay green, and a `data/` store can import Reanimated to hold a shared value.

This change adds two strict rules on the source graph:
* `core/` and `data/` of layered modules may not import `react`, `react-native` or `react-native-reanimated` (UI logic)
* `core/` may not import the store library or the legacy `state`/`react-query`/`redux` layers

Ref APP-4084.

