### PR TITLE
feat(images): route signed image URLs through our own CDN behind a flag

### DIFF
--- a/src/components/expanded-state/unique-token/saveToCameraRoll.ts
+++ b/src/components/expanded-state/unique-token/saveToCameraRoll.ts
@@ -4,7 +4,7 @@ import { PermissionsAndroid, Platform } from 'react-native';
 import { CameraRoll } from '@react-native-camera-roll/camera-roll';
 import RNFetchBlob from 'rn-fetch-blob';
 
-import { shouldCreateImgixClient } from '@/handlers/imgix';
+import { shouldCreateImgixClient, withImageHost } from '@/handlers/imgix';
 import { WrappedAlert as Alert } from '@/helpers/alert';
 import * as i18n from '@/languages';
 
@@ -78,7 +78,7 @@ const saveToCameraRoll = async (url: string): Promise<void> => {
     alertError();
     return;
   }
-  const url2Download = staticImgixClient?.buildURL(url, { fm: 'png' });
+  const url2Download = withImageHost(staticImgixClient.buildURL(url, { fm: 'png' }));
 
   if (Platform.OS === 'android') {
     await downloadImageAndroid(url2Download);

--- a/src/components/images/imageType.test.ts
+++ b/src/components/images/imageType.test.ts
@@ -1,27 +1,31 @@
 import { getImageType } from './imageType';
 
-const IMGIX = 'https://rainbow.imgix.net';
+jest.mock('react-native-dotenv', () => ({ IMGIX_DOMAIN: 'rainbow.imgix.net' }));
+
 const encoded = (source: string) => encodeURIComponent(source);
 
 describe('getImageType', () => {
-  describe('for imgix images', () => {
+  describe.each([
+    ['imgix', 'https://rainbow.imgix.net'],
+    ['our own CDN', 'https://img.p.rainbow.me'],
+  ])('for images on %s', (_label, origin) => {
     it('reads the format out of fm=', () => {
-      expect(getImageType(`${IMGIX}/${encoded('https://example.com/a.svg')}?w=120&fm=png`)).toBe('png');
+      expect(getImageType(`${origin}/${encoded('https://example.com/a.svg')}?w=120&fm=png`)).toBe('png');
     });
 
     it('reads a non-png fm', () => {
-      expect(getImageType(`${IMGIX}/${encoded('https://example.com/b.png')}?w=120&fm=gif`)).toBe('gif');
+      expect(getImageType(`${origin}/${encoded('https://example.com/b.png')}?w=120&fm=gif`)).toBe('gif');
     });
 
     it('assumes png when fm is absent, whatever the source extension is', () => {
       // The path is an encoded source URL, so its extension describes the source
       // rather than the response. Without fm there is nothing else to go on.
-      expect(getImageType(`${IMGIX}/${encoded('https://example.com/c.svg')}?w=120`)).toBe('png');
-      expect(getImageType(`${IMGIX}/${encoded('https://example.com/d.jpg')}?w=120`)).toBe('png');
+      expect(getImageType(`${origin}/${encoded('https://example.com/c.svg')}?w=120`)).toBe('png');
+      expect(getImageType(`${origin}/${encoded('https://example.com/d.jpg')}?w=120`)).toBe('png');
     });
 
     it('returns unknown for an fm we cannot decode', () => {
-      expect(getImageType(`${IMGIX}/${encoded('https://example.com/e.png')}?w=120&fm=tiff`)).toBe('unknown');
+      expect(getImageType(`${origin}/${encoded('https://example.com/e.png')}?w=120&fm=tiff`)).toBe('unknown');
     });
   });
 
@@ -42,6 +46,11 @@ describe('getImageType', () => {
 
     it('ignores the query string when sniffing the extension', () => {
       expect(getImageType('https://example.com/a.png?w=120')).toBe('png');
+    });
+
+    it('includes hosts that merely look like ours, since the match is exact', () => {
+      expect(getImageType(`https://notimgix.net/${encoded('https://example.com/h.svg')}?w=120&fm=png`)).toBe('unknown');
+      expect(getImageType(`https://imgix.net.attacker.com/${encoded('https://x.com/i.svg')}?fm=png`)).toBe('unknown');
     });
   });
 

--- a/src/components/images/imageType.ts
+++ b/src/components/images/imageType.ts
@@ -1,3 +1,4 @@
+import { isImageCdnUrl } from '@/handlers/imageCdn';
 import { memoFn } from '@/utils/memoFn';
 
 const fastImageExtension = {
@@ -18,17 +19,16 @@ const pathRegex = /fm=([a-z]+)/;
 /**
  * Derives the image format a URL will return.
  *
- * For our image CDN (currently any `imgix.net` host) the path is a
- * percent-encoded source URL, so its file extension describes the source rather
- * than the response. The `fm` parameter is the only reliable signal there, and
- * png is assumed when it is absent.
+ * For our own image CDNs the path is a percent-encoded source URL, so its file
+ * extension describes the source rather than the response. The `fm` parameter
+ * is the only reliable signal there, and png is assumed when it is absent.
  *
  * Every other URL is sniffed from the file extension.
  */
 export const getImageType = memoFn((path: string): DetectedImageExtension => {
   try {
     const url = new URL(path);
-    if (url.host.includes('imgix.net')) {
+    if (isImageCdnUrl(url)) {
       const [, type = 'png'] = path.match(pathRegex) || [];
       return fastImageExtension[type as FastImageExtensions] || 'unknown';
     }

--- a/src/features/config/stores/remoteConfig.ts
+++ b/src/features/config/stores/remoteConfig.ts
@@ -41,6 +41,7 @@ export interface RainbowConfig extends Record<
   cash_kyc_review_delay_ms: number;
 
   /* Booleans */
+  image_cdn_enabled: boolean;
   f2c_enabled: boolean;
   op_rewards_enabled: boolean;
   swagg_enabled: boolean;
@@ -177,6 +178,7 @@ export const DEFAULT_CONFIG = {
   cash_kyc_review_delay_ms: time.seconds(60),
 
   /* Booleans */
+  image_cdn_enabled: false,
   f2c_enabled: true,
   op_rewards_enabled: false,
   swagg_enabled: true,

--- a/src/handlers/imageCdn.ts
+++ b/src/handlers/imageCdn.ts
@@ -1,0 +1,5 @@
+import { IMGIX_DOMAIN } from 'react-native-dotenv';
+
+export const RAINBOW_IMAGE_CDN_HOST = 'img.p.rainbow.me';
+
+export const isImageCdnUrl = (url: URL): boolean => url.hostname === IMGIX_DOMAIN || url.hostname === RAINBOW_IMAGE_CDN_HOST;

--- a/src/handlers/imgix.test.ts
+++ b/src/handlers/imgix.test.ts
@@ -1,7 +1,8 @@
-import { getSizedImageUrl, maybeSignSource, maybeSignUri, staticSignatureLRU } from './imgix';
+import { withRemoteConfig } from '@/features/config/testing/mockRemoteConfig';
 
-// The LRU keys off the options as passed, before the pixel ratio is applied.
-const cacheKey = (uri: string, w?: number, fm?: string) => `${uri}-${w}-${fm}`;
+import { getSizedImageUrl, maybeSignSource, maybeSignUri, staticSignatureLRU, withImageHost } from './imgix';
+
+jest.mock('@/features/config/stores/remoteConfig');
 
 jest.mock('react-native-dotenv', () => ({
   IMGIX_DOMAIN: 'rainbow.imgix.net',
@@ -27,6 +28,9 @@ jest.mock('@/logger', () => ({
 beforeEach(() => {
   staticSignatureLRU.clear();
 });
+
+// The LRU keys off the options as passed, before the pixel ratio is applied.
+const cacheKey = (uri: string, w?: number, fm?: string) => `${uri}-${w}-${fm}`;
 
 describe('maybeSignUri', () => {
   it('encodes the source URL into the path and signs it', () => {
@@ -120,5 +124,43 @@ describe('maybeSignSource', () => {
       headers: { a: 'b' },
       uri: 'https://rainbow.imgix.net/https%3A%2F%2Fexample.com%2Fsource.png?w=120&s=5e0397bc0858d369116917aa7c173977',
     });
+  });
+});
+
+describe('withImageHost', () => {
+  const signed = 'https://rainbow.imgix.net/https%3A%2F%2Fexample.com%2Fa.png?w=120&s=abc123';
+
+  it('leaves the URL on imgix while the flag is off', () => {
+    withRemoteConfig({ image_cdn_enabled: false }, () => {
+      expect(withImageHost(signed)).toBe(signed);
+    });
+  });
+
+  it('swaps only the host when the flag is on, leaving path, query and signature intact', () => {
+    withRemoteConfig({ image_cdn_enabled: true }, () => {
+      expect(withImageHost(signed)).toBe('https://img.p.rainbow.me/https%3A%2F%2Fexample.com%2Fa.png?w=120&s=abc123');
+    });
+  });
+
+  it('ignores URLs it did not mint', () => {
+    withRemoteConfig({ image_cdn_enabled: true }, () => {
+      expect(withImageHost('https://example.com/a.png')).toBe('https://example.com/a.png');
+      expect(withImageHost(undefined)).toBeUndefined();
+    });
+  });
+
+  it('rewrites on the way out of the cache, so a flip needs no cache invalidation', () => {
+    const source = 'https://example.com/flip.png';
+    const beforeFlip = maybeSignUri(source, { w: 40 });
+    expect(beforeFlip).toContain('https://rainbow.imgix.net/');
+
+    withRemoteConfig({ image_cdn_enabled: true }, () => {
+      expect(maybeSignUri(source, { w: 40 })).toBe(beforeFlip?.replace('https://rainbow.imgix.net/', 'https://img.p.rainbow.me/'));
+    });
+  });
+
+  it('restores the previous value after the block, without an afterEach', () => {
+    withRemoteConfig({ image_cdn_enabled: true }, () => undefined);
+    expect(withImageHost(signed)).toBe(signed);
   });
 });

--- a/src/handlers/imgix.ts
+++ b/src/handlers/imgix.ts
@@ -6,6 +6,8 @@ import { IMGIX_DOMAIN as domain, IMGIX_TOKEN as secureURLToken } from 'react-nat
 import { type Source } from 'react-native-fast-image';
 import parse from 'url-parse';
 
+import { getRemoteConfig } from '@/features/config/stores/remoteConfig';
+import { RAINBOW_IMAGE_CDN_HOST } from '@/handlers/imageCdn';
 import { logger, RainbowError } from '@/logger';
 
 export const shouldCreateImgixClient = (): ImgixClient | null => {
@@ -23,6 +25,22 @@ export const shouldCreateImgixClient = (): ImgixClient | null => {
 };
 
 const staticImgixClient = shouldCreateImgixClient();
+
+const IMGIX_PREFIX = `https://${domain}/`;
+
+/**
+ * Swaps imgix for our own CDN on an already-signed URL. The signature covers
+ * only the path and query, so it stays valid across the swap.
+ *
+ * Applied after the signature cache rather than before it, so the cache holds
+ * host-independent URLs and flipping the feature flag does not invalidate it.
+ */
+export function withImageHost(signedUri: string): string;
+export function withImageHost(signedUri: string | undefined): string | undefined;
+export function withImageHost(signedUri: string | undefined): string | undefined {
+  if (!signedUri?.startsWith(IMGIX_PREFIX) || !getRemoteConfig().image_cdn_enabled) return signedUri;
+  return `https://${RAINBOW_IMAGE_CDN_HOST}/${signedUri.slice(IMGIX_PREFIX.length)}`;
+}
 
 // Below, we use a static buffer to prevent multiple successive signing attempts
 // for components which may have been unmounted/remounted. This is done to
@@ -108,10 +126,10 @@ export const maybeSignUri = (externalImageUri: string | undefined, options?: Img
   // If the image has already been signed, return this quickly.
   const signature = `${externalImageUri}-${options?.w}-${options?.fm}`;
   if (typeof externalImageUri === 'string' && staticSignatureLRU.has(signature as string) && !skipCaching) {
-    return staticSignatureLRU.get(signature);
+    return withImageHost(staticSignatureLRU.get(signature));
   }
   if (typeof externalImageUri === 'string' && !!externalImageUri.length && isPossibleToSignUri(externalImageUri)) {
-    return shouldSignUri(externalImageUri, options);
+    return withImageHost(shouldSignUri(externalImageUri, options));
   }
   return externalImageUri;
 };


### PR DESCRIPTION
We're switching to a custom domain `img.p.rainbow.me` to front Imgix. 

This change adds an `image_cdn_enabled` remote config flag, defaulting to off:
* With it on, signed URLs get their host rewritten to our CDN on the way out
* With it off nothing changes

The proxy currently forwards everything to imgix; the reason we want to flag the flip is if there's issues with the proxy itself. Also Imgix signatures cover only the path and query, not the host, so an already-signed URL stays valid when we swap the host. That lets us move traffic over without touching the signing logic at all.

The swap deliberately happens after the signature cache rather than before it, so the cache stores host-independent URLs and flipping the flag doesn't invalidate it. Worth knowing for that emergency case: 
* NFT image URLs are baked into the persisted NFT caches at parse time, so turning the flag off takes effect immediately for newly signed URLs but cached NFT entries keep the CDN host until they refetch. Those caches survive a restart, so the first paint of NFT images on a cold launch can still hit the proxy until the refetch lands.
* Every other consumer signs at render time and recovers on the next render.

An incidental (good) effect of this change is that the image format check tightens from a substring match on `imgix.net` to an exact host comparison, which stops hosts like `imgix.net.attacker.com` from being treated as ours.

Ref APP-4028, APP-4019.
