### PR TITLE
fix(swaps): improve accuracy of displayed gas estimates

### DIFF
--- a/src/__swaps__/screens/Swap/hooks/useEstimatedGasFee.ts
+++ b/src/__swaps__/screens/Swap/hooks/useEstimatedGasFee.ts
@@ -5,14 +5,14 @@ import { ChainId } from '@/features/network/types/backendNetworks';
 import { useSwapsStore } from '@/state/swaps/swapsStore';
 
 import { useSyncedSwapQuoteStore } from '../providers/SyncSwapStateAndSharedValues';
-import { useSwapEstimatedGasLimit } from './useSwapEstimatedGasLimit';
+import { useSwapFeeEstimateGasLimit } from './useSwapEstimatedGasLimit';
 
 export function useSwapEstimatedGasFee(overrideGasSettings?: GasSettings) {
   const preferredNetwork = useSwapsStore(s => s.preferredNetwork);
   const { assetToSell, quote, chainId = preferredNetwork || ChainId.mainnet } = useSyncedSwapQuoteStore();
   const gasSettings = useSelectedGas(chainId);
 
-  const estimatedGasLimit = useSwapEstimatedGasLimit({ chainId, assetToSell, quote });
+  const estimatedGasLimit = useSwapFeeEstimateGasLimit({ chainId, assetToSell, quote });
   const estimatedFee = useEstimatedGasFee({ chainId, gasLimit: estimatedGasLimit, gasSettings: overrideGasSettings || gasSettings });
 
   return estimatedFee;

--- a/src/__swaps__/screens/Swap/hooks/useSwapEstimatedGasLimit.ts
+++ b/src/__swaps__/screens/Swap/hooks/useSwapEstimatedGasLimit.ts
@@ -1,12 +1,15 @@
+import { useMemo } from 'react';
+
 import { useQuery } from '@tanstack/react-query';
 
 import { type ParsedSearchAsset } from '@/__swaps__/types/assets';
-import { gasUnits } from '@/features/gas/utils/gasUnits';
+import { isCrosschainQuote } from '@/__swaps__/utils/quotes';
+import { useBackendNetworksStore } from '@/features/network/stores/backendNetworksStore';
 import { type ChainId } from '@/features/network/types/backendNetworks';
 import { estimateUnlockAndCrosschainSwap } from '@/raps/actions/crosschainSwap';
-import { estimateUnlockAndSwap } from '@/raps/actions/swap';
+import { estimateUnlockAndSwapGasLimits } from '@/raps/actions/swap';
 import { createQueryKey, type QueryConfigWithSelect, type QueryFunctionArgs, type QueryFunctionResult } from '@/react-query';
-import { SwapType, type CrosschainQuote, type Quote, type QuoteError } from '@rainbow-me/swaps';
+import { type CrosschainQuote, type Quote, type QuoteError } from '@rainbow-me/swaps';
 
 // ///////////////////////////////////////////////
 // Query Types
@@ -26,6 +29,10 @@ const estimateSwapGasLimitQueryKey = ({ chainId, quote, assetToSell }: EstimateS
 
 type EstimateSwapGasLimitQueryKey = ReturnType<typeof estimateSwapGasLimitQueryKey>;
 
+function getDefaultSwapGasLimit(chainId: ChainId): string {
+  return useBackendNetworksStore.getState().getChainGasUnits(chainId).basic.swap;
+}
+
 // ///////////////////////////////////////////////
 // Query Function
 
@@ -33,30 +40,39 @@ async function estimateSwapGasLimitQueryFunction({
   queryKey: [{ chainId, quote, assetToSell }],
 }: QueryFunctionArgs<typeof estimateSwapGasLimitQueryKey>) {
   if (!chainId) throw 'chainId is required';
+
   if (!quote || 'error' in quote || !assetToSell) {
+    const gasLimit = getDefaultSwapGasLimit(chainId);
     return {
-      gasLimit: gasUnits.basic_swap[chainId],
+      transactionGasLimit: gasLimit,
+      feeEstimateGasLimit: gasLimit,
       chainId,
     };
   }
 
-  const gasLimit = await (quote.swapType === SwapType.crossChain
-    ? estimateUnlockAndCrosschainSwap({
-        chainId,
-        quote: quote as CrosschainQuote,
-      })
-    : estimateUnlockAndSwap({
-        chainId,
-        quote,
-      }));
+  let gasLimitEstimate;
+  if (isCrosschainQuote(quote)) {
+    const gasLimit = await estimateUnlockAndCrosschainSwap({
+      chainId,
+      quote,
+    });
+    gasLimitEstimate = { transactionGasLimit: gasLimit, feeEstimateGasLimit: gasLimit };
+  } else {
+    gasLimitEstimate = await estimateUnlockAndSwapGasLimits({
+      chainId,
+      quote,
+    });
+  }
 
-  if (!gasLimit) {
+  if (!gasLimitEstimate.transactionGasLimit || !gasLimitEstimate.feeEstimateGasLimit) {
+    const gasLimit = getDefaultSwapGasLimit(chainId);
     return {
-      gasLimit: gasUnits.basic_swap[chainId],
+      transactionGasLimit: gasLimit,
+      feeEstimateGasLimit: gasLimit,
       chainId,
     };
   }
-  return { gasLimit, chainId };
+  return { ...gasLimitEstimate, chainId };
 }
 
 type EstimateSwapGasLimitResult = QueryFunctionResult<typeof estimateSwapGasLimitQueryFunction>;
@@ -64,11 +80,19 @@ type EstimateSwapGasLimitResult = QueryFunctionResult<typeof estimateSwapGasLimi
 // ///////////////////////////////////////////////
 // Query Hook
 
-export function useSwapEstimatedGasLimit(
+function useSwapGasLimits(
   { chainId, quote, assetToSell, usePlaceholderData = true }: EstimateSwapGasLimitArgs,
   config: QueryConfigWithSelect<EstimateSwapGasLimitResult, Error, EstimateSwapGasLimitResult, EstimateSwapGasLimitQueryKey> = {}
 ) {
-  const placeholderData = chainId && usePlaceholderData ? { chainId, gasLimit: gasUnits.basic_swap[chainId] } : undefined;
+  const defaultGasLimit = chainId && usePlaceholderData ? getDefaultSwapGasLimit(chainId) : undefined;
+  const placeholderData = useMemo(
+    () =>
+      chainId && usePlaceholderData && defaultGasLimit
+        ? { chainId, transactionGasLimit: defaultGasLimit, feeEstimateGasLimit: defaultGasLimit }
+        : undefined,
+    [chainId, defaultGasLimit, usePlaceholderData]
+  );
+
   const { data } = useQuery(
     estimateSwapGasLimitQueryKey({
       chainId,
@@ -87,8 +111,20 @@ export function useSwapEstimatedGasLimit(
     }
   );
 
-  // we keepPreviousData so we can return the previous gasLimit while fetching
-  // which is great when refetching for the same chainId, but we don't want to keep the previous data
-  // when fetching for a different chainId
-  return data && data.chainId === chainId ? data.gasLimit : placeholderData?.gasLimit;
+  // Keep the previous estimate while refetching on one chain, but not after the selected chain changes.
+  return data && data.chainId === chainId ? data : placeholderData;
+}
+
+export function useSwapEstimatedGasLimit(
+  parameters: EstimateSwapGasLimitArgs,
+  config: QueryConfigWithSelect<EstimateSwapGasLimitResult, Error, EstimateSwapGasLimitResult, EstimateSwapGasLimitQueryKey> = {}
+): string | undefined {
+  return useSwapGasLimits(parameters, config)?.transactionGasLimit;
+}
+
+export function useSwapFeeEstimateGasLimit(
+  parameters: EstimateSwapGasLimitArgs,
+  config: QueryConfigWithSelect<EstimateSwapGasLimitResult, Error, EstimateSwapGasLimitResult, EstimateSwapGasLimitQueryKey> = {}
+): string | undefined {
+  return useSwapGasLimits(parameters, config)?.feeEstimateGasLimit;
 }

--- a/src/__swaps__/screens/Swap/providers/SyncSwapStateAndSharedValues.tsx
+++ b/src/__swaps__/screens/Swap/providers/SyncSwapStateAndSharedValues.tsx
@@ -8,8 +8,8 @@ import { create } from 'zustand';
 import { type ExtendedAnimatedAssetWithColors } from '@/__swaps__/types/assets';
 import { analytics } from '@/analytics';
 import { getUniqueId } from '@/entities/assetId';
-import { type GasSettings } from '@/features/gas/hooks/useCustomGas';
 import { useSelectedGas } from '@/features/gas/hooks/useSelectedGas';
+import { calculateMaxGasFeeWorklet } from '@/features/gas/utils/calculateGasFee';
 import { useBackendNetworksStore } from '@/features/network/stores/backendNetworksStore';
 import { ChainId } from '@/features/network/types/backendNetworks';
 import {
@@ -92,25 +92,6 @@ const SyncQuoteSharedValuesToState = () => {
 
   return null;
 };
-
-const isFeeNaNWorklet = (value: string | undefined) => {
-  'worklet';
-
-  return isNaN(Number(value)) || typeof value === 'undefined';
-};
-
-export function calculateGasFeeWorklet(gasSettings: GasSettings, gasLimit: string) {
-  'worklet';
-
-  if (gasSettings.isEIP1559) {
-    const maxBaseFee = isFeeNaNWorklet(gasSettings.maxBaseFee) ? '0' : gasSettings.maxBaseFee;
-    const maxPriorityFee = isFeeNaNWorklet(gasSettings.maxPriorityFee) ? '0' : gasSettings.maxPriorityFee;
-    return mulWorklet(gasLimit, sumWorklet(maxBaseFee, maxPriorityFee));
-  }
-
-  const gasPrice = isFeeNaNWorklet(gasSettings.gasPrice) ? '0' : gasSettings.gasPrice;
-  return mulWorklet(gasLimit, gasPrice);
-}
 
 export function formatUnitsWorklet(value: string, decimals: number) {
   'worklet';
@@ -265,7 +246,7 @@ function SyncGasStateToSharedValues() {
     )
       return undefined;
 
-    const gasFee = calculateGasFeeWorklet(gasSettings, estimatedGasLimit);
+    const gasFee = calculateMaxGasFeeWorklet(gasSettings, estimatedGasLimit);
     return isNaN(Number(gasFee)) ? undefined : gasFee;
   }, [estimatedGasLimit, gasSettings]);
 

--- a/src/features/gas/hooks/useEstimatedGasFee.ts
+++ b/src/features/gas/hooks/useEstimatedGasFee.ts
@@ -2,13 +2,14 @@ import { useMemo } from 'react';
 
 import { formatUnits } from 'viem';
 
-import { calculateGasFeeWorklet } from '@/__swaps__/screens/Swap/providers/SyncSwapStateAndSharedValues';
 import { convertAmountToNativeDisplayWorklet } from '@/features/currency/utils/nativeDisplay';
 import { type ChainId } from '@/features/network/types/backendNetworks';
 import { formatNumber, multiply } from '@/helpers/utilities';
 import { userAssetsStoreManager } from '@/state/assets/userAssetsStoreManager';
 import { useNativeAsset } from '@/utils/ethereumUtils';
 
+import { calculateEstimatedGasFeeWorklet } from '../utils/calculateGasFee';
+import { useBaseFee } from '../utils/meteorology';
 import { weiToGwei } from '../utils/parseGas';
 import { type GasSettings } from './useCustomGas';
 
@@ -31,11 +32,12 @@ export function useEstimatedGasFee({
 }) {
   const nativeNetworkAsset = useNativeAsset({ chainId });
   const nativeCurrency = userAssetsStoreManager(state => state.currency);
+  const { data: currentBaseFee } = useBaseFee({ chainId });
 
   return useMemo(() => {
     if (!gasLimit || !gasSettings || !nativeNetworkAsset?.price) return;
 
-    const gasFee = calculateGasFeeWorklet(gasSettings, gasLimit);
+    const gasFee = calculateEstimatedGasFeeWorklet(gasSettings, gasLimit, currentBaseFee);
     if (isNaN(Number(gasFee))) {
       return;
     }
@@ -47,5 +49,5 @@ export function useEstimatedGasFee({
     const feeInUserCurrency = multiply(networkAssetPrice, feeFormatted);
 
     return convertAmountToNativeDisplayWorklet(feeInUserCurrency, nativeCurrency, true);
-  }, [gasLimit, gasSettings, nativeCurrency, nativeNetworkAsset?.decimals, nativeNetworkAsset?.price]);
+  }, [currentBaseFee, gasLimit, gasSettings, nativeCurrency, nativeNetworkAsset?.decimals, nativeNetworkAsset?.price]);
 }

--- a/src/features/gas/utils/calculateGasFee.test.ts
+++ b/src/features/gas/utils/calculateGasFee.test.ts
@@ -23,6 +23,14 @@ describe('gas fee calculations', () => {
     expect(calculateEstimatedGasFeeWorklet(eip1559GasSettings, '100', undefined)).toBe('1200');
   });
 
+  it.each(['', ' ', 'Infinity'])('falls back to the fee cap when the current base fee is %p', currentBaseFee => {
+    expect(calculateEstimatedGasFeeWorklet(eip1559GasSettings, '100', currentBaseFee)).toBe('1200');
+  });
+
+  it.each(['', ' ', 'Infinity'])('treats an invalid selected fee value %p as zero', maxBaseFee => {
+    expect(calculateMaxGasFeeWorklet({ ...eip1559GasSettings, maxBaseFee }, '100')).toBe('200');
+  });
+
   it('uses the selected gas price for legacy transactions', () => {
     expect(calculateEstimatedGasFeeWorklet({ isEIP1559: false, gasPrice: '5' }, '100', '4')).toBe('500');
   });

--- a/src/features/gas/utils/calculateGasFee.test.ts
+++ b/src/features/gas/utils/calculateGasFee.test.ts
@@ -1,0 +1,29 @@
+import { calculateEstimatedGasFeeWorklet, calculateMaxGasFeeWorklet } from './calculateGasFee';
+
+describe('gas fee calculations', () => {
+  const eip1559GasSettings = {
+    isEIP1559: true,
+    maxBaseFee: '10',
+    maxPriorityFee: '2',
+  } as const;
+
+  it('keeps the fee cap calculation for affordability checks', () => {
+    expect(calculateMaxGasFeeWorklet(eip1559GasSettings, '100')).toBe('1200');
+  });
+
+  it('uses the current base fee for an expected EIP-1559 fee', () => {
+    expect(calculateEstimatedGasFeeWorklet(eip1559GasSettings, '100', '4')).toBe('600');
+  });
+
+  it('does not estimate above the selected fee cap', () => {
+    expect(calculateEstimatedGasFeeWorklet(eip1559GasSettings, '100', '20')).toBe('1200');
+  });
+
+  it('falls back to the fee cap when the current base fee is unavailable', () => {
+    expect(calculateEstimatedGasFeeWorklet(eip1559GasSettings, '100', undefined)).toBe('1200');
+  });
+
+  it('uses the selected gas price for legacy transactions', () => {
+    expect(calculateEstimatedGasFeeWorklet({ isEIP1559: false, gasPrice: '5' }, '100', '4')).toBe('500');
+  });
+});

--- a/src/features/gas/utils/calculateGasFee.ts
+++ b/src/features/gas/utils/calculateGasFee.ts
@@ -1,9 +1,9 @@
 import { type GasSettings } from '@/features/gas/types/gas';
-import { lessThanWorklet, mulWorklet, sumWorklet } from '@/framework/core/safeMath';
+import { isNumberStringWorklet, lessThanWorklet, mulWorklet, sumWorklet } from '@/framework/core/safeMath';
 
 function safeFeeWorklet(value: string | undefined): string {
   'worklet';
-  return typeof value === 'undefined' || isNaN(Number(value)) ? '0' : value;
+  return typeof value === 'string' && isNumberStringWorklet(value) ? value : '0';
 }
 
 function calculateEIP1559GasFeeWorklet(gasLimit: string, baseFee: string, priorityFee: string): string {
@@ -22,7 +22,7 @@ export function calculateMaxGasFeeWorklet(gasSettings: GasSettings, gasLimit: st
 
 export function calculateEstimatedGasFeeWorklet(gasSettings: GasSettings, gasLimit: string, currentBaseFee: string | undefined): string {
   'worklet';
-  if (!gasSettings.isEIP1559 || typeof currentBaseFee === 'undefined' || isNaN(Number(currentBaseFee))) {
+  if (!gasSettings.isEIP1559 || !currentBaseFee || !isNumberStringWorklet(currentBaseFee)) {
     return calculateMaxGasFeeWorklet(gasSettings, gasLimit);
   }
 

--- a/src/features/gas/utils/calculateGasFee.ts
+++ b/src/features/gas/utils/calculateGasFee.ts
@@ -1,0 +1,32 @@
+import { type GasSettings } from '@/features/gas/types/gas';
+import { lessThanWorklet, mulWorklet, sumWorklet } from '@/framework/core/safeMath';
+
+function safeFeeWorklet(value: string | undefined): string {
+  'worklet';
+  return typeof value === 'undefined' || isNaN(Number(value)) ? '0' : value;
+}
+
+function calculateEIP1559GasFeeWorklet(gasLimit: string, baseFee: string, priorityFee: string): string {
+  'worklet';
+  return mulWorklet(gasLimit, sumWorklet(baseFee, priorityFee));
+}
+
+export function calculateMaxGasFeeWorklet(gasSettings: GasSettings, gasLimit: string): string {
+  'worklet';
+  if (gasSettings.isEIP1559) {
+    return calculateEIP1559GasFeeWorklet(gasLimit, safeFeeWorklet(gasSettings.maxBaseFee), safeFeeWorklet(gasSettings.maxPriorityFee));
+  }
+
+  return mulWorklet(gasLimit, safeFeeWorklet(gasSettings.gasPrice));
+}
+
+export function calculateEstimatedGasFeeWorklet(gasSettings: GasSettings, gasLimit: string, currentBaseFee: string | undefined): string {
+  'worklet';
+  if (!gasSettings.isEIP1559 || typeof currentBaseFee === 'undefined' || isNaN(Number(currentBaseFee))) {
+    return calculateMaxGasFeeWorklet(gasSettings, gasLimit);
+  }
+
+  const maxBaseFee = safeFeeWorklet(gasSettings.maxBaseFee);
+  const estimatedBaseFee = lessThanWorklet(currentBaseFee, maxBaseFee) ? currentBaseFee : maxBaseFee;
+  return calculateEIP1559GasFeeWorklet(gasLimit, estimatedBaseFee, safeFeeWorklet(gasSettings.maxPriorityFee));
+}

--- a/src/raps/actions/crosschainSwap.ts
+++ b/src/raps/actions/crosschainSwap.ts
@@ -87,7 +87,7 @@ export const estimateCrosschainSwapGasLimit = async ({
     if (requiresApprove) {
       if (CHAIN_IDS_WITH_TRACE_SUPPORT.includes(chainId)) {
         const gasLimitWithFakeApproval = await estimateSwapGasLimitWithFakeApproval(provider, quote);
-        return gasLimitWithFakeApproval || getDefaultGasLimitForTrade(quote, chainId);
+        return gasLimitWithFakeApproval || getCrosschainSwapDefaultGasLimit(quote) || getDefaultGasLimitForTrade(quote, chainId);
       }
 
       return getCrosschainSwapDefaultGasLimit(quote) || getDefaultGasLimitForTrade(quote, chainId);

--- a/src/raps/actions/crosschainSwap.ts
+++ b/src/raps/actions/crosschainSwap.ts
@@ -86,13 +86,8 @@ export const estimateCrosschainSwapGasLimit = async ({
   try {
     if (requiresApprove) {
       if (CHAIN_IDS_WITH_TRACE_SUPPORT.includes(chainId)) {
-        try {
-          const gasLimitWithFakeApproval = await estimateSwapGasLimitWithFakeApproval(chainId, provider, quote);
-          return gasLimitWithFakeApproval;
-        } catch (e) {
-          const routeGasLimit = getCrosschainSwapDefaultGasLimit(quote);
-          if (routeGasLimit) return routeGasLimit;
-        }
+        const gasLimitWithFakeApproval = await estimateSwapGasLimitWithFakeApproval(provider, quote);
+        return gasLimitWithFakeApproval || getDefaultGasLimitForTrade(quote, chainId);
       }
 
       return getCrosschainSwapDefaultGasLimit(quote) || getDefaultGasLimitForTrade(quote, chainId);

--- a/src/raps/actions/crosschainSwap.ts
+++ b/src/raps/actions/crosschainSwap.ts
@@ -2,7 +2,6 @@ import { type Signer } from '@ethersproject/abstract-signer';
 
 import { TransactionDirection, TransactionStatus, type NewTransaction } from '@/entities/transactions';
 import { type TransactionGasParams, type TransactionLegacyGasParams } from '@/features/gas/types/gasSpeed';
-import { gasUnits } from '@/features/gas/utils/gasUnits';
 import { useBackendNetworksStore } from '@/features/network/stores/backendNetworksStore';
 import { type ChainId } from '@/features/network/types/backendNetworks';
 import { estimateGasWithPadding, getProvider, toHex } from '@/handlers/web3';
@@ -80,9 +79,6 @@ export const estimateCrosschainSwapGasLimit = async ({
   quote: CrosschainQuote;
 }): Promise<string> => {
   const provider = getProvider({ chainId });
-  if (!provider || !quote) {
-    return gasUnits.basic_swap[chainId];
-  }
   try {
     if (requiresApprove) {
       if (CHAIN_IDS_WITH_TRACE_SUPPORT.includes(chainId)) {

--- a/src/raps/actions/swap.ts
+++ b/src/raps/actions/swap.ts
@@ -10,7 +10,7 @@ import { gasUnits } from '@/features/gas/utils/gasUnits';
 import { useBackendNetworksStore } from '@/features/network/stores/backendNetworksStore';
 import { type ChainId } from '@/features/network/types/backendNetworks';
 import { estimateGasWithPadding, getProvider, toHex } from '@/handlers/web3';
-import { add } from '@/helpers/utilities';
+import { add, greaterThan } from '@/helpers/utilities';
 import { ensureError, logger, RainbowError } from '@/logger';
 import { REFERRER } from '@/references/constants';
 import { addNewTransaction } from '@/state/pendingTransactions/addNewTransaction';
@@ -38,6 +38,7 @@ import {
   estimateSwapGasLimitWithFakeApproval,
   estimateTransactionsGasLimit,
   getDefaultGasLimitForTrade,
+  getFallbackGasLimitForTrade,
   overrideWithFastSpeedIfNeeded,
   populateSwap,
   SWAP_GAS_PADDING,
@@ -50,16 +51,38 @@ const WRAPPED_NATIVE_ASSET_INTERFACE = new Interface(['function deposit() payabl
 
 type SwapExecutionResult = ReplayableExecution;
 
-export const estimateUnlockAndSwap = async ({
+type GasLimitEstimate = {
+  transactionGasLimit: string;
+  feeEstimateGasLimit: string;
+};
+
+type EstimateSwapGasLimitParameters = {
+  chainId: ChainId;
+  requiresApprove?: boolean;
+  quote: Quote;
+};
+
+function getFallbackGasLimitEstimate(quote: Quote, chainId: ChainId): GasLimitEstimate {
+  return createGasLimitEstimate(getDefaultGasLimitForTrade(quote, chainId), getFallbackGasLimitForTrade(chainId));
+}
+
+function createGasLimitEstimate(transactionGasLimit: string, feeEstimateGasLimit = transactionGasLimit): GasLimitEstimate {
+  return {
+    transactionGasLimit,
+    feeEstimateGasLimit: greaterThan(feeEstimateGasLimit, transactionGasLimit) ? transactionGasLimit : feeEstimateGasLimit,
+  };
+}
+
+export const estimateUnlockAndSwapGasLimits = async ({
   quote,
   chainId,
   requiresApprove: requiresApproveInput,
-}: Pick<RapSwapActionParameters<'swap'>, 'quote' | 'chainId' | 'requiresApprove'>) => {
+}: Pick<RapSwapActionParameters<'swap'>, 'quote' | 'chainId' | 'requiresApprove'>): Promise<GasLimitEstimate> => {
   const { from: accountAddress, sellTokenAddress, allowanceNeeded } = quote;
   const requiresApprove = requiresApproveInput ?? allowanceNeeded;
   const allowanceTargetAddress = requiresApprove ? getQuoteAllowanceTargetAddress(quote) : null;
 
-  let gasLimits: (string | number)[] = [];
+  let unlockGasLimit = '0';
 
   if (requiresApprove && allowanceTargetAddress) {
     // Try simulation-based estimation first
@@ -105,49 +128,46 @@ export const estimateUnlockAndSwap = async ({
         ],
       });
       if (gasLimitFromSimulation) {
-        return gasLimitFromSimulation;
+        return createGasLimitEstimate(gasLimitFromSimulation);
       }
     }
 
-    const unlockGasLimit = await estimateApprove({
+    unlockGasLimit = await estimateApprove({
       owner: accountAddress,
       tokenAddress: sellTokenAddress,
       spender: allowanceTargetAddress,
       chainId,
     });
-    gasLimits = gasLimits.concat(unlockGasLimit);
   }
 
-  const swapGasLimit = await estimateSwapGasLimit({
+  const swapGasLimitEstimate = await estimateSwapGasLimits({
     chainId,
     requiresApprove,
     quote,
   });
 
-  if (swapGasLimit === null || swapGasLimit === undefined || isNaN(Number(swapGasLimit))) {
-    return getDefaultGasLimitForTrade(quote, chainId);
+  if (isNaN(Number(swapGasLimitEstimate.transactionGasLimit)) || isNaN(Number(swapGasLimitEstimate.feeEstimateGasLimit))) {
+    return getFallbackGasLimitEstimate(quote, chainId);
   }
 
-  const gasLimit = gasLimits.concat(swapGasLimit).reduce((acc, limit) => add(acc, limit), '0');
-  if (isNaN(Number(gasLimit))) {
-    return getDefaultGasLimitForTrade(quote, chainId);
+  const transactionGasLimit = add(unlockGasLimit, swapGasLimitEstimate.transactionGasLimit);
+  const feeEstimateGasLimit = add(unlockGasLimit, swapGasLimitEstimate.feeEstimateGasLimit);
+
+  if (isNaN(Number(transactionGasLimit)) || isNaN(Number(feeEstimateGasLimit))) {
+    return getFallbackGasLimitEstimate(quote, chainId);
   }
 
-  return gasLimit.toString();
+  return createGasLimitEstimate(transactionGasLimit.toString(), feeEstimateGasLimit.toString());
 };
 
-export const estimateSwapGasLimit = async ({
-  chainId,
-  requiresApprove,
-  quote,
-}: {
-  chainId: ChainId;
-  requiresApprove?: boolean;
-  quote: Quote;
-}): Promise<string> => {
+export const estimateUnlockAndSwap = async (
+  parameters: Pick<RapSwapActionParameters<'swap'>, 'quote' | 'chainId' | 'requiresApprove'>
+): Promise<string> => (await estimateUnlockAndSwapGasLimits(parameters)).transactionGasLimit;
+
+const estimateSwapGasLimits = async ({ chainId, requiresApprove, quote }: EstimateSwapGasLimitParameters): Promise<GasLimitEstimate> => {
   const provider = getProvider({ chainId });
   if (!provider || !quote) {
-    return gasUnits.basic_swap[chainId];
+    return getFallbackGasLimitEstimate(quote, chainId);
   }
 
   const isWrapNativeAsset = quote.swapType === SwapType.wrap;
@@ -155,7 +175,7 @@ export const estimateSwapGasLimit = async ({
 
   // Wrap / Unwrap Eth
   if (isWrapNativeAsset || isUnwrapNativeAsset) {
-    const default_estimate = isWrapNativeAsset ? gasUnits.weth_wrap : gasUnits.weth_unwrap;
+    const defaultGasLimit = isWrapNativeAsset ? gasUnits.weth_wrap : gasUnits.weth_unwrap;
     try {
       const gasLimit = await estimateGasWithPadding(
         {
@@ -169,43 +189,44 @@ export const estimateSwapGasLimit = async ({
       );
 
       if (gasLimit === null || gasLimit === undefined || isNaN(Number(gasLimit))) {
-        return quote?.defaultGasLimit || default_estimate;
+        return createGasLimitEstimate(quote.defaultGasLimit || defaultGasLimit, defaultGasLimit);
       }
 
-      return gasLimit;
+      return createGasLimitEstimate(gasLimit);
     } catch (e) {
-      return quote?.defaultGasLimit || default_estimate;
+      return createGasLimitEstimate(quote.defaultGasLimit || defaultGasLimit, defaultGasLimit);
     }
     // Swap
+  } else if (requiresApprove) {
+    if (CHAIN_IDS_WITH_TRACE_SUPPORT.includes(chainId)) {
+      try {
+        const gasLimit = await estimateSwapGasLimitWithFakeApproval(chainId, provider, quote);
+        return createGasLimitEstimate(gasLimit);
+      } catch (e) {
+        // Fall through to the configured fallback estimate.
+      }
+    }
+
+    return getFallbackGasLimitEstimate(quote, chainId);
   } else {
     try {
       const { params, method, methodArgs } = getQuoteExecutionDetails(quote, { from: quote.from }, provider);
 
-      if (requiresApprove) {
-        if (CHAIN_IDS_WITH_TRACE_SUPPORT.includes(chainId)) {
-          try {
-            const gasLimitWithFakeApproval = await estimateSwapGasLimitWithFakeApproval(chainId, provider, quote);
-            return gasLimitWithFakeApproval;
-          } catch (e) {
-            //
-          }
-        }
-
-        return getDefaultGasLimitForTrade(quote, chainId);
-      }
-
       const gasLimit = await estimateGasWithPadding(params, method, methodArgs, provider, SWAP_GAS_PADDING);
 
       if (gasLimit === null || gasLimit === undefined || isNaN(Number(gasLimit))) {
-        return getDefaultGasLimitForTrade(quote, chainId);
+        return getFallbackGasLimitEstimate(quote, chainId);
       }
 
-      return gasLimit;
+      return createGasLimitEstimate(gasLimit);
     } catch (error) {
-      return getDefaultGasLimitForTrade(quote, chainId);
+      return getFallbackGasLimitEstimate(quote, chainId);
     }
   }
 };
+
+export const estimateSwapGasLimit = async (parameters: EstimateSwapGasLimitParameters): Promise<string> =>
+  (await estimateSwapGasLimits(parameters)).transactionGasLimit;
 
 export const executeSwap = async ({
   gasLimit,

--- a/src/raps/actions/swap.ts
+++ b/src/raps/actions/swap.ts
@@ -199,12 +199,8 @@ const estimateSwapGasLimits = async ({ chainId, requiresApprove, quote }: Estima
     // Swap
   } else if (requiresApprove) {
     if (CHAIN_IDS_WITH_TRACE_SUPPORT.includes(chainId)) {
-      try {
-        const gasLimit = await estimateSwapGasLimitWithFakeApproval(chainId, provider, quote);
-        return createGasLimitEstimate(gasLimit);
-      } catch (e) {
-        // Fall through to the configured fallback estimate.
-      }
+      const gasLimit = await estimateSwapGasLimitWithFakeApproval(provider, quote);
+      if (gasLimit) return createGasLimitEstimate(gasLimit);
     }
 
     return getFallbackGasLimitEstimate(quote, chainId);

--- a/src/raps/actions/swap.ts
+++ b/src/raps/actions/swap.ts
@@ -9,6 +9,7 @@ import { type TransactionGasParams, type TransactionLegacyGasParams } from '@/fe
 import { gasUnits } from '@/features/gas/utils/gasUnits';
 import { useBackendNetworksStore } from '@/features/network/stores/backendNetworksStore';
 import { type ChainId } from '@/features/network/types/backendNetworks';
+import { isNumberStringWorklet } from '@/framework/core/safeMath';
 import { estimateGasWithPadding, getProvider, toHex } from '@/handlers/web3';
 import { add, greaterThan } from '@/helpers/utilities';
 import { ensureError, logger, RainbowError } from '@/logger';
@@ -127,7 +128,7 @@ export const estimateUnlockAndSwapGasLimits = async ({
           },
         ],
       });
-      if (gasLimitFromSimulation) {
+      if (gasLimitFromSimulation && isNumberStringWorklet(gasLimitFromSimulation)) {
         return createGasLimitEstimate(gasLimitFromSimulation);
       }
     }
@@ -146,14 +147,17 @@ export const estimateUnlockAndSwapGasLimits = async ({
     quote,
   });
 
-  if (isNaN(Number(swapGasLimitEstimate.transactionGasLimit)) || isNaN(Number(swapGasLimitEstimate.feeEstimateGasLimit))) {
+  if (
+    !isNumberStringWorklet(swapGasLimitEstimate.transactionGasLimit) ||
+    !isNumberStringWorklet(swapGasLimitEstimate.feeEstimateGasLimit)
+  ) {
     return getFallbackGasLimitEstimate(quote, chainId);
   }
 
   const transactionGasLimit = add(unlockGasLimit, swapGasLimitEstimate.transactionGasLimit);
   const feeEstimateGasLimit = add(unlockGasLimit, swapGasLimitEstimate.feeEstimateGasLimit);
 
-  if (isNaN(Number(transactionGasLimit)) || isNaN(Number(feeEstimateGasLimit))) {
+  if (!isNumberStringWorklet(transactionGasLimit) || !isNumberStringWorklet(feeEstimateGasLimit)) {
     return getFallbackGasLimitEstimate(quote, chainId);
   }
 
@@ -188,7 +192,7 @@ const estimateSwapGasLimits = async ({ chainId, requiresApprove, quote }: Estima
         WRAP_GAS_PADDING
       );
 
-      if (gasLimit === null || gasLimit === undefined || isNaN(Number(gasLimit))) {
+      if (!gasLimit || !isNumberStringWorklet(gasLimit)) {
         return createGasLimitEstimate(quote.defaultGasLimit || defaultGasLimit, defaultGasLimit);
       }
 
@@ -210,7 +214,7 @@ const estimateSwapGasLimits = async ({ chainId, requiresApprove, quote }: Estima
 
       const gasLimit = await estimateGasWithPadding(params, method, methodArgs, provider, SWAP_GAS_PADDING);
 
-      if (gasLimit === null || gasLimit === undefined || isNaN(Number(gasLimit))) {
+      if (!gasLimit || !isNumberStringWorklet(gasLimit)) {
         return getFallbackGasLimitEstimate(quote, chainId);
       }
 

--- a/src/raps/actions/swapGasLimits.test.ts
+++ b/src/raps/actions/swapGasLimits.test.ts
@@ -87,6 +87,7 @@ describe('estimateUnlockAndSwapGasLimits', () => {
     jest.mocked(getDefaultGasLimitForTrade).mockReturnValue('2000000');
     jest.mocked(getFallbackGasLimitForTrade).mockReturnValue('525000');
     jest.mocked(estimateApprove).mockResolvedValue('55000');
+    jest.mocked(estimateSwapGasLimitWithFakeApproval).mockResolvedValue(undefined);
   });
 
   it('uses a complete simulation estimate for both execution and fee display', async () => {
@@ -100,6 +101,15 @@ describe('estimateUnlockAndSwapGasLimits', () => {
     expect(estimateApprove).not.toHaveBeenCalled();
   });
 
+  it.each([' ', 'Infinity'])('uses fallback estimates when simulation returns %p', async gasLimit => {
+    jest.mocked(estimateTransactionsGasLimit).mockResolvedValue(gasLimit);
+
+    await expect(estimateUnlockAndSwapGasLimits({ chainId: 4663, quote })).resolves.toEqual({
+      transactionGasLimit: '2055000',
+      feeEstimateGasLimit: '580000',
+    });
+  });
+
   it('keeps the quote gas cap for execution while displaying the configured fallback estimate', async () => {
     jest.mocked(estimateTransactionsGasLimit).mockResolvedValue(undefined);
 
@@ -109,13 +119,32 @@ describe('estimateUnlockAndSwapGasLimits', () => {
     });
   });
 
-  it('uses the configured fee fallback when fake-approval estimation fails', async () => {
+  it('uses a fake-approval estimate when available', async () => {
     jest.mocked(estimateTransactionsGasLimit).mockResolvedValue(undefined);
-    jest.mocked(estimateSwapGasLimitWithFakeApproval).mockResolvedValue(undefined);
+    jest.mocked(estimateSwapGasLimitWithFakeApproval).mockResolvedValue('410000');
+
+    await expect(estimateUnlockAndSwapGasLimits({ chainId: 1, quote: { ...quote, chainId: 1 } })).resolves.toEqual({
+      transactionGasLimit: '465000',
+      feeEstimateGasLimit: '465000',
+    });
+  });
+
+  it('uses the configured fee fallback when no fake-approval estimate is available', async () => {
+    jest.mocked(estimateTransactionsGasLimit).mockResolvedValue(undefined);
 
     await expect(estimateUnlockAndSwapGasLimits({ chainId: 1, quote: { ...quote, chainId: 1 } })).resolves.toEqual({
       transactionGasLimit: '2055000',
       feeEstimateGasLimit: '580000',
+    });
+  });
+
+  it('uses fallback estimates when approval estimation returns a non-finite value', async () => {
+    jest.mocked(estimateTransactionsGasLimit).mockResolvedValue(undefined);
+    jest.mocked(estimateApprove).mockResolvedValue('Infinity');
+
+    await expect(estimateUnlockAndSwapGasLimits({ chainId: 4663, quote })).resolves.toEqual({
+      transactionGasLimit: '2000000',
+      feeEstimateGasLimit: '525000',
     });
   });
 

--- a/src/raps/actions/swapGasLimits.test.ts
+++ b/src/raps/actions/swapGasLimits.test.ts
@@ -1,0 +1,115 @@
+import { StaticJsonRpcProvider } from '@ethersproject/providers';
+
+import { getProvider } from '@/handlers/web3';
+import { estimateTransactionsGasLimit, getDefaultGasLimitForTrade, getFallbackGasLimitForTrade, populateSwap } from '@/raps/utils';
+import { SwapType, type Quote } from '@rainbow-me/swaps';
+
+import { estimateUnlockAndSwapGasLimits } from './swap';
+import { estimateApprove, populateApprove } from './unlock';
+
+jest.mock('@/handlers/web3', () => ({
+  estimateGasWithPadding: jest.fn(),
+  getProvider: jest.fn(),
+  toHex: jest.fn(),
+}));
+
+jest.mock('@/state/performance/performance', () => ({
+  executeFn: jest.fn(),
+  Screens: { SWAPS: 'swaps' },
+  TimeToSignOperation: { BroadcastTransaction: 'broadcastTransaction' },
+}));
+
+jest.mock('@/state/swaps/swapsStore', () => ({
+  swapsStore: { getState: jest.fn(() => ({ degenMode: false })) },
+}));
+
+jest.mock('@/raps/utils', () => ({
+  CHAIN_IDS_WITH_TRACE_SUPPORT: [1],
+  SWAP_GAS_PADDING: 1.1,
+  estimateSwapGasLimitWithFakeApproval: jest.fn(),
+  estimateTransactionsGasLimit: jest.fn(),
+  getDefaultGasLimitForTrade: jest.fn(),
+  getFallbackGasLimitForTrade: jest.fn(),
+  overrideWithFastSpeedIfNeeded: jest.fn(),
+  populateSwap: jest.fn(),
+}));
+
+jest.mock('./unlock', () => ({
+  estimateApprove: jest.fn(),
+  populateApprove: jest.fn(),
+}));
+
+const quote: Quote = {
+  allowanceNeeded: true,
+  allowanceTarget: '0x00000000009726632680fb29d3f7a9734e3010e2',
+  buyAmount: '1',
+  buyAmountDisplay: '1',
+  buyAmountDisplayMinimum: '1',
+  buyAmountInEth: '1',
+  buyAmountMinusFees: '1',
+  buyTokenAddress: '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
+  chainId: 4663,
+  defaultGasLimit: '2000000',
+  fee: '0',
+  feeInEth: '0',
+  feePercentageBasisPoints: 0,
+  from: '0x1111111111111111111111111111111111111111',
+  sellAmount: '236400',
+  sellAmountDisplay: '0.2364',
+  sellAmountInEth: '1',
+  sellAmountMinusFees: '236400',
+  sellTokenAddress: '0x5fc5360d0400a0fd4f2af552add042d716f1d168',
+  swapType: SwapType.normal,
+  tradeAmountUSD: 0.24,
+  tradeFeeAmountUSD: 0,
+};
+
+const transaction = {
+  data: '0x1234',
+  from: quote.from,
+  to: quote.allowanceTarget,
+};
+
+const provider = new StaticJsonRpcProvider('http://127.0.0.1:8545', 4663);
+
+describe('estimateUnlockAndSwapGasLimits', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.mocked(getProvider).mockReturnValue(provider);
+    jest.mocked(populateApprove).mockResolvedValue(transaction);
+    jest.mocked(populateSwap).mockResolvedValue(transaction);
+    jest.mocked(getDefaultGasLimitForTrade).mockReturnValue('2000000');
+    jest.mocked(getFallbackGasLimitForTrade).mockReturnValue('525000');
+    jest.mocked(estimateApprove).mockResolvedValue('55000');
+  });
+
+  it('uses a complete simulation estimate for both execution and fee display', async () => {
+    jest.mocked(estimateTransactionsGasLimit).mockResolvedValue('410000');
+
+    await expect(estimateUnlockAndSwapGasLimits({ chainId: 4663, quote })).resolves.toEqual({
+      transactionGasLimit: '410000',
+      feeEstimateGasLimit: '410000',
+    });
+
+    expect(estimateApprove).not.toHaveBeenCalled();
+  });
+
+  it('keeps the quote gas cap for execution while displaying the configured fallback estimate', async () => {
+    jest.mocked(estimateTransactionsGasLimit).mockResolvedValue(undefined);
+
+    await expect(estimateUnlockAndSwapGasLimits({ chainId: 4663, quote })).resolves.toEqual({
+      transactionGasLimit: '2055000',
+      feeEstimateGasLimit: '580000',
+    });
+  });
+
+  it('never projects a fee estimate above the transaction gas limit', async () => {
+    jest.mocked(estimateTransactionsGasLimit).mockResolvedValue(undefined);
+    jest.mocked(getDefaultGasLimitForTrade).mockReturnValue('300000');
+
+    await expect(estimateUnlockAndSwapGasLimits({ chainId: 4663, quote })).resolves.toEqual({
+      transactionGasLimit: '355000',
+      feeEstimateGasLimit: '355000',
+    });
+  });
+});

--- a/src/raps/actions/swapGasLimits.test.ts
+++ b/src/raps/actions/swapGasLimits.test.ts
@@ -1,7 +1,13 @@
 import { StaticJsonRpcProvider } from '@ethersproject/providers';
 
 import { getProvider } from '@/handlers/web3';
-import { estimateTransactionsGasLimit, getDefaultGasLimitForTrade, getFallbackGasLimitForTrade, populateSwap } from '@/raps/utils';
+import {
+  estimateSwapGasLimitWithFakeApproval,
+  estimateTransactionsGasLimit,
+  getDefaultGasLimitForTrade,
+  getFallbackGasLimitForTrade,
+  populateSwap,
+} from '@/raps/utils';
 import { SwapType, type Quote } from '@rainbow-me/swaps';
 
 import { estimateUnlockAndSwapGasLimits } from './swap';
@@ -98,6 +104,16 @@ describe('estimateUnlockAndSwapGasLimits', () => {
     jest.mocked(estimateTransactionsGasLimit).mockResolvedValue(undefined);
 
     await expect(estimateUnlockAndSwapGasLimits({ chainId: 4663, quote })).resolves.toEqual({
+      transactionGasLimit: '2055000',
+      feeEstimateGasLimit: '580000',
+    });
+  });
+
+  it('uses the configured fee fallback when fake-approval estimation fails', async () => {
+    jest.mocked(estimateTransactionsGasLimit).mockResolvedValue(undefined);
+    jest.mocked(estimateSwapGasLimitWithFakeApproval).mockResolvedValue(undefined);
+
+    await expect(estimateUnlockAndSwapGasLimits({ chainId: 1, quote: { ...quote, chainId: 1 } })).resolves.toEqual({
       transactionGasLimit: '2055000',
       feeEstimateGasLimit: '580000',
     });

--- a/src/raps/utils.test.ts
+++ b/src/raps/utils.test.ts
@@ -1,0 +1,25 @@
+import { getFallbackGasLimitForTrade } from './utils';
+
+const mockGetChainGasUnits = jest.fn();
+
+jest.mock('@/features/network/stores/backendNetworksStore', () => ({
+  useBackendNetworksStore: {
+    getState: () => ({ getChainGasUnits: mockGetChainGasUnits }),
+  },
+}));
+
+jest.mock('@/handlers/web3', () => ({
+  toHexNoLeadingZeros: jest.fn(),
+}));
+
+jest.mock('@/resources/transactions/transactionSimulation', () => ({
+  simulateTransactions: jest.fn(),
+}));
+
+describe('getFallbackGasLimitForTrade', () => {
+  it('applies the existing fallback padding to the configured chain gas units', () => {
+    mockGetChainGasUnits.mockReturnValue({ basic: { swap: '350000' } });
+
+    expect(getFallbackGasLimitForTrade(4663)).toBe('525000');
+  });
+});

--- a/src/raps/utils.ts
+++ b/src/raps/utils.ts
@@ -161,10 +161,9 @@ export function getDefaultGasLimitForTrade(quote: Quote, chainId: Chain['id']): 
 }
 
 export const estimateSwapGasLimitWithFakeApproval = async (
-  chainId: number,
   provider: StaticJsonRpcProvider,
   quote: Quote | CrosschainQuote
-): Promise<string> => {
+): Promise<string | undefined> => {
   let stateDiff: unknown;
 
   try {
@@ -199,7 +198,7 @@ export const estimateSwapGasLimitWithFakeApproval = async (
   } catch (e) {
     //
   }
-  return getDefaultGasLimitForTrade(quote, chainId);
+  return undefined;
 };
 
 export const populateSwap = async ({

--- a/src/raps/utils.ts
+++ b/src/raps/utils.ts
@@ -14,6 +14,7 @@ import type {
 } from '@/features/gas/types/gas';
 import gasUtils from '@/features/gas/utils/gas';
 import { gasUnits } from '@/features/gas/utils/gasUnits';
+import { useBackendNetworksStore } from '@/features/network/stores/backendNetworksStore';
 import { ChainId } from '@/features/network/types/backendNetworks';
 import type { Transaction } from '@/graphql/__generated__/metadataPOST';
 import { toHexNoLeadingZeros } from '@/handlers/web3';
@@ -150,9 +151,14 @@ const getClosestGasEstimate = async (estimationFn: (gasEstimate: number) => Prom
   return '-1';
 };
 
-export const getDefaultGasLimitForTrade = (quote: Quote, chainId: Chain['id']): string => {
-  return quote?.defaultGasLimit || multiply(gasUnits.basic_swap[chainId], EXTRA_GAS_PADDING);
-};
+export function getFallbackGasLimitForTrade(chainId: Chain['id']): string {
+  const basicSwapGasLimit = useBackendNetworksStore.getState().getChainGasUnits(chainId).basic.swap;
+  return multiply(basicSwapGasLimit, EXTRA_GAS_PADDING);
+}
+
+export function getDefaultGasLimitForTrade(quote: Quote, chainId: Chain['id']): string {
+  return quote.defaultGasLimit || getFallbackGasLimitForTrade(chainId);
+}
 
 export const estimateSwapGasLimitWithFakeApproval = async (
   chainId: number,

--- a/src/screens/Airdrops/utils.ts
+++ b/src/screens/Airdrops/utils.ts
@@ -2,13 +2,13 @@ import { type TransactionReceipt, type TransactionRequest } from '@ethersproject
 import { type Wallet } from '@ethersproject/wallet';
 import { formatUnits, type Address } from 'viem';
 
-import { calculateGasFeeWorklet } from '@/__swaps__/screens/Swap/providers/SyncSwapStateAndSharedValues';
 import { analytics } from '@/analytics';
 import { TransactionStatus, type NewTransaction } from '@/entities/transactions';
 import { type NativeCurrencyKey } from '@/features/currency/types';
 import { convertAmountToNativeDisplayWorklet } from '@/features/currency/utils/nativeDisplay';
 import { safeBigInt } from '@/features/gas/hooks/useEstimatedGasFee';
 import { type GasSettings } from '@/features/gas/types/gas';
+import { calculateMaxGasFeeWorklet } from '@/features/gas/utils/calculateGasFee';
 import { buildGasParams, weiToGwei } from '@/features/gas/utils/parseGas';
 import { type LedgerSigner } from '@/features/hardware-wallet/utils/LedgerSigner';
 import { useBackendNetworksStore } from '@/features/network/stores/backendNetworksStore';
@@ -212,7 +212,7 @@ export async function getGasInfo({
   if (!gasLimit || gasLimit === '0') return { gasFeeDisplay: undefined, gasLimit: undefined, sufficientFundsForGas: false };
 
   const chainNativeAsset = useBackendNetworksStore.getState().getChainsNativeAsset()[chainId];
-  const gasFeeWei = calculateGasFeeWorklet(gasSettings, gasLimit);
+  const gasFeeWei = calculateMaxGasFeeWorklet(gasSettings, gasLimit);
   const gasFeeNativeToken = formatUnits(safeBigInt(gasFeeWei), chainNativeAsset.decimals);
   const userNativeAsset = userAssetsStore.getState().getNativeAssetForChain(chainId);
   const nativeAssetBalance = userNativeAsset?.balance?.amount || '0';

--- a/src/screens/claimables/transaction/context/TransactionClaimableContext.tsx
+++ b/src/screens/claimables/transaction/context/TransactionClaimableContext.tsx
@@ -4,7 +4,6 @@ import { useMutation } from '@tanstack/react-query';
 import { triggerHaptics } from 'react-native-turbo-haptics';
 import { formatUnits, getAddress } from 'viem';
 
-import { calculateGasFeeWorklet } from '@/__swaps__/screens/Swap/providers/SyncSwapStateAndSharedValues';
 import { transformRainbowTokenToParsedSearchAsset } from '@/__swaps__/utils/assets';
 import { getDefaultSlippageWorklet } from '@/__swaps__/utils/swaps';
 import { analytics } from '@/analytics';
@@ -13,6 +12,7 @@ import { convertAmountToNativeDisplay, convertAmountToNativeDisplayWorklet } fro
 import { safeBigInt } from '@/features/gas/hooks/useEstimatedGasFee';
 import { getGasSettingsBySpeed, useGasSettings } from '@/features/gas/hooks/useSelectedGas';
 import { GasSpeed } from '@/features/gas/types/gasSpeed';
+import { calculateMaxGasFeeWorklet } from '@/features/gas/utils/calculateGasFee';
 import { buildGasParams, weiToGwei } from '@/features/gas/utils/parseGas';
 import { useBackendNetworksStore } from '@/features/network/stores/backendNetworksStore';
 import { type ChainId } from '@/features/network/types/backendNetworks';
@@ -239,7 +239,7 @@ export function TransactionClaimableContextProvider({
         return;
       }
 
-      const gasFeeWei = calculateGasFeeWorklet(gasSettings, gasLimit);
+      const gasFeeWei = calculateMaxGasFeeWorklet(gasSettings, gasLimit);
 
       const nativeAsset = useBackendNetworksStore.getState().getChainsNativeAsset()[claimable.chainId];
       const userNativeAsset = userAssetsStore.getState().getNativeAssetForChain(claimable.chainId);

--- a/src/screens/token-launcher/components/PriceAndGasSync.tsx
+++ b/src/screens/token-launcher/components/PriceAndGasSync.tsx
@@ -2,10 +2,10 @@ import { memo, useEffect, useMemo } from 'react';
 
 import { formatUnits } from 'viem';
 
-import { calculateGasFeeWorklet } from '@/__swaps__/screens/Swap/providers/SyncSwapStateAndSharedValues';
 import { safeBigInt } from '@/features/gas/hooks/useEstimatedGasFee';
 import { useGasSettings } from '@/features/gas/hooks/useSelectedGas';
 import { GasSpeed } from '@/features/gas/types/gasSpeed';
+import { calculateMaxGasFeeWorklet } from '@/features/gas/utils/calculateGasFee';
 import { useBackendNetworksStore } from '@/features/network/stores/backendNetworksStore';
 import { lessThanOrEqualToWorklet } from '@/framework/core/safeMath';
 import { time } from '@/framework/core/utils/time';
@@ -35,7 +35,7 @@ function _PriceAndGasSync() {
   const chainNativeAssetRequiredForTransactionGas = useMemo(() => {
     if (!gasSettings) return '0';
 
-    const gasFeeWei = calculateGasFeeWorklet(gasSettings, TOKEN_LAUNCH_GAS_LIMIT);
+    const gasFeeWei = calculateMaxGasFeeWorklet(gasSettings, TOKEN_LAUNCH_GAS_LIMIT);
 
     return formatUnits(safeBigInt(gasFeeWei), chainNativeAsset.decimals);
   }, [chainNativeAsset, gasSettings]);

--- a/src/systems/funding/stores/createDepositGasStores.ts
+++ b/src/systems/funding/stores/createDepositGasStores.ts
@@ -1,7 +1,6 @@
 import { createDerivedStore, createQueryStore, type InferStoreState } from '@storesjs/stores';
 import { formatUnits, type Address } from 'viem';
 
-import { calculateGasFeeWorklet } from '@/__swaps__/screens/Swap/providers/SyncSwapStateAndSharedValues';
 import { isCrosschainQuote } from '@/__swaps__/utils/quotes';
 import { stripNonDecimalNumbers } from '@/__swaps__/utils/swaps';
 import { type NativeCurrencyKey } from '@/features/currency/types';
@@ -9,6 +8,7 @@ import { convertAmountToNativeDisplayWorklet } from '@/features/currency/utils/n
 import { safeBigInt } from '@/features/gas/hooks/useEstimatedGasFee';
 import { type GasSettings, type MeteorologyLegacyResponse, type MeteorologyResponse } from '@/features/gas/types/gas';
 import { GasSpeed } from '@/features/gas/types/gasSpeed';
+import { calculateMaxGasFeeWorklet } from '@/features/gas/utils/calculateGasFee';
 import { rainbowMeteorologyGetData } from '@/features/gas/utils/gasFees';
 import { gasUnits } from '@/features/gas/utils/gasUnits';
 import { isLegacyMeteorologyFeeData } from '@/features/gas/utils/meteorologyClassification';
@@ -443,7 +443,7 @@ function calculateGasFee(
 ): string | undefined {
   if (!nativeNetworkAsset?.price) return;
 
-  const gasFee = calculateGasFeeWorklet(gasSettings, gasLimit);
+  const gasFee = calculateMaxGasFeeWorklet(gasSettings, gasLimit);
   if (isNaN(Number(gasFee))) return;
 
   const nativeAssetPrice = nativeNetworkAsset.price.value?.toString();

--- a/src/systems/funding/stores/createDepositStore.ts
+++ b/src/systems/funding/stores/createDepositStore.ts
@@ -1,9 +1,9 @@
 import { createBaseStore } from '@storesjs/stores';
 
-import { calculateGasFeeWorklet } from '@/__swaps__/screens/Swap/providers/SyncSwapStateAndSharedValues';
 import { type ExtendedAnimatedAssetWithColors } from '@/__swaps__/types/assets';
 import { type GasSettings } from '@/features/gas/types/gas';
 import { type GasSpeed } from '@/features/gas/types/gasSpeed';
+import { calculateMaxGasFeeWorklet } from '@/features/gas/utils/calculateGasFee';
 import { divWorklet, greaterThanWorklet, powWorklet, subWorklet } from '@/framework/core/safeMath';
 import { isNativeAsset } from '@/handlers/assets';
 
@@ -57,7 +57,7 @@ export function computeMaxSwappableAmount(
 ): string | undefined {
   if (!asset?.balance.amount) return undefined;
 
-  const gasFee = gasSettings != null && gasLimit != null ? calculateGasFeeWorklet(gasSettings, gasLimit) : null;
+  const gasFee = gasSettings != null && gasLimit != null ? calculateMaxGasFeeWorklet(gasSettings, gasLimit) : null;
 
   if (gasFee != null && isNativeAsset(asset.address, asset.chainId)) {
     const result = subWorklet(asset.balance.amount, divWorklet(gasFee, powWorklet(10, asset.decimals)));


### PR DESCRIPTION
Fixes APP-4088

## What changed (plus any additional context for devs)

- Swap gas fees now use the current EIP-1559 base fee instead of the maximum base fee
  - Balance checks and max amount calculations still use the max possible fee
- When approve + swap simulation is unavailable, the displayed fee uses the backend-configured chain fallback while the transaction keeps the quote-provided gas limit
- Adds test coverage for fee calculations and swap gas limit fallbacks

## Screen recordings / screenshots

## What to test
