### PR TITLE
refactor(design-system): inline Skia font manager unmount cleanup

### DIFF
--- a/src/design-system/components/SkiaText/skiaFontManager.ts
+++ b/src/design-system/components/SkiaText/skiaFontManager.ts
@@ -15,7 +15,6 @@ import { Platform as SkiaPlatform } from '@shopify/react-native-skia/src/Platfor
 import { type TextAlign } from '@/components/text/types';
 import { type TextWeight } from '@/design-system/components/Text/Text';
 import { IS_DEV } from '@/env';
-import { useCleanup } from '@/hooks/useCleanup';
 import { useLazyRef } from '@/hooks/useLazyRef';
 
 interface FontManager {
@@ -76,10 +75,12 @@ export function useSkiaFontManager(align: TextAlign, weight: TextWeight, additio
     additionalWeights ? [align, weight, ...additionalWeights] : [align, weight]
   );
 
-  useCleanup(() => {
-    releaseParagraphBuilder(fontInfoRef);
-    releaseFontManager();
-  });
+  useEffect(() => {
+    return () => {
+      releaseParagraphBuilder(fontInfoRef);
+      releaseFontManager();
+    };
+  }, [fontInfoRef]);
 
   return manager;
 }


### PR DESCRIPTION
The design system should be self-contained: importing only npm packages and its own files. The Skia font manager currently imports an app-level `useCleanup` hook for its unmount release of the paragraph builder and font manager refcounts. The wrapper's value elsewhere is packaging the lint suppression that cleanup-only effects usually need, but this callsite captures only stable values, so a plain `useEffect` is lint-clean without it.

This change writes the cleanup as the equivalent inline `useEffect`. `useCleanup` itself is unchanged and keeps its other consumers (for now). No behavior change.

One of a few small steps toward a fully self-contained design system, after which we can lock the boundary with a dependency rule. 

Ref APP-4084.