### PR TITLE
fix(swaps): ensure swap polling and quote updates stop after unmount

### DIFF
--- a/src/__swaps__/screens/Swap/hooks/useSwapInputsController.lifecycle.test.ts
+++ b/src/__swaps__/screens/Swap/hooks/useSwapInputsController.lifecycle.test.ts
@@ -298,7 +298,7 @@ describe('useSwapInputsController quote-owner lifecycle', () => {
     expect(mockSwapState.quote).toBeNull();
   });
 
-  it('blocks queued publication and timer resurrection after cleanup', async () => {
+  it('blocks queued publication and leaves polling stopped after cleanup', async () => {
     const pendingQuote = createDeferred<TestQuote>();
     const obsoleteQuote = createQuote();
     const currentQuote = createQuote();
@@ -316,6 +316,7 @@ describe('useSwapInputsController quote-owner lifecycle', () => {
     flushUIWork();
 
     expect(mockSwapState.quote).toBe(currentQuote);
+    // The quote work was already ahead of cleanup in the UI queue; Reanimated's later cleanup must leave its timer inactive.
     expect(getTimerClock().animationActive).toBe(false);
   });
 });

--- a/src/__swaps__/screens/Swap/hooks/useSwapInputsController.lifecycle.test.ts
+++ b/src/__swaps__/screens/Swap/hooks/useSwapInputsController.lifecycle.test.ts
@@ -1,0 +1,410 @@
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+import { useSwapInputsController } from './useSwapInputsController';
+
+type Effect = () => void | (() => void);
+
+type MutableValue<T> = {
+  value: T;
+  modify: (update: (value: T) => T) => void;
+};
+
+type MockSharedValue = MutableValue<unknown> & {
+  animationActive: boolean;
+};
+
+type TestAsset = {
+  address: string;
+  chainId: number;
+  decimals: number;
+  maxSwappableAmount: string;
+  networks: Record<number, { decimals: number }>;
+  price: { value: number };
+  uniqueId: string;
+};
+
+type TestQuote = {
+  buyAmountMinusFees: string;
+  buyTokenAsset: { price: { value: number } };
+  sellAmount: string;
+  sellTokenAsset: { price: { value: number } };
+};
+
+const mockEffectCleanups: Array<() => void> = [];
+const mockGetQuote = jest.fn<(...args: unknown[]) => Promise<TestQuote>>();
+const mockSharedValues: MockSharedValue[] = [];
+const mockTrack = jest.fn();
+const mockUIWorkQueue: Array<() => void> = [];
+const mockSwapState: { quote: TestQuote | null; slippage: string; source: string } = {
+  quote: null,
+  slippage: '0.5',
+  source: 'auto',
+};
+let mockDelayUIWork = false;
+let mockIsOnUI = false;
+
+function mockMutable<T>(value: T): MutableValue<T> {
+  return {
+    value,
+    modify(update) {
+      this.value = update(this.value);
+    },
+  };
+}
+
+function mockRegisterEffect(effect: Effect): void {
+  const cleanup = effect();
+  if (cleanup) mockEffectCleanups.push(cleanup);
+}
+
+function mockScheduleUI(work: () => void): void {
+  const runWorklet = () => {
+    const wasOnUI = mockIsOnUI;
+    mockIsOnUI = true;
+    try {
+      work();
+    } finally {
+      mockIsOnUI = wasOnUI;
+    }
+  };
+
+  if (mockDelayUIWork) {
+    mockUIWorkQueue.push(runWorklet);
+  } else {
+    runWorklet();
+  }
+}
+
+jest.mock('react', () => ({
+  useCallback: (callback: unknown) => callback,
+  useEffect: (effect: Effect) => mockRegisterEffect(effect),
+  useRef: <T>(initialValue: T) => ({ current: initialValue }),
+}));
+
+jest.mock('react-native-reanimated', () => ({
+  Easing: { linear: 'linear' },
+  runOnJS: (callback: unknown) => callback,
+  runOnUI:
+    (callback: (...args: unknown[]) => void) =>
+    (...args: unknown[]) =>
+      mockScheduleUI(() => callback(...args)),
+  useAnimatedReaction: jest.fn(),
+  useDerivedValue: (derive: () => unknown) => ({
+    get value() {
+      return derive();
+    },
+  }),
+  useSharedValue: (initialValue: unknown) => {
+    let currentValue = initialValue;
+    const setValue = (value: unknown) => {
+      currentValue = value;
+      sharedValue.animationActive = mockIsAnimation(value);
+    };
+    const sharedValue: MockSharedValue = {
+      animationActive: false,
+      get value() {
+        return currentValue;
+      },
+      set value(value: unknown) {
+        if (mockIsOnUI) setValue(value);
+        else mockScheduleUI(() => setValue(value));
+      },
+      modify(update) {
+        const applyUpdate = () => setValue(update(currentValue));
+        if (mockIsOnUI) applyUpdate();
+        else mockScheduleUI(applyUpdate);
+      },
+    };
+    mockRegisterEffect(() => () => {
+      mockScheduleUI(() => {
+        sharedValue.animationActive = false;
+      });
+    });
+    mockSharedValues.push(sharedValue);
+    return sharedValue;
+  },
+  withRepeat: (animation: unknown) => ({ __animation: 'repeat', animation }),
+  withSequence: (...animations: unknown[]) => ({ __animation: 'sequence', animations }),
+  withSpring: (value: unknown) => value,
+  withTiming: (value: unknown) => ({ __animation: 'timing', value }),
+}));
+
+jest.mock('react-native-turbo-haptics', () => ({ triggerHaptics: jest.fn() }));
+
+jest.mock('use-debounce', () => ({
+  useDebouncedCallback: (callback: unknown) => callback,
+}));
+
+jest.mock('@/__swaps__/screens/Swap/constants', () => ({
+  SCRUBBER_WIDTH: 100,
+  SLIDER_COLLAPSED_HEIGHT: 1,
+  SLIDER_HEIGHT: 1,
+  SLIDER_ROUND_THRESHOLD_END: 0.99,
+  SLIDER_ROUND_THRESHOLD_START: 0.01,
+  SLIDER_WIDTH: 100,
+  snappySpringConfig: {},
+}));
+
+jest.mock('@/__swaps__/utils/decimalFormatter', () => ({
+  valueBasedDecimalFormatter: ({ amount }: { amount: unknown }) => String(amount),
+}));
+
+jest.mock('@/__swaps__/utils/flipAssets', () => ({
+  getInputValuesForSliderPositionWorklet: () => ({
+    inputAmount: 0,
+    inputNativeValue: 0,
+    outputAmount: 0,
+    outputNativeValue: 0,
+  }),
+}));
+
+jest.mock('@/__swaps__/utils/swaps', () => ({
+  buildQuoteParams: (params: unknown) => ({ params }),
+  clamp: (value: number, minimum: number, maximum: number) => Math.min(Math.max(value, minimum), maximum),
+  getQuotePrice: () => 1,
+  trimTrailingZeros: (value: unknown) => String(value),
+}));
+
+jest.mock('@/analytics', () => ({
+  analytics: {
+    event: { swapsReceivedQuote: 'swaps.received_quote' },
+    track: (...args: unknown[]) => mockTrack(...args),
+  },
+}));
+
+jest.mock('@/components/animations/animationConfigs', () => ({
+  SPRING_CONFIGS: { sliderConfig: {} },
+}));
+
+jest.mock('@/features/currency/utils/nativeDisplay', () => ({
+  addSymbolToNativeDisplayWorklet: (value: unknown) => String(value),
+  convertAmountToNativeDisplayWorklet: (value: unknown) => String(value),
+}));
+
+jest.mock('@/framework/core/safeMath', () => ({
+  divWorklet: (left: unknown, right: unknown) => Number(left) / Number(right),
+  equalWorklet: (left: unknown, right: unknown) => Number(left) === Number(right),
+  greaterThanWorklet: (left: unknown, right: unknown) => Number(left) > Number(right),
+  isNumberStringWorklet: (value: unknown) => !Number.isNaN(Number(value)),
+  mulWorklet: (left: unknown, right: unknown) => Number(left) * Number(right),
+  toFixedWorklet: (value: unknown) => String(value),
+}));
+
+jest.mock('@/framework/ui/utils/addCommasToNumber', () => ({
+  addCommasToNumber: (value: unknown) => String(value),
+}));
+
+jest.mock('@/helpers/utilities', () => ({
+  convertRawAmountToDecimalFormat: (value: unknown) => String(value),
+  handleSignificantDecimalsWorklet: (value: unknown) => String(value),
+}));
+
+jest.mock('@/logger', () => ({ logger: { debug: jest.fn() } }));
+
+jest.mock('@/state/swaps/swapsStore', () => ({
+  swapsStore: {
+    getState: () => mockSwapState,
+    setState: (update: Partial<typeof mockSwapState>) => Object.assign(mockSwapState, update),
+  },
+}));
+
+jest.mock('@/state/wallets/walletsStore', () => ({
+  getAccountAddress: () => '0x0000000000000000000000000000000000000001',
+}));
+
+jest.mock('@rainbow-me/swaps', () => ({
+  getCrosschainQuote: jest.fn(),
+  getQuote: (...args: unknown[]) => mockGetQuote(...args),
+}));
+
+jest.mock('./analyticsTrackQuoteFailed', () => ({ analyticsTrackQuoteFailed: jest.fn() }));
+
+jest.mock('./useSwapNavigation', () => ({
+  NavigationSteps: { INPUT_ELEMENT_FOCUSED: 1 },
+}));
+
+describe('useSwapInputsController quote-owner lifecycle', () => {
+  beforeEach(() => {
+    mockDelayUIWork = false;
+    mockEffectCleanups.length = 0;
+    mockGetQuote.mockReset();
+    mockIsOnUI = false;
+    mockSharedValues.length = 0;
+    mockSwapState.quote = null;
+    mockTrack.mockClear();
+    mockUIWorkQueue.length = 0;
+  });
+
+  afterEach(() => {
+    mockDelayUIWork = false;
+    unmountController();
+    flushUIWork();
+  });
+
+  it('continues to apply and poll a quote while its owner is mounted', async () => {
+    const nextQuote = createQuote();
+    mockGetQuote.mockResolvedValue(nextQuote);
+    const mounted = createController();
+
+    mounted.controller.fetchQuote();
+    await flushPromises();
+
+    expect(mounted.quote.value).toBe(nextQuote);
+    expect(mockSwapState.quote).toBe(nextQuote);
+    expect(getTimerClock().animationActive).toBe(true);
+    expect(mockTrack).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores a pending quote and refuses later requests after its owner unmounts', async () => {
+    const pendingQuote = createDeferred<TestQuote>();
+    const currentQuote = createQuote();
+    mockGetQuote.mockReturnValue(pendingQuote.promise);
+    const obsolete = createController();
+
+    obsolete.controller.fetchQuote();
+    expect(mockGetQuote).toHaveBeenCalledTimes(1);
+
+    unmountController();
+    mockSwapState.quote = currentQuote;
+    pendingQuote.resolve(createQuote());
+    await flushPromises();
+
+    expect(obsolete.quote.value).toBeNull();
+    expect(mockSwapState.quote).toBe(currentQuote);
+    expect(getTimerClock().animationActive).toBe(false);
+    expect(mockTrack).not.toHaveBeenCalled();
+
+    obsolete.controller.fetchQuote();
+    obsolete.controller.quoteFetchingInterval.start();
+    await flushPromises();
+
+    expect(mockGetQuote).toHaveBeenCalledTimes(1);
+    expect(getTimerClock().animationActive).toBe(false);
+  });
+
+  it('does not restart polling when a pending request rejects after unmount', async () => {
+    const pendingQuote = createDeferred<TestQuote>();
+    mockGetQuote.mockReturnValue(pendingQuote.promise);
+    const obsolete = createController();
+
+    obsolete.controller.fetchQuote();
+    unmountController();
+    mockDelayUIWork = true;
+    pendingQuote.reject(new Error('request failed after dismissal'));
+    await flushPromises();
+
+    expect(mockUIWorkQueue).toHaveLength(0);
+    expect(getTimerClock().animationActive).toBe(false);
+    expect(mockSwapState.quote).toBeNull();
+  });
+
+  it('blocks queued publication and timer resurrection after cleanup', async () => {
+    const pendingQuote = createDeferred<TestQuote>();
+    const obsoleteQuote = createQuote();
+    const currentQuote = createQuote();
+    mockGetQuote.mockReturnValue(pendingQuote.promise);
+    const obsolete = createController();
+
+    obsolete.controller.fetchQuote();
+    mockDelayUIWork = true;
+    pendingQuote.resolve(obsoleteQuote);
+    await flushPromises();
+    expect(mockUIWorkQueue).toHaveLength(1);
+
+    mockSwapState.quote = currentQuote;
+    unmountController();
+    flushUIWork();
+
+    expect(mockSwapState.quote).toBe(currentQuote);
+    expect(getTimerClock().animationActive).toBe(false);
+  });
+});
+
+function createAsset(uniqueId: string, address: string): TestAsset {
+  return {
+    address,
+    chainId: 8453,
+    decimals: 18,
+    maxSwappableAmount: '10',
+    networks: { 8453: { decimals: 18 } },
+    price: { value: 1 },
+    uniqueId,
+  };
+}
+
+function createController() {
+  const inputAsset = createAsset('INPUT', '0x0000000000000000000000000000000000000001');
+  const outputAsset = createAsset('OUTPUT', '0x0000000000000000000000000000000000000002');
+  const quote = mockMutable<TestQuote | null>(null);
+  // React hooks are mocked above so the controller can be exercised without adding a renderer dependency.
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  const controller = useSwapInputsController({
+    currentCurrency: 'USD',
+    focusedInput: mockMutable('inputAmount'),
+    initialValues: {
+      focusedInput: 'inputAmount',
+      inputAmount: 1,
+      inputAsset,
+      inputMethod: 'inputAmount',
+      inputNativeValue: 1,
+      lastTypedInput: 'inputAmount',
+      outputAsset,
+      percentageToSell: 0.5,
+    },
+    inputProgress: mockMutable(1),
+    internalSelectedInputAsset: mockMutable(inputAsset),
+    internalSelectedOutputAsset: mockMutable(outputAsset),
+    isFetching: mockMutable(false),
+    isQuoteStale: mockMutable(0),
+    lastTypedInput: mockMutable('inputAmount'),
+    outputProgress: mockMutable(1),
+    quote,
+    sliderPressProgress: mockMutable(1),
+    sliderXPosition: mockMutable(50),
+  } as never);
+
+  return { controller, quote };
+}
+
+function createQuote(): TestQuote {
+  return {
+    buyAmountMinusFees: '2',
+    buyTokenAsset: { price: { value: 1 } },
+    sellAmount: '1',
+    sellTokenAsset: { price: { value: 1 } },
+  };
+}
+
+function createDeferred<T>() {
+  let reject: (reason?: unknown) => void = () => undefined;
+  let resolve: (value: T | PromiseLike<T>) => void = () => undefined;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    reject = rejectPromise;
+    resolve = resolvePromise;
+  });
+
+  return { promise, reject, resolve };
+}
+
+function flushUIWork(): void {
+  while (mockUIWorkQueue.length) mockUIWorkQueue.shift()?.();
+}
+
+function getTimerClock(): MockSharedValue {
+  const timerClock = mockSharedValues[mockSharedValues.length - 1];
+  if (!timerClock) throw new Error('Expected useAnimatedInterval to create its timer clock');
+  return timerClock;
+}
+
+async function flushPromises(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+function mockIsAnimation(value: unknown): boolean {
+  return typeof value === 'object' && value !== null && '__animation' in value;
+}
+
+function unmountController(): void {
+  mockEffectCleanups.splice(0).forEach(cleanup => cleanup());
+}

--- a/src/__swaps__/screens/Swap/hooks/useSwapInputsController.ts
+++ b/src/__swaps__/screens/Swap/hooks/useSwapInputsController.ts
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 
 import {
   runOnJS,
@@ -104,6 +104,14 @@ export function useSwapInputsController({
 }) {
   const inputValues = useSharedValue<InputValues>(applyInitialInputValues(initialValues));
   const inputMethod = useSharedValue<InputMethods>(initialValues.inputMethod || 'slider');
+  const isMounted = useRef(true);
+
+  useEffect(() => {
+    isMounted.current = true;
+    return () => {
+      isMounted.current = false;
+    };
+  }, []);
 
   const percentageToSwap = useDerivedValue(() => {
     return Math.round(clamp((sliderXPosition.value - SCRUBBER_WIDTH / SLIDER_WIDTH) / SLIDER_WIDTH, 0, 1) * 100) / 100;
@@ -224,6 +232,7 @@ export function useSwapInputsController({
   });
 
   const updateQuoteStore = useCallback((data: Quote | CrosschainQuote | QuoteError | null) => {
+    if (!isMounted.current) return;
     swapsStore.setState({ quote: data });
   }, []);
 
@@ -378,6 +387,7 @@ export function useSwapInputsController({
   );
 
   const fetchAndUpdateQuote = async ({ inputAmount, lastTypedInput: lastTypedInputParam, outputAmount }: RequestNewQuoteParams) => {
+    if (!isMounted.current) return;
     const originalInputAssetUniqueId = internalSelectedInputAsset.value?.uniqueId;
     const originalOutputAssetUniqueId = internalSelectedOutputAsset.value?.uniqueId;
 
@@ -420,6 +430,7 @@ export function useSwapInputsController({
 
     try {
       const quoteResponse = await (isCrosschainSwap ? getCrosschainQuote(params) : getQuote(params));
+      if (!isMounted.current) return;
 
       const inputAsset = internalSelectedInputAsset.value;
       const outputAsset = internalSelectedOutputAsset.value;
@@ -478,6 +489,7 @@ export function useSwapInputsController({
         });
       })();
     } catch {
+      if (!isMounted.current) return;
       runOnUI(resetFetchingStatus)({ fromError: true, quoteFetchingInterval });
     }
   };

--- a/src/hooks/reanimated/useAnimatedTime.test.ts
+++ b/src/hooks/reanimated/useAnimatedTime.test.ts
@@ -9,6 +9,7 @@ type MockAnimationState = { active: boolean };
 
 const mockEffects: Effect[] = [];
 const mockTimingCallbacks: AnimationCallback[] = [];
+const mockUIWorkQueue: Array<() => void> = [];
 let mockAnimationStates = new WeakMap<object, MockAnimationState>();
 
 jest.mock('react', () => ({
@@ -18,7 +19,7 @@ jest.mock('react', () => ({
 
 jest.mock('react-native-reanimated', () => ({
   Easing: { linear: 'linear' },
-  runOnUI: (worklet: () => void) => worklet,
+  runOnUI: (worklet: () => void) => () => mockUIWorkQueue.push(worklet),
   useSharedValue: (initialValue: unknown) => {
     let currentValue = initialValue;
     const animationState: MockAnimationState = { active: false };
@@ -32,6 +33,7 @@ jest.mock('react-native-reanimated', () => ({
       },
     };
 
+    // Reanimated's useSharedValue owns cancellation of its current animation on unmount.
     mockEffects.push(() => () => {
       animationState.active = false;
     });
@@ -52,6 +54,7 @@ describe('useAnimatedTime lifecycle', () => {
     mockAnimationStates = new WeakMap();
     mockEffects.length = 0;
     mockTimingCallbacks.length = 0;
+    mockUIWorkQueue.length = 0;
   });
 
   it('preserves start, stop, restart, and completion behavior while mounted', () => {
@@ -78,7 +81,7 @@ describe('useAnimatedTime lifecycle', () => {
     runCleanups(cleanups);
   });
 
-  it('makes retained controls and completion callbacks inert after unmount', () => {
+  it("does not revive Reanimated's canceled timer after unmount", () => {
     const onEndWorklet = jest.fn();
     const onStartWorklet = jest.fn();
     const timer = useAnimatedTime({ onEndWorklet, onStartWorklet });
@@ -100,20 +103,20 @@ describe('useAnimatedTime lifecycle', () => {
     expect(onEndWorklet).not.toHaveBeenCalled();
   });
 
-  it('restores a live auto-start timer during React Strict Mode effect replay', () => {
+  it('starts once after React Strict Mode effect replay', async () => {
     const onStartWorklet = jest.fn();
     const timer = useAnimatedTime({ autoStart: true, onStartWorklet });
     const timerClock = timer.timeInSeconds;
 
     const firstCleanups = setupEffects();
-    expect(getAnimationState(timerClock).active).toBe(true);
-
     runCleanups(firstCleanups);
-    expect(getAnimationState(timerClock).active).toBe(false);
-
     const replayCleanups = setupEffects();
+
+    await flushMicrotasks();
+    flushUIWork();
+
     expect(getAnimationState(timerClock).active).toBe(true);
-    expect(onStartWorklet).toHaveBeenCalledTimes(2);
+    expect(onStartWorklet).toHaveBeenCalledTimes(1);
 
     runCleanups(replayCleanups);
     timer.restart();
@@ -125,6 +128,14 @@ function getAnimationState(sharedValue: object): MockAnimationState {
   const animationState = mockAnimationStates.get(sharedValue);
   if (!animationState) throw new Error('Expected a mocked shared value');
   return animationState;
+}
+
+function flushUIWork(): void {
+  while (mockUIWorkQueue.length) mockUIWorkQueue.shift()?.();
+}
+
+async function flushMicrotasks(): Promise<void> {
+  await Promise.resolve();
 }
 
 function mockIsAnimation(value: unknown): boolean {

--- a/src/hooks/reanimated/useAnimatedTime.test.ts
+++ b/src/hooks/reanimated/useAnimatedTime.test.ts
@@ -1,0 +1,140 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+import { useAnimatedTime } from './useAnimatedTime';
+
+type Effect = () => void | (() => void);
+type AnimationCallback = (finished?: boolean) => void;
+
+type MockAnimationState = { active: boolean };
+
+const mockEffects: Effect[] = [];
+const mockTimingCallbacks: AnimationCallback[] = [];
+let mockAnimationStates = new WeakMap<object, MockAnimationState>();
+
+jest.mock('react', () => ({
+  useCallback: (callback: unknown) => callback,
+  useEffect: (effect: Effect) => mockEffects.push(effect),
+}));
+
+jest.mock('react-native-reanimated', () => ({
+  Easing: { linear: 'linear' },
+  runOnUI: (worklet: () => void) => worklet,
+  useSharedValue: (initialValue: unknown) => {
+    let currentValue = initialValue;
+    const animationState: MockAnimationState = { active: false };
+    const sharedValue = {
+      get value() {
+        return currentValue;
+      },
+      set value(value: unknown) {
+        currentValue = value;
+        animationState.active = mockIsAnimation(value);
+      },
+    };
+
+    mockEffects.push(() => () => {
+      animationState.active = false;
+    });
+    mockAnimationStates.set(sharedValue, animationState);
+    return sharedValue;
+  },
+  withRepeat: (animation: unknown) => ({ __animation: 'repeat', animation }),
+  withSequence: (...animations: unknown[]) => ({ __animation: 'sequence', animations }),
+  withTiming: (value: unknown, config: unknown, callback?: AnimationCallback) => {
+    void config;
+    if (callback) mockTimingCallbacks.push(callback);
+    return { __animation: 'timing', value };
+  },
+}));
+
+describe('useAnimatedTime lifecycle', () => {
+  beforeEach(() => {
+    mockAnimationStates = new WeakMap();
+    mockEffects.length = 0;
+    mockTimingCallbacks.length = 0;
+  });
+
+  it('preserves start, stop, restart, and completion behavior while mounted', () => {
+    const onEndWorklet = jest.fn();
+    const onStartWorklet = jest.fn();
+    const timer = useAnimatedTime({ onEndWorklet, onStartWorklet });
+    const cleanups = setupEffects();
+    const timerClock = timer.timeInSeconds;
+
+    timer.start();
+    expect(getAnimationState(timerClock).active).toBe(true);
+    expect(onStartWorklet).toHaveBeenCalledTimes(1);
+
+    mockTimingCallbacks[0]?.(true);
+    expect(onEndWorklet).toHaveBeenCalledTimes(1);
+
+    timer.stop();
+    expect(getAnimationState(timerClock).active).toBe(false);
+
+    timer.restart();
+    expect(getAnimationState(timerClock).active).toBe(true);
+    expect(onStartWorklet).toHaveBeenCalledTimes(2);
+
+    runCleanups(cleanups);
+  });
+
+  it('makes retained controls and completion callbacks inert after unmount', () => {
+    const onEndWorklet = jest.fn();
+    const onStartWorklet = jest.fn();
+    const timer = useAnimatedTime({ onEndWorklet, onStartWorklet });
+    const cleanups = setupEffects();
+    const timerClock = timer.timeInSeconds;
+
+    timer.start();
+    const finish = mockTimingCallbacks[0];
+    runCleanups(cleanups);
+
+    expect(getAnimationState(timerClock).active).toBe(false);
+
+    timer.start();
+    timer.restart();
+    finish?.(true);
+
+    expect(getAnimationState(timerClock).active).toBe(false);
+    expect(onStartWorklet).toHaveBeenCalledTimes(1);
+    expect(onEndWorklet).not.toHaveBeenCalled();
+  });
+
+  it('restores a live auto-start timer during React Strict Mode effect replay', () => {
+    const onStartWorklet = jest.fn();
+    const timer = useAnimatedTime({ autoStart: true, onStartWorklet });
+    const timerClock = timer.timeInSeconds;
+
+    const firstCleanups = setupEffects();
+    expect(getAnimationState(timerClock).active).toBe(true);
+
+    runCleanups(firstCleanups);
+    expect(getAnimationState(timerClock).active).toBe(false);
+
+    const replayCleanups = setupEffects();
+    expect(getAnimationState(timerClock).active).toBe(true);
+    expect(onStartWorklet).toHaveBeenCalledTimes(2);
+
+    runCleanups(replayCleanups);
+    timer.restart();
+    expect(getAnimationState(timerClock).active).toBe(false);
+  });
+});
+
+function getAnimationState(sharedValue: object): MockAnimationState {
+  const animationState = mockAnimationStates.get(sharedValue);
+  if (!animationState) throw new Error('Expected a mocked shared value');
+  return animationState;
+}
+
+function mockIsAnimation(value: unknown): boolean {
+  return typeof value === 'object' && value !== null && '__animation' in value;
+}
+
+function setupEffects(): Array<() => void> {
+  return mockEffects.map(effect => effect()).filter((cleanup): cleanup is () => void => typeof cleanup === 'function');
+}
+
+function runCleanups(cleanups: Array<() => void>): void {
+  cleanups.forEach(cleanup => cleanup());
+}

--- a/src/hooks/reanimated/useAnimatedTime.ts
+++ b/src/hooks/reanimated/useAnimatedTime.ts
@@ -1,8 +1,8 @@
 import { useCallback, useEffect } from 'react';
 
-import { Easing, useSharedValue, withRepeat, withSequence, withTiming, type SharedValue } from 'react-native-reanimated';
+import { Easing, runOnUI, useSharedValue, withRepeat, withSequence, withTiming, type DerivedValue } from 'react-native-reanimated';
 
-interface TimerConfig {
+type TimerConfig = {
   /** Whether the timer should start automatically. @default false */
   autoStart?: boolean;
   /** The duration of the timer in milliseconds. @default 1000 */
@@ -10,12 +10,12 @@ interface TimerConfig {
   /** A worklet function to be called when the timer ends. */
   onEndWorklet?: () => void;
   /** A worklet function to be called when the timer starts. */
-  onStartWorklet?: (currentTime: SharedValue<number>) => void;
+  onStartWorklet?: (currentTime: DerivedValue<number>) => void;
   /** Whether the timer should repeat after completion. @default false */
   shouldRepeat?: boolean;
-}
+};
 
-interface TimerResult {
+type TimerResult = {
   /** A worklet function that pauses the timer. */
   pause: () => void;
   /** A worklet function that restarts the timer. */
@@ -24,9 +24,9 @@ interface TimerResult {
   start: () => void;
   /** A worklet function that stops the timer. */
   stop: () => void;
-  /** A shared value representing the timer clock in seconds. */
-  timeInSeconds: SharedValue<number>;
-}
+  /** A read-only shared value representing the timer clock in seconds. */
+  timeInSeconds: DerivedValue<number>;
+};
 
 /**
  * ### useAnimatedTime
@@ -62,22 +62,27 @@ interface TimerResult {
  *   shouldRepeat: true,
  * });
  */
-export function useAnimatedTime(config: TimerConfig = {}): TimerResult {
-  const { autoStart = false, durationMs = 1000, onEndWorklet, onStartWorklet, shouldRepeat = false } = config;
-
+export function useAnimatedTime({
+  autoStart = false,
+  durationMs = 1000,
+  onEndWorklet,
+  onStartWorklet,
+  shouldRepeat = false,
+}: TimerConfig = {}): TimerResult {
+  const isDisposed = useSharedValue(false);
   const pausedAt = useSharedValue(0);
   const timeInSeconds = useSharedValue(0);
 
   const start = useCallback(() => {
     'worklet';
+    if (isDisposed.value) return;
 
     if (onStartWorklet) onStartWorklet(timeInSeconds);
 
     const repeatingTimer = withRepeat(
       withTiming(durationMs / 1000, { duration: durationMs, easing: Easing.linear }, finished => {
-        if (finished && onEndWorklet) {
-          onEndWorklet();
-        }
+        if (!finished || isDisposed.value) return;
+        if (onEndWorklet) onEndWorklet();
       }),
       shouldRepeat ? -1 : 1,
       false
@@ -95,9 +100,8 @@ export function useAnimatedTime(config: TimerConfig = {}): TimerResult {
             easing: Easing.linear,
           },
           finished => {
-            if (finished && onEndWorklet) {
-              onEndWorklet();
-            }
+            if (!finished || isDisposed.value) return;
+            if (onEndWorklet) onEndWorklet();
           }
         ),
         repeatingTimer
@@ -108,20 +112,24 @@ export function useAnimatedTime(config: TimerConfig = {}): TimerResult {
       }
       timeInSeconds.value = repeatingTimer;
     }
-  }, [durationMs, onEndWorklet, onStartWorklet, pausedAt, shouldRepeat, timeInSeconds]);
+  }, [durationMs, isDisposed, onEndWorklet, onStartWorklet, pausedAt, shouldRepeat, timeInSeconds]);
 
   const stop = useCallback(() => {
     'worklet';
+    if (isDisposed.value) return;
+
     pausedAt.value = 0;
     timeInSeconds.value = 0;
-  }, [pausedAt, timeInSeconds]);
+  }, [isDisposed, pausedAt, timeInSeconds]);
 
   const pause = useCallback(() => {
     'worklet';
+    if (isDisposed.value) return;
+
     const currentTime = timeInSeconds.value;
     pausedAt.value = currentTime;
     timeInSeconds.value = currentTime;
-  }, [pausedAt, timeInSeconds]);
+  }, [isDisposed, pausedAt, timeInSeconds]);
 
   const restart = useCallback(() => {
     'worklet';
@@ -130,9 +138,11 @@ export function useAnimatedTime(config: TimerConfig = {}): TimerResult {
   }, [start, stop]);
 
   useEffect(() => {
-    if (autoStart) {
-      start();
-    }
+    isDisposed.value = false;
+    if (autoStart) runOnUI(start)();
+    return () => {
+      isDisposed.value = true;
+    };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/src/hooks/reanimated/useAnimatedTime.ts
+++ b/src/hooks/reanimated/useAnimatedTime.ts
@@ -138,9 +138,15 @@ export function useAnimatedTime({
   }, [start, stop]);
 
   useEffect(() => {
+    let isCurrentEffect = true;
     isDisposed.value = false;
-    if (autoStart) runOnUI(start)();
+    if (autoStart) {
+      queueMicrotask(() => {
+        if (isCurrentEffect) runOnUI(start)();
+      });
+    }
     return () => {
+      isCurrentEffect = false;
       isDisposed.value = true;
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
Fixes APP-3731

## What changed (plus any additional context for devs)
- In rare cases, particularly when rapidly entering and exiting the swap flow, an old quote could continue writing quotes into the swap store
- Adds a guard in the swap quote fetcher and hardens the timer primitive to prevent post-unmount results from applying and polling from continuing
- Adds a test reproducing the issue (most of the diff)

## Screen recordings / screenshots

## What to test
