### PR TITLE
fix(CASH): prevent backdrop dismissal during money flows

### DIFF
--- a/src/features/cash/screens/add-cash-sheet/AddCashSheet.tsx
+++ b/src/features/cash/screens/add-cash-sheet/AddCashSheet.tsx
@@ -481,6 +481,7 @@ export const AddCashSheet = memo(function AddCashSheet() {
       layoutAnimation={PANEL_LAYOUT}
       panelStyle={isKeypad ? styles.fullScreenPanel : undefined}
       showHandle={!isKeypad}
+      showTapToDismiss={!isProcessing}
     >
       <Box background="surfaceSecondary" style={isKeypad ? styles.fullScreenContent : undefined}>
         {view === 'pending' ? (

--- a/src/features/cash/screens/add-wallet-sheet/AddWalletSheet.tsx
+++ b/src/features/cash/screens/add-wallet-sheet/AddWalletSheet.tsx
@@ -102,7 +102,7 @@ export const AddWalletSheet = memo(function AddWalletSheet() {
   const isError = state === 'error';
 
   return (
-    <PanelSheet>
+    <PanelSheet showTapToDismiss={state !== 'linking' && state !== 'linked'}>
       <Box paddingBottom="20px" paddingHorizontal="20px" paddingTop="52px">
         <Stack space="32px">
           <Box paddingHorizontal="12px">


### PR DESCRIPTION
Part of APP-4090

## Description

An accidental backdrop tap can unmount a money sheet while a charge or wallet-link signature is in flight. The backdrop tap channel is now disabled only during active work; deliberate drag and back dismissal remain unchanged.

## Testing

- Submit an Add Cash order and verify tapping the backdrop does not dismiss the sheet while processing.
- Confirm Add Wallet and verify tapping the backdrop does not dismiss while linking.
- Verify deliberate dismissal remains available.
