### PR TITLE
chore(dep-cruiser): disallow src/vendor importing app code

### DIFF
--- a/.dependency-cruiser.cjs
+++ b/.dependency-cruiser.cjs
@@ -121,6 +121,14 @@ const sourceRules = [
     to: { path: '^src/features/[^/]+/screens/', pathNot: '^src/features/$1/screens/' },
   },
   {
+    name: 'vendor-imports-nothing-first-party',
+    severity: 'error',
+    comment:
+      'A vendored library imports only npm packages and itself: never app code, and never another vendored library. Vendored code is a fork we intend to keep diffable against upstream; a first-party import couples the fork to our internals and makes the next upstream sync a merge instead of a diff. Anything a vendored library needs from the app comes in through its public options.',
+    from: { path: '^src/vendor/([^/]+)/' },
+    to: { path: '^src/', pathNot: '^src/vendor/$1/' },
+  },
+  {
     name: 'layer-core-is-a-leaf',
     severity: 'error',
     comment:

--- a/tools/deps-check/config.test.ts
+++ b/tools/deps-check/config.test.ts
@@ -102,6 +102,34 @@ describe('.dependency-cruiser.cjs', () => {
       expect(configs.source.options.enhancedResolveOptions?.extensions).toContain('.d.ts');
     });
 
+    describe('vendor-imports-nothing-first-party', () => {
+      const { from, to, toPathNot } = rule('source', 'vendor-imports-nothing-first-party');
+
+      it('applies to files inside a vendored library', () => {
+        expect('src/vendor/ens-avatar/src/specs/erc721.ts').toMatch(from);
+      });
+
+      it('does not apply to first-party code', () => {
+        expect('src/features/ens/utils/fetchENSImage.ts').not.toMatch(from);
+      });
+
+      it('forbids importing app code', () => {
+        const appFile = 'src/components/images/index.ts';
+        expect(appFile).toMatch(to);
+        expect(appFile).not.toMatch(toPathNot('src/vendor/ens-avatar/src/specs/erc721.ts'));
+      });
+
+      it('forbids importing another vendored library', () => {
+        const otherLib = 'src/vendor/react-native-shadow-stack/index.js';
+        expect(otherLib).toMatch(to);
+        expect(otherLib).not.toMatch(toPathNot('src/vendor/ens-avatar/src/specs/erc721.ts'));
+      });
+
+      it('allows a library to import itself', () => {
+        expect('src/vendor/ens-avatar/src/index.ts').toMatch(toPathNot('src/vendor/ens-avatar/src/specs/erc721.ts'));
+      });
+    });
+
     describe('layer-core-is-a-leaf', () => {
       const { from, to } = rule('source', 'layer-core-is-a-leaf');
 


### PR DESCRIPTION
`src/vendor` contains vendored code meant to be isolated from our codebase and easy to sync with upstream. After the recent cleanup decoupling this dir from our app, it is now 100% isolated as it should be. 

This change encodes the dependency rule that `src/vendor` cannot import anything outside its own dir except npm packages and itself so we keep it this way going forward.

Ref APP-4084.