### PR TITLE
fix(CASH): treat 408 and 429 as ambiguous

### DIFF
--- a/src/features/cash/services/rampClient.ts
+++ b/src/features/cash/services/rampClient.ts
@@ -135,10 +135,10 @@ export function isNotFoundError(error: unknown): boolean {
   return error instanceof RainbowFetchError && error.response?.status === 404;
 }
 
-/** The backend answered and refused, so the request definitively took no effect. Transport failures and 5xx stay ambiguous. */
+/** The backend answered and refused, so the request definitively took no effect. Timeouts, rate limits, transport failures, and 5xx stay ambiguous. */
 export function isDefinitiveRejection(error: unknown): boolean {
   const status = error instanceof RainbowFetchError ? error.response?.status : undefined;
-  return status !== undefined && status >= 400 && status < 500;
+  return status !== undefined && status >= 400 && status < 500 && status !== 408 && status !== 429;
 }
 
 // The user JWT replaces the shared app key on these calls. On 401 the cached

--- a/src/features/cash/stores/cardRemovalFlowStore.test.ts
+++ b/src/features/cash/stores/cardRemovalFlowStore.test.ts
@@ -106,8 +106,13 @@ describe('cardRemovalFlowStore', () => {
     expect(mockListCards).not.toHaveBeenCalled();
   });
 
-  it('clears the card when reconciliation confirms an ambiguous delete succeeded', async () => {
-    mockDeleteCard.mockRejectedValue(new Error('connection lost'));
+  it.each([
+    { label: 'a transport error', failure: new Error('connection lost') },
+    { label: 'a 408', failure: fetchError(408) },
+    { label: 'a 429', failure: fetchError(429) },
+    { label: 'a 500', failure: fetchError(500) },
+  ])('clears the card when reconciliation confirms $label was an ambiguous delete that succeeded', async ({ failure }) => {
+    mockDeleteCard.mockRejectedValue(failure);
     mockListCards.mockResolvedValue([]);
 
     expect(await flow().remove(CARD)).toBe('removed');

--- a/src/features/cash/stores/cashBuyOrderStore.test.ts
+++ b/src/features/cash/stores/cashBuyOrderStore.test.ts
@@ -171,11 +171,16 @@ describe('submitBuyOrder', () => {
     expect(phase()).toBe('error');
   });
 
-  // An ambiguous failure (transport error, 5xx) leaves it unknown whether the order was created, so
+  // An ambiguous failure (transport error, 408, 429, 5xx) leaves it unknown whether the order was created, so
   // a retry with the same inputs must replay the same id — the backend then returns the existing
   // order instead of creating a second one.
-  it('replays the same order id when retrying after an ambiguous failure', async () => {
-    createBuyOrder.mockRejectedValueOnce(new Error('network down')).mockResolvedValueOnce(CREATED_PENDING_ORDER);
+  it.each([
+    { label: 'a transport error', failure: new Error('network down') },
+    { label: 'a 408', failure: fetchError(408) },
+    { label: 'a 429', failure: fetchError(429) },
+    { label: 'a 500', failure: fetchError(500) },
+  ])('replays the same order id when retrying after $label', async ({ failure }) => {
+    createBuyOrder.mockRejectedValueOnce(failure).mockResolvedValueOnce(CREATED_PENDING_ORDER);
 
     await getState().submitBuyOrder(SUBMIT_INPUT);
     await getState().submitBuyOrder(SUBMIT_INPUT);


### PR DESCRIPTION
Part of APP-4090

## Description

HTTP 408 and 429 do not prove that a write was rejected. Treating them as definitive can create a second buy order or skip card-removal reconciliation, so these responses now follow the existing ambiguous-outcome paths.
