### PR TITLE
chore(FastCurrencySelectionRow): remove test-mode gradient swap

### DIFF
--- a/src/components/asset-list/RecyclerAssetList2/FastComponents/FastCurrencySelectionRow.tsx
+++ b/src/components/asset-list/RecyclerAssetList2/FastComponents/FastCurrencySelectionRow.tsx
@@ -7,7 +7,6 @@ import RadialGradient from 'react-native-radial-gradient';
 import RainbowCoinIcon from '@/components/coin-icon/RainbowCoinIcon';
 import ContextMenuButton from '@/components/native-context-menu/contextMenu';
 import { Text, TextIcon } from '@/design-system';
-import { IS_TEST } from '@/env';
 import { ChainId } from '@/features/network/types/backendNetworks';
 import { opacity } from '@/framework/ui/utils/opacity';
 import { isNativeAsset } from '@/handlers/assets';
@@ -16,8 +15,6 @@ import { colors, fonts, fontWithWidth, getFontSize } from '@/styles';
 import ButtonPressAnimation from '../../../animations/ButtonPressAnimation';
 import { CoinRowHeight } from '../../../coin-row';
 import { FloatingEmojis } from '../../../floating-emojis';
-
-const SafeRadialGradient = (IS_TEST ? View : RadialGradient) as typeof RadialGradient;
 
 interface FastCurrencySelectionRowProps {
   item: any;
@@ -33,7 +30,7 @@ export function FavStar({ toggleFavorite, favorite, theme }: FavStarProps) {
   const { isDarkMode, colors } = theme;
   return (
     <ButtonPressAnimation onPress={() => toggleFavorite()}>
-      <SafeRadialGradient
+      <RadialGradient
         center={[0, 15]}
         colors={
           favorite
@@ -45,7 +42,7 @@ export function FavStar({ toggleFavorite, favorite, theme }: FavStarProps) {
         <TextIcon color={{ custom: favorite ? colors.yellowFavorite : opacity(colors.blueGreyDark, 0.2) }} size="icon 13px" weight="bold">
           {'􀋃'}
         </TextIcon>
-      </SafeRadialGradient>
+      </RadialGradient>
     </ButtonPressAnimation>
   );
 }
@@ -61,11 +58,11 @@ export function Info({ contextMenuProps, showFavoriteButton, theme }: InfoProps)
   return (
     <ContextMenuButton onPressMenuItem={contextMenuProps.handlePressMenuItem} {...contextMenuProps} style={showFavoriteButton && sx.info}>
       <ButtonPressAnimation>
-        <SafeRadialGradient center={[0, 15]} colors={colors.gradients.lightestGrey} style={[sx.actionIconContainer, sx.infoIcon]}>
+        <RadialGradient center={[0, 15]} colors={colors.gradients.lightestGrey} style={[sx.actionIconContainer, sx.infoIcon]}>
           <TextIcon color={{ custom: opacity(colors.blueGreyDark, 0.3) }} size="icon 16px" weight="bold">
             {'􀅳'}
           </TextIcon>
-        </SafeRadialGradient>
+        </RadialGradient>
       </ButtonPressAnimation>
     </ContextMenuButton>
   );


### PR DESCRIPTION
`FastCurrencySelectionRow` favorite star and info icon render plain `View`s instead of their radial gradients whenever `IS_TEST` is set. The code dates to the Detox era in ([#2162](https://github.com/rainbow-me/rainbow/pull/2162), Jun 2021: "radial gradients that were slowing our e2e and were probably leading to tests timing out"), where the runner synchronized on the render loop. Maestro doesn't; it polls the accessibility tree with timeouts, so the mitigation's reason retired with the runner.

This change removes the conditional and lets the code render exactly as in prod.

Ref APP-4084.