### PR TITLE
chore: remove IS_TEST rendering fork in TextShadow

### DIFF
--- a/src/design-system/components/TextShadow/TextShadow.tsx
+++ b/src/design-system/components/TextShadow/TextShadow.tsx
@@ -3,7 +3,6 @@ import { Platform, View, type StyleProp, type ViewStyle } from 'react-native';
 
 import ConditionalWrap from 'conditional-wrap';
 
-import { IS_TEST } from '@/env';
 import { opacity } from '@/framework/ui/utils/opacity';
 
 import { useColorMode } from '../../color/ColorMode';
@@ -60,7 +59,7 @@ export const TextShadow = ({
       }),
     [blur, color, disabled, enableInLightMode, inferredTextColor, isAnimatedText, isDarkMode, shadowOpacity, x, y]
   );
-  if (IS_TEST || (Platform.OS === 'android' && !enableOnAndroid)) {
+  if (Platform.OS === 'android' && !enableOnAndroid) {
     // Make sure to apply containerStyle if we have one.
     return (
       <ConditionalWrap condition={!!containerStyle} wrap={children => <View style={containerStyle}>{children}</View>}>

--- a/src/design-system/components/TextShadow/TextShadow.tsx
+++ b/src/design-system/components/TextShadow/TextShadow.tsx
@@ -78,9 +78,6 @@ export const TextShadow = ({
         color={{ custom: 'transparent' }}
         size={children.props.size}
         style={[internalShadowStyle, children.props.style, internalPositionStyle]}
-        // The child Text nests inside this Text and flattens into it on the native
-        // side, which strips the child's own testID from the element tree. Hoist it
-        // here so the rendered element keeps the caller's identity.
         testID={children.props.testID}
         weight={children.props.weight}
       >

--- a/src/design-system/components/TextShadow/TextShadow.tsx
+++ b/src/design-system/components/TextShadow/TextShadow.tsx
@@ -78,6 +78,10 @@ export const TextShadow = ({
         color={{ custom: 'transparent' }}
         size={children.props.size}
         style={[internalShadowStyle, children.props.style, internalPositionStyle]}
+        // The child Text nests inside this Text and flattens into it on the native
+        // side, which strips the child's own testID from the element tree. Hoist it
+        // here so the rendered element keeps the caller's identity.
+        testID={children.props.testID}
         weight={children.props.weight}
       >
         {children}


### PR DESCRIPTION
`TextShadow` renders a bare passthrough whenever `IS_TEST` is set, so every e2e run exercises a different component tree than the one we ship. The fork turns out to exist for an undocumented reason: on iOS the shadowed child `Text` nests inside the shadow's own `Text` and flattens into it natively, which strips the child's `testID` from the element tree, and the passthrough was masking that.

This change removes the fork by making `TextShadow` forward the child's `testID` to the element it actually renders which is the canonical fix for cases like this.

Ref APP-4084.