### PR TITLE
chore(Box): remove dead test-mode gradient override

### DIFF
--- a/src/design-system/components/Box/Box.tsx
+++ b/src/design-system/components/Box/Box.tsx
@@ -1,11 +1,9 @@
 import React, { forwardRef, useMemo, type ReactNode } from 'react';
 import { View, type StyleProp, type ViewStyle } from 'react-native';
 
-import { LinearGradient } from 'expo-linear-gradient';
 import Animated from 'react-native-reanimated';
 
 import { type BackgroundColor } from '@/design-system/color/palettes';
-import { IS_TEST } from '@/env';
 
 import { useColorMode } from '../../color/ColorMode';
 import { useForegroundColor, useForegroundColors } from '../../color/useForegroundColor';
@@ -16,8 +14,6 @@ import { BackgroundProvider } from '../BackgroundProvider/BackgroundProvider';
 import { Border, type BorderProps } from '../Border/Border';
 import { ApplyShadow } from '../private/ApplyShadow/ApplyShadow';
 import type * as Polymorphic from './polymorphic';
-
-const COMPONENTS_TO_OVERRIDE_IN_TEST_MODE = [LinearGradient];
 
 const positions = ['absolute'] as const;
 type Position = (typeof positions)[number];
@@ -194,8 +190,7 @@ export const Box = forwardRef(function Box(
   const width = typeof widthProp === 'number' ? widthProp : resolveToken(widths, widthProp);
   const height = typeof heightProp === 'number' ? heightProp : resolveToken(heights, heightProp);
 
-  const ComponentToUse = IS_TEST && COMPONENTS_TO_OVERRIDE_IN_TEST_MODE.some(_C => Component instanceof _C) ? View : Component;
-  const isView = ComponentToUse === View || ComponentToUse === Animated.View;
+  const isView = Component === View || Component === Animated.View;
 
   const shadowStylesExist =
     !!styleProp &&
@@ -302,7 +297,7 @@ export const Box = forwardRef(function Box(
         return (
           <ApplyShadow backgroundColor={backgroundColor} shadows={shadows}>
             {/* eslint-disable-next-line react/jsx-props-no-spreading */}
-            <ComponentToUse style={backgroundStyle} {...restProps} ref={ref}>
+            <Component style={backgroundStyle} {...restProps} ref={ref}>
               {children}
               {borderColor || borderWidth ? (
                 <Border
@@ -315,14 +310,14 @@ export const Box = forwardRef(function Box(
                   enableInLightMode
                 />
               ) : null}
-            </ComponentToUse>
+            </Component>
           </ApplyShadow>
         );
       }}
     </BackgroundProvider>
   ) : (
     // eslint-disable-next-line react/jsx-props-no-spreading
-    <ComponentToUse style={style} {...restProps} ref={ref}>
+    <Component style={style} {...restProps} ref={ref}>
       {children}
       {borderColor || borderWidth ? (
         <Border
@@ -335,7 +330,7 @@ export const Box = forwardRef(function Box(
           enableInLightMode
         />
       ) : null}
-    </ComponentToUse>
+    </Component>
   );
 }) as PolymorphicBox;
 


### PR DESCRIPTION
`Box` has a test-mode override meant to render `LinearGradient` as a plain `View` in e2e builds. It is a noop however: the check is `Component instanceof LinearGradient`, `expo-linear-gradient` exports a class, and every caller passes the class itself via `as={LinearGradient}`, for which `instanceof` is always false (no subclass or wrapper of it exists in the repo). So the swap never fires and e2e has been rendering real gradients all along.

This change deletes the override and the `IS_TEST` dependency it carried. No behavior change anywhere, test builds included, since the removed branch is unreachable.

 Ref APP-4084.