### PR TITLE
feat(CASH): fetch credit cards on resume flow

### DIFF
--- a/src/features/cash/screens/cash-deposit-setup/steps/useAddPasskeyFlow.test.ts
+++ b/src/features/cash/screens/cash-deposit-setup/steps/useAddPasskeyFlow.test.ts
@@ -61,7 +61,7 @@ const setLinkedCard = jest.mocked(useCashPaymentMethodStore.getState().setLinked
 const TOKEN = 'bst_1';
 const OPTIONS_JSON = '{"publicKey":{"challenge":"abc"}}';
 const CREDENTIAL_JSON = '{"id":"cred-1"}';
-const RECOVERED_CARD = { id: 'card-1', brand: 'Visa', last4: '4242' };
+const LINKED_CARD = { id: 'card-1', brand: 'Visa', last4: '4242' };
 
 const flow = () => useAddPasskeyFlowStore.getState();
 const session = () => useCashSetupSessionStore.getState();
@@ -79,6 +79,12 @@ const verifyRecoverySession = () => {
   session().setDateOfBirth({ year: 1815, month: 12, day: 10 });
   session().setSsnLast4('1234');
   session().setPhoneVerified(recoveryChallenge, { bootstrapToken: TOKEN, expiresAt: Date.now() + 60_000 });
+};
+const verifyResumeSession = () => {
+  session().reset();
+  const resumeChallenge = { kind: 'resume', resumeId: 'resume-1' } as const;
+  session().setPhoneSubmitted({ challenge: resumeChallenge, phoneNationalNumber: '4155550100', resendAfter: 0 });
+  session().setPhoneVerified(resumeChallenge, { bootstrapToken: TOKEN, expiresAt: Date.now() + 60_000 });
 };
 
 beforeEach(() => {
@@ -106,6 +112,7 @@ describe('useAddPasskeyFlowStore.submit', () => {
       passkeyName: 'iPhone 15 Pro',
     });
     expect(setUserId).toHaveBeenCalledWith('user-1');
+    expect(mockListCards).not.toHaveBeenCalled();
     expect(track).toHaveBeenNthCalledWith(1, 'cash.passkey_submitted');
     expect(track).toHaveBeenNthCalledWith(2, 'cash.passkey_added');
 
@@ -165,14 +172,32 @@ describe('useAddPasskeyFlowStore.submit', () => {
 
   it('restores the recovered account card after passkey enrollment', async () => {
     verifyRecoverySession();
-    mockListCards.mockResolvedValue([RECOVERED_CARD]);
+    mockListCards.mockResolvedValue([LINKED_CARD]);
 
     await expect(flow().submit()).resolves.toBe('recovered');
 
     expect(mockListCards).toHaveBeenCalledWith({ trigger: 'recovery' });
-    expect(setLinkedCard).toHaveBeenCalledWith(RECOVERED_CARD);
+    expect(setLinkedCard).toHaveBeenCalledWith(LINKED_CARD);
     expect(setUserId).toHaveBeenCalledWith('user-1');
     expect(mockFinishAddPasskey).toHaveBeenCalledTimes(1);
+  });
+
+  it('restores the resumed account card after passkey enrollment', async () => {
+    verifyResumeSession();
+    mockListCards.mockResolvedValue([LINKED_CARD]);
+
+    await expect(flow().submit()).resolves.toBe('completed');
+
+    expect(mockListCards).toHaveBeenCalledWith({ trigger: 'resume' });
+    expect(setLinkedCard).toHaveBeenCalledWith(LINKED_CARD);
+
+    const [finishOrder] = mockFinishAddPasskey.mock.invocationCallOrder;
+    const [setUserIdOrder] = setUserId.mock.invocationCallOrder;
+    const [listCardsOrder] = mockListCards.mock.invocationCallOrder;
+    const [setLinkedCardOrder] = setLinkedCard.mock.invocationCallOrder;
+    expect(finishOrder).toBeLessThan(setUserIdOrder);
+    expect(setUserIdOrder).toBeLessThan(listCardsOrder);
+    expect(listCardsOrder).toBeLessThan(setLinkedCardOrder);
   });
 
   it('completes recovery when card restoration fails after passkey enrollment', async () => {

--- a/src/features/cash/screens/cash-deposit-setup/steps/useAddPasskeyFlow.ts
+++ b/src/features/cash/screens/cash-deposit-setup/steps/useAddPasskeyFlow.ts
@@ -43,13 +43,13 @@ export const useAddPasskeyFlowStore = createBaseStore<AddPasskeyFlowStore>((set,
       useCashAccountStore.getState().setUserId(userId);
       analytics.track(analytics.event.cashPasskeyAdded);
 
-      if (recovering) {
+      if (session.source !== 'signup') {
         try {
-          const [card] = await listCards({ trigger: 'recovery' });
+          const [card] = await listCards({ trigger: session.source });
           if (card) useCashPaymentMethodStore.getState().setLinkedCard(card);
         } catch (error) {
           if (!isPasskeyCancellation(error)) {
-            logger.error(new RainbowError('[useAddPasskeyFlow]: Failed to restore recovered account', error));
+            logger.error(new RainbowError('[useAddPasskeyFlow]: Failed to restore linked card', error));
           }
         }
       }

--- a/src/features/cash/services/cashSignInService.ts
+++ b/src/features/cash/services/cashSignInService.ts
@@ -8,7 +8,7 @@ import { US_COUNTRY_CALLING_CODE } from '../utils/phoneNumber';
 import { getPasskeyAssertion, isPasskeyCancellation } from './cashPasskeyService';
 import { finalizeAuth, finishLogin, startLogin, type StartLoginParams } from './userClient';
 
-export type CashSignInTrigger = 'cardLink' | 'addCash' | 'signInScreen' | 'recovery';
+export type CashSignInTrigger = 'cardLink' | 'addCash' | 'signInScreen' | 'recovery' | 'resume';
 
 const TOKEN_EXPIRY_MARGIN = time.seconds(30);
 


### PR DESCRIPTION
Fixed: APP-4089

## Why?

A Cash account can retain linked credit cards after an admin removes its passkey. When the user enrolls a new passkey through Signup Resume, the app currently skips card restoration and incorrectly sends the user through card setup again.

Restore linked cards after resumed setup so local payment-method state matches the existing account. Fresh Signup remains unchanged, and restoration failures do not invalidate successful passkey enrollment.

Card restoration requires an authenticated request, so the user may see a second Face ID prompt immediately after creating the new passkey. This matches existing Recovery behavior. Tracked in DES-167

## Testing

- Remove the passkey from a Cash account with a linked card through the admin tooling.
- Complete Signup Resume and enroll a new passkey.
- Complete the second Face ID prompt and verify the linked card appears in Add Cash.
- Verify a fresh Cash signup still proceeds to card setup.
