### PR TITLE
chore(deps-check): boundary rules for the app root and feature screens

### DIFF
--- a/.dependency-cruiser.cjs
+++ b/.dependency-cruiser.cjs
@@ -105,6 +105,22 @@ const UI_RUNTIME_PACKAGES = '^node_modules/(react|react-native|react-native-rean
 
 const sourceRules = [
   {
+    name: 'nothing-imports-app',
+    severity: 'error',
+    comment:
+      'src/app/ is the composition root: it wires features, providers and navigation together for the entry point, and only the entry point (src/App.tsx) may import it. Anything else importing from app/ inverts the top of the dependency graph and couples a feature or shared module to cross-domain orchestration.',
+    from: { pathNot: '^src/(app/|App\\.tsx$)' },
+    to: { path: '^src/app/' },
+  },
+  {
+    name: 'screens-are-feature-internal',
+    severity: 'error',
+    comment:
+      "A feature's screens/ directory holds that feature's private screen internals; another feature importing from it couples itself to a screen's internal file layout. Code shared across features belongs on the owning feature's public surface (components/, utils/, types/, ...), moved there before the import. Non-feature code (navigation route tables, legacy screens) is outside this rule.",
+    from: { path: '^src/features/([^/]+)/' },
+    to: { path: '^src/features/[^/]+/screens/', pathNot: '^src/features/$1/screens/' },
+  },
+  {
     name: 'layer-core-is-a-leaf',
     severity: 'error',
     comment:

--- a/tools/deps-check/config.test.ts
+++ b/tools/deps-check/config.test.ts
@@ -30,10 +30,22 @@ function loadConfig(graph: string): Config {
 const configs = Object.fromEntries(GRAPHS.map(graph => [graph, loadConfig(graph)])) as Record<Graph, Config>;
 const ruleNames = (config: Config) => config.forbidden.map(rule => rule.name);
 
-function rule(graph: Graph, name: string): { from: RegExp; to: RegExp } {
+function rule(graph: Graph, name: string): { from: RegExp; fromPathNot: RegExp; to: RegExp; toPathNot: (fromPath: string) => RegExp } {
   const found = configs[graph].forbidden.find(r => r.name === name);
   if (!found) throw new Error(`rule ${name} is not on the ${graph} graph`);
-  return { from: new RegExp(found.from.path ?? '(?!)'), to: new RegExp(found.to.path ?? '(?!)') };
+  const from = new RegExp(found.from.path ?? '(?!)');
+  return {
+    from,
+    fromPathNot: new RegExp(found.from.pathNot ?? '(?!)'),
+    to: new RegExp(found.to.path ?? '(?!)'),
+    // dependency-cruiser substitutes the from match's capture groups into
+    // to.pathNot ($1); resolve them the same way to test the pair.
+    toPathNot(fromPath: string): RegExp {
+      const match = from.exec(fromPath);
+      if (!match) throw new Error(`from does not match ${fromPath}`);
+      return new RegExp((found?.to.pathNot ?? '(?!)').replace(/\$(\d)/g, (_, i) => match[Number(i)]));
+    },
+  };
 }
 
 describe('.dependency-cruiser.cjs', () => {
@@ -125,10 +137,7 @@ describe('.dependency-cruiser.cjs', () => {
     });
 
     describe('nothing-imports-app', () => {
-      const found = configs.source.forbidden.find(r => r.name === 'nothing-imports-app');
-      if (!found) throw new Error('rule nothing-imports-app is not on the source graph');
-      const fromPathNot = new RegExp(found.from.pathNot ?? '(?!)');
-      const to = new RegExp(found.to.path ?? '(?!)');
+      const { fromPathNot, to } = rule('source', 'nothing-imports-app');
 
       it('applies to everything except the entry point and app/ itself', () => {
         expect('src/components/TapToDismiss.tsx').not.toMatch(fromPathNot);
@@ -148,18 +157,7 @@ describe('.dependency-cruiser.cjs', () => {
     });
 
     describe('screens-are-feature-internal', () => {
-      const found = configs.source.forbidden.find(r => r.name === 'screens-are-feature-internal');
-      if (!found) throw new Error('rule screens-are-feature-internal is not on the source graph');
-      const from = new RegExp(found.from.path ?? '(?!)');
-      const to = new RegExp(found.to.path ?? '(?!)');
-
-      // dependency-cruiser substitutes the from match's capture groups into
-      // to.pathNot ($1); resolve them the same way to test the pair.
-      function toPathNot(fromPath: string): RegExp {
-        const match = from.exec(fromPath);
-        if (!match) throw new Error(`from does not match ${fromPath}`);
-        return new RegExp((found?.to.pathNot ?? '(?!)').replace(/\$(\d)/g, (_, i) => match[Number(i)]));
-      }
+      const { from, to, toPathNot } = rule('source', 'screens-are-feature-internal');
 
       it('applies to files inside a feature', () => {
         expect('src/features/discover/utils/sportsSurfaceIntent.ts').toMatch(from);

--- a/tools/deps-check/config.test.ts
+++ b/tools/deps-check/config.test.ts
@@ -1,6 +1,6 @@
 import { GRAPHS, type Graph } from './internal/cruise';
 
-type RuleConfig = { name: string; from: { path?: string }; to: { path?: string; circular?: boolean } };
+type RuleConfig = { name: string; from: { path?: string; pathNot?: string }; to: { path?: string; pathNot?: string; circular?: boolean } };
 type Config = {
   forbidden: RuleConfig[];
   options: {
@@ -121,6 +121,68 @@ describe('.dependency-cruiser.cjs', () => {
 
       it('does not classify legacy directories as layers', () => {
         expect('src/components/ui/x.tsx').not.toMatch(to);
+      });
+    });
+
+    describe('nothing-imports-app', () => {
+      const found = configs.source.forbidden.find(r => r.name === 'nothing-imports-app');
+      if (!found) throw new Error('rule nothing-imports-app is not on the source graph');
+      const fromPathNot = new RegExp(found.from.pathNot ?? '(?!)');
+      const to = new RegExp(found.to.path ?? '(?!)');
+
+      it('applies to everything except the entry point and app/ itself', () => {
+        expect('src/components/TapToDismiss.tsx').not.toMatch(fromPathNot);
+        expect('src/features/wallet/ui/x.tsx').not.toMatch(fromPathNot);
+        expect('src/App.tsx').toMatch(fromPathNot);
+        expect('src/app/navigation/DeeplinkHandler.tsx').toMatch(fromPathNot);
+      });
+
+      it('forbids imports into app/', () => {
+        expect('src/app/error-boundary/ErrorBoundary.tsx').toMatch(to);
+      });
+
+      it('does not catch paths that merely start with app', () => {
+        expect('src/application/x.ts').not.toMatch(to);
+        expect('src/Apple.tsx').not.toMatch(fromPathNot);
+      });
+    });
+
+    describe('screens-are-feature-internal', () => {
+      const found = configs.source.forbidden.find(r => r.name === 'screens-are-feature-internal');
+      if (!found) throw new Error('rule screens-are-feature-internal is not on the source graph');
+      const from = new RegExp(found.from.path ?? '(?!)');
+      const to = new RegExp(found.to.path ?? '(?!)');
+
+      // dependency-cruiser substitutes the from match's capture groups into
+      // to.pathNot ($1); resolve them the same way to test the pair.
+      function toPathNot(fromPath: string): RegExp {
+        const match = from.exec(fromPath);
+        if (!match) throw new Error(`from does not match ${fromPath}`);
+        return new RegExp((found?.to.pathNot ?? '(?!)').replace(/\$(\d)/g, (_, i) => match[Number(i)]));
+      }
+
+      it('applies to files inside a feature', () => {
+        expect('src/features/discover/utils/sportsSurfaceIntent.ts').toMatch(from);
+      });
+
+      it('does not apply to non-feature code, so route tables stay free to import screens', () => {
+        expect('src/navigation/Routes.ios.tsx').not.toMatch(from);
+        expect('src/screens/Diagnostics/index.tsx').not.toMatch(from);
+      });
+
+      it("forbids importing another feature's screens/", () => {
+        const screen = 'src/features/polymarket/screens/x/List.tsx';
+        expect(screen).toMatch(to);
+        expect(screen).not.toMatch(toPathNot('src/features/discover/utils/x.ts'));
+      });
+
+      it("allows a feature's own screens/", () => {
+        expect('src/features/polymarket/screens/x/List.tsx').toMatch(toPathNot('src/features/polymarket/hooks/x.ts'));
+      });
+
+      it("allows another feature's public surface", () => {
+        expect('src/features/polymarket/utils/x.ts').not.toMatch(to);
+        expect('src/features/rnbw-rewards/components/SpinnableCoin.tsx').not.toMatch(to);
       });
     });
 


### PR DESCRIPTION
Adds two new boundary rules to dep cruiser:
* nothing but the entry point imports the `src/app/` composition root, and 
* no feature imports another feature's `screens/` internals (the last of those were relocated in #7801)

A feature can still import its own screens and any feature's public directories, and non-feature code like the navigation route tables is deliberately out of scope. Both rules are zero-violation today, so they land strict with no baseline.