### PR TITLE
chore: remove test-mode rendering fork from GradientText

### DIFF
--- a/src/components/text/GradientText.tsx
+++ b/src/components/text/GradientText.tsx
@@ -46,12 +46,14 @@ const GradientText = memo(function GradientText({
   const invisibleChild = useMemo(() => {
     return React.cloneElement(children, {
       style: [textStyle, children.props.style, { opacity: 0 }],
+      testID: undefined,
     });
   }, [children, textStyle]);
 
   const visibleChild = useMemo(() => {
     return React.cloneElement(children, {
       style: [textStyle, children.props.style],
+      testID: undefined,
     });
   }, [children, textStyle]);
 
@@ -60,11 +62,14 @@ const GradientText = memo(function GradientText({
     return React.cloneElement(children, {
       color: { custom: 'transparent' },
       style: [textStyle, children.props.style, shadow],
+      testID: undefined,
     });
   }, [children, shadow, textStyle]);
 
   const maskedView = (
-    <MaskedView style={shadow ? undefined : { marginTop, marginBottom }} maskElement={visibleChild}>
+    // The child is cloned into mask, gradient, and shadow layers; the id lives on this
+    // root alone so the rendered element keeps the caller's identity exactly once.
+    <MaskedView style={shadow ? undefined : { marginTop, marginBottom }} testID={children.props.testID} maskElement={visibleChild}>
       <LinearGradient
         start={start}
         end={end}

--- a/src/hooks/useSearchCurrencyList.ts
+++ b/src/hooks/useSearchCurrencyList.ts
@@ -6,7 +6,6 @@ import { rankings } from 'match-sorter';
 import { useDiscoverSearchQueryStore, useDiscoverSearchStore } from '@/__swaps__/screens/Swap/resources/search/searchV2';
 import { type SearchAsset, type TokenSearchAssetKey, type TokenSearchThreshold } from '@/__swaps__/types/search';
 import { getUniqueId } from '@/entities/assetId';
-import { IS_TEST } from '@/env';
 import { ChainId } from '@/features/network/types/backendNetworks';
 import { addHexPrefix } from '@/handlers/web3';
 import tokenSectionTypes from '@/helpers/tokenSectionTypes';
@@ -107,7 +106,7 @@ const useSearchCurrencyList = () => {
           title: i18n.t(
             i18n.l.exchange.token_sections[tokenSectionTypes.verifiedTokenSection as keyof typeof i18n.l.exchange.token_sections]
           ),
-          useGradientText: !IS_TEST,
+          useGradientText: true,
         });
       }
       if (highLiquidityAssets?.length) {
@@ -146,7 +145,7 @@ const useSearchCurrencyList = () => {
           title: i18n.t(
             i18n.l.exchange.token_sections[tokenSectionTypes.verifiedTokenSection as keyof typeof i18n.l.exchange.token_sections]
           ),
-          useGradientText: !IS_TEST,
+          useGradientText: true,
         });
       }
     }


### PR DESCRIPTION
Companion to #7791, same issue in the second wrapper. The discover token search renders its gradient section headers as plain text whenever `IS_TEST` is set, so e2e doesn't match production. The fork compensates for `GradientText` cloning its child into up to three layers (mask, gradient content, shadow), which duplicates the child's `testID` across elements instead of exposing it once.

This change puts the caller's `testID` on the one element `GradientText` actually renders, strips it from the clones, and deletes the test-mode fork. Test builds now render the production gradient headers, and we're rejoice due to two less `IS_TEST` references 🙌 

Ref APP-4084.