### PR TITLE
refactor: drop app-level SharedOrDerivedValue alias for reanimated's own types

### DIFF
--- a/src/design-system/components/SkiaText/useSkiaText.ts
+++ b/src/design-system/components/SkiaText/useSkiaText.ts
@@ -11,7 +11,7 @@ import {
   type SkTextShadow,
   type SkTextStyle,
 } from '@shopify/react-native-skia';
-import { useDerivedValue } from 'react-native-reanimated';
+import { useDerivedValue, type DerivedValue, type SharedValue } from 'react-native-reanimated';
 
 import { type TextAlign } from '@/components/text/types';
 import { useColorMode } from '@/design-system/color/ColorMode';
@@ -21,9 +21,10 @@ import { type SharedOrDerivedValueText } from '@/design-system/components/Text/A
 import { type TextWeight } from '@/design-system/components/Text/Text';
 import { typeHierarchy, type TextSize } from '@/design-system/typography/typeHierarchy';
 import { opacity } from '@/framework/ui/utils/opacity';
-import { type SharedOrDerivedValue } from '@/types/reanimated';
 
 import { getSkiaFontWeight, useSkiaFontManager } from './skiaFontManager';
+
+type SharedOrDerivedValue<T> = SharedValue<T> | DerivedValue<T>;
 
 export type TextSegment = {
   backgroundPaint?: SkPaint;

--- a/src/features/charts/line/compact/types.ts
+++ b/src/features/charts/line/compact/types.ts
@@ -1,6 +1,5 @@
 import { type BaseStore } from '@storesjs/stores';
-
-import { type SharedOrDerivedValue } from '@/types/reanimated';
+import { type DerivedValue, type SharedValue } from 'react-native-reanimated';
 
 /**
  * Price points drawn by a compact line chart.
@@ -25,7 +24,7 @@ export type LineChartDataStore = {
  */
 export type SparklineChartProps<S extends LineChartDataStore> = {
   chartId: string;
-  color: string | SharedOrDerivedValue<string>;
+  color: string | SharedValue<string> | DerivedValue<string>;
   height: number;
   livePointer?: boolean;
   store: BaseStore<S>;

--- a/src/features/polymarket/components/InnerShadow.tsx
+++ b/src/features/polymarket/components/InnerShadow.tsx
@@ -2,15 +2,13 @@ import { memo, useCallback, useMemo } from 'react';
 import { StyleSheet, type LayoutChangeEvent } from 'react-native';
 
 import { Canvas, rect, RoundedRect, rrect, Shadow } from '@shopify/react-native-skia';
-import Animated, { useSharedValue } from 'react-native-reanimated';
-
-import { type SharedOrDerivedValue } from '@/types/reanimated';
+import Animated, { useSharedValue, type DerivedValue, type SharedValue } from 'react-native-reanimated';
 
 const ZERO_RECT = Object.freeze(rrect(rect(0, 0, 0, 0), 0, 0));
 
 type InnerShadowProps = {
   borderRadius?: number;
-  color: string | SharedOrDerivedValue<string>;
+  color: string | SharedValue<string> | DerivedValue<string>;
   blur: number;
   dx: number;
   dy: number;

--- a/src/types/reanimated.ts
+++ b/src/types/reanimated.ts
@@ -1,3 +1,0 @@
-import { type DerivedValue, type SharedValue } from 'react-native-reanimated';
-
-export type SharedOrDerivedValue<T> = SharedValue<T> | DerivedValue<T>;


### PR DESCRIPTION
The design system currently imports `SharedOrDerivedValue` from an app-level types module, one of the last first-party imports keeping it from depending only on npm packages and itself. The whole module is a two-line alias for `SharedValue<T> | DerivedValue<T>`.

This change inlines the union at each consumer and deletes the module. The design system keeps the name as a module-local alias since it uses it several times.

Ref APP-4084.