### PR TITLE
feat(CASH): Gate Add Cash screen with authentication

### DIFF
--- a/e2e/flows/cash/AddCashChips.yaml
+++ b/e2e/flows/cash/AddCashChips.yaml
@@ -16,9 +16,10 @@ tags:
       FLAG: Cash
       VALUE: 'true'
 - runFlow: ../../utils/SetCashDepositReady.yaml
-# A ready member skips the intro panel and lands straight on the Add Cash presets sheet.
+# A ready member skips the intro panel, reauthenticates, and lands on the Add Cash presets sheet.
 - tapOn:
     id: buy-button
+- runFlow: ../../utils/ReauthenticateCash.yaml
 - assertVisible:
     id: cash-deposit-add-cash-add-from
 - assertVisible:

--- a/e2e/flows/cash/AddCashCustomAmount.yaml
+++ b/e2e/flows/cash/AddCashCustomAmount.yaml
@@ -16,9 +16,10 @@ tags:
       FLAG: Cash
       VALUE: 'true'
 - runFlow: ../../utils/SetCashDepositReady.yaml
-# A ready member lands straight on the Add Cash presets sheet.
+# A ready member reauthenticates before the Add Cash presets sheet is shown.
 - tapOn:
     id: buy-button
+- runFlow: ../../utils/ReauthenticateCash.yaml
 - assertVisible:
     id: cash-deposit-add-cash-amount-more
 # Tapping the "•••" chip flips the sheet into the full-screen keypad amount entry.

--- a/e2e/flows/cash/AddCashNoCard.yaml
+++ b/e2e/flows/cash/AddCashNoCard.yaml
@@ -19,10 +19,11 @@ tags:
     file: ../../utils/SetCashAccount.yaml
     env:
       VALUE: 'true'
-# An account holder with no linked card lands on the sheet: no Add From row,
-# the action button is a plain Add Credit Card that opens Setup at the card step.
+# An account holder reauthenticates before the sheet is shown. With no linked card,
+# there is no Add From row and the action button opens Setup at the card step.
 - tapOn:
     id: buy-button
+- runFlow: ../../utils/ReauthenticateCash.yaml
 - assertVisible:
     id: cash-deposit-add-cash-add-card
 - assertNotVisible:

--- a/e2e/flows/cash/SetupRecovery.yaml
+++ b/e2e/flows/cash/SetupRecovery.yaml
@@ -85,9 +85,10 @@ tags:
     timeout: 10000
 - assertNotVisible:
     id: cash-setup-kyc-success-overlay
-# Recovery completes setup after passkey enrollment; an account with no saved card returns to Add Cash.
+# Recovery completes setup after passkey enrollment; an account with no saved card reauthenticates before Add Cash.
 - tapOn:
     id: cash-setup-next
+- runFlow: ../../utils/ReauthenticateCash.yaml
 - extendedWaitUntil:
     visible:
       id: cash-deposit-add-cash-add-card

--- a/e2e/utils/ReauthenticateCash.yaml
+++ b/e2e/utils/ReauthenticateCash.yaml
@@ -1,0 +1,12 @@
+appId: ${APP_ID}
+---
+- assertVisible:
+    id: cash-reauth-continue
+- assertNotVisible:
+    id: cash-deposit-add-cash-amount-50
+- tapOn:
+    id: cash-reauth-continue
+- extendedWaitUntil:
+    visible:
+      id: cash-deposit-add-cash-amount-50
+    timeout: 10000

--- a/src/app/navigation/TestDeeplinkHandler.tsx
+++ b/src/app/navigation/TestDeeplinkHandler.tsx
@@ -51,9 +51,9 @@ export function TestDeeplinkHandler() {
           break;
         case 'setCashLinkedCard':
           if (query.value === 'true') {
-            useCashPaymentMethodStore.getState().setLinkedCard(MOCK_LINKED_CARD);
+            useCashPaymentMethodStore.getState().addLinkedCard(MOCK_LINKED_CARD);
           } else {
-            useCashPaymentMethodStore.getState().clearLinkedCard();
+            useCashPaymentMethodStore.getState().setCards([]);
           }
           break;
         case 'sandbox-test':

--- a/src/features/cash/screens/add-cash-sheet/AddCashSheet.tsx
+++ b/src/features/cash/screens/add-cash-sheet/AddCashSheet.tsx
@@ -14,10 +14,12 @@ import { DEFAULT_HANDLE_COLOR_DARK, DEFAULT_HANDLE_COLOR_LIGHT, PanelSheet } fro
 import { Box, Inline, Text, useColorMode, useForegroundColor } from '@/design-system';
 import { opacity } from '@/design-system/utils/opacity';
 import { ORDER_FAST_POLL_DURATION_MS, ORDER_FAST_POLL_INTERVAL_MS, ORDER_SLOW_POLL_INTERVAL_MS } from '@/features/cash/constants';
+import { openCashAuthGate } from '@/features/cash/services/cashAuthGateService';
 import { isPasskeyCancellation } from '@/features/cash/services/cashPasskeyService';
 import { checkWalletLink } from '@/features/cash/services/walletLinkService';
+import { useCashAuthGateStore } from '@/features/cash/stores/cashAuthGateStore';
 import { cashBuyOrderActions, selectCashBuyPhase, useCashBuyOrderStore, useCashBuyPhase } from '@/features/cash/stores/cashBuyOrderStore';
-import { useCashLinkedCard, type LinkedCard } from '@/features/cash/stores/cashPaymentMethodStore';
+import { useCashFundingState, type CashFundingState } from '@/features/cash/stores/cashPaymentMethodStore';
 import { getTelemetryErrorReason } from '@/features/cash/utils/getTelemetryErrorReason';
 import { useRemoteConfig } from '@/features/config/stores/remoteConfig';
 import { ChainId } from '@/features/network/types/backendNetworks';
@@ -41,6 +43,7 @@ import { AddCardHint } from './AddCardHint';
 import { AddFromRow } from './AddFromRow';
 import { AmountDisplay } from './AmountDisplay';
 import { PendingOrderContent } from './PendingOrderContent';
+import { ReauthenticateContent } from './ReauthenticateContent';
 import { SettingsButton } from './SettingsButton';
 import { useAddCashAmount } from './useAddCashAmount';
 
@@ -182,14 +185,14 @@ function getActionButtonLabel(canSubmitAmount: boolean): string {
 
 function AddCashActionButton({
   canSubmitAmount,
-  hasLinkedCard,
+  funding,
   isKeypad,
   isProcessing,
   onAddCard,
   onHoldToAdd,
 }: {
   canSubmitAmount: boolean;
-  hasLinkedCard: boolean;
+  funding: CashFundingState;
   isKeypad: boolean;
   isProcessing: boolean;
   onAddCard: () => void;
@@ -204,11 +207,11 @@ function AddCashActionButton({
       paddingTop={isKeypad ? undefined : '24px'}
       style={{ paddingBottom: isKeypad ? safeAreaInsetValues.bottom + 16 : 32 }}
     >
-      {hasLinkedCard ? (
+      {funding.kind !== 'none' ? (
         <HoldToActivateButton
           backgroundColor="accent"
           color={canSubmitAmount ? 'label' : 'labelTertiary'}
-          disabled={!canSubmitAmount || isProcessing}
+          disabled={!canSubmitAmount || isProcessing || funding.kind === 'loading'}
           disabledBackgroundColor={isDarkMode ? opacity(accent, 0.1) : 'fillTertiary'}
           height={48}
           isProcessing={isProcessing}
@@ -236,8 +239,8 @@ function AddCashActionButton({
 function PresetAmountContent({
   amount,
   canSubmitAmount,
+  funding,
   isProcessing,
-  linkedCard,
   onAddCard,
   onAddFrom,
   onHoldToAdd,
@@ -247,8 +250,8 @@ function PresetAmountContent({
 }: {
   amount: AddCashAmount;
   canSubmitAmount: boolean;
+  funding: CashFundingState;
   isProcessing: boolean;
-  linkedCard: LinkedCard | null;
   onAddCard: () => void;
   onAddFrom: () => void;
   onHoldToAdd: () => void;
@@ -260,10 +263,10 @@ function PresetAmountContent({
     <>
       <AddCashHeader onSettings={onSettings} topPadding="28px" />
       <AmountPresetGrid onMore={onMore} onSelectPreset={onSelectPreset} selectedAmount={amount.selectedPresetAmount} />
-      {linkedCard ? <AddFromRow card={linkedCard} onPress={onAddFrom} /> : <AddCardHint />}
+      {funding.kind === 'none' ? <AddCardHint /> : <AddFromRow funding={funding} onPress={onAddFrom} />}
       <AddCashActionButton
         canSubmitAmount={canSubmitAmount}
-        hasLinkedCard={linkedCard != null}
+        funding={funding}
         isKeypad={false}
         isProcessing={isProcessing}
         onAddCard={onAddCard}
@@ -276,8 +279,8 @@ function PresetAmountContent({
 function KeypadAmountContent({
   amount,
   canSubmitAmount,
+  funding,
   isProcessing,
-  linkedCard,
   onAddCard,
   onAddFrom,
   onHoldToAdd,
@@ -285,8 +288,8 @@ function KeypadAmountContent({
 }: {
   amount: AddCashAmount;
   canSubmitAmount: boolean;
+  funding: CashFundingState;
   isProcessing: boolean;
-  linkedCard: LinkedCard | null;
   onAddCard: () => void;
   onAddFrom: () => void;
   onHoldToAdd: () => void;
@@ -299,13 +302,13 @@ function KeypadAmountContent({
       <Box as={Animated.View} entering={FadeIn.duration(160)} exiting={FadeOut.duration(160)} style={styles.amountArea}>
         <AmountDisplay displayedAmount={amount.displayedAmount} />
       </Box>
-      {linkedCard ? (
+      {funding.kind === 'none' ? (
+        <AddCardHint />
+      ) : (
         <>
           <KeypadFundingCaption />
-          <AddFromRow card={linkedCard} onPress={onAddFrom} />
+          <AddFromRow funding={funding} onPress={onAddFrom} />
         </>
-      ) : (
-        <AddCardHint />
       )}
       <Box as={Animated.View} entering={FadeIn.duration(160)} paddingBottom="8px" paddingTop="24px">
         <NumberPad
@@ -317,7 +320,7 @@ function KeypadAmountContent({
       </Box>
       <AddCashActionButton
         canSubmitAmount={canSubmitAmount}
-        hasLinkedCard={linkedCard != null}
+        funding={funding}
         isKeypad
         isProcessing={isProcessing}
         onAddCard={onAddCard}
@@ -328,7 +331,8 @@ function KeypadAmountContent({
 }
 
 export const AddCashSheet = memo(function AddCashSheet() {
-  const linkedCard = useCashLinkedCard();
+  const funding = useCashFundingState();
+  const openGate = useCashAuthGateStore(state => (state.status.step === 'closed' ? null : state.status));
   const [mode, setMode] = useState<AddCashMode>('presets');
   const amount = useAddCashAmount(DEFAULT_SELECTED_AMOUNT);
   const { resetKeypadAmount } = amount;
@@ -373,6 +377,14 @@ export const AddCashSheet = memo(function AddCashSheet() {
   const slowPollAt = submittedAt !== null ? submittedAt + ORDER_FAST_POLL_DURATION_MS : null;
   const isSlowPolling = useTimestampReached(slowPollAt);
 
+  // Post-paint on purpose: parking the gate in a layout effect fires before this component's store
+  // subscription attaches, and the store's snapshot cache swallows the missed update — the sheet
+  // then sits on the loading row forever. The unmount clear keeps a stale gate from flashing on reopen.
+  useEffect(() => {
+    void openCashAuthGate();
+    return () => useCashAuthGateStore.getState().clear();
+  }, []);
+
   useWatcher({
     enabled: isPolling,
     interval: isSlowPolling ? ORDER_SLOW_POLL_INTERVAL_MS : ORDER_FAST_POLL_INTERVAL_MS,
@@ -411,7 +423,7 @@ export const AddCashSheet = memo(function AddCashSheet() {
   // A deposit can only credit a wallet the Cash account has linked, so resolve that first: the token
   // it mints also authorizes the order that follows.
   const handleHoldToAdd = useCallback(async () => {
-    if (!linkedCard || walletCheckRef.current) return;
+    if (funding.kind !== 'card' || walletCheckRef.current) return;
 
     const controller = new AbortController();
     walletCheckRef.current = controller;
@@ -422,12 +434,12 @@ export const AddCashSheet = memo(function AddCashSheet() {
       if (status === 'needsLink') {
         navigation.navigate(Routes.CASH_ADD_WALLET_SHEET, {
           walletAddress: accountAddress,
-          cardId: linkedCard.id,
+          cardId: funding.card.id,
           depositAmount: amount.amount,
         });
         return;
       }
-      cashBuyOrderActions.submitBuyOrder({ cardId: linkedCard.id, depositAmount: amount.amount, walletAddress: accountAddress });
+      cashBuyOrderActions.submitBuyOrder({ cardId: funding.card.id, depositAmount: amount.amount, walletAddress: accountAddress });
     } catch (error) {
       if (controller.signal.aborted || isPasskeyCancellation(error)) return;
       logger.error(new RainbowError('[AddCashSheet]: Failed to resolve the deposit wallet', error));
@@ -442,7 +454,7 @@ export const AddCashSheet = memo(function AddCashSheet() {
       }
       setIsCheckingWallet(false);
     }
-  }, [accountAddress, amount.amount, linkedCard, navigation]);
+  }, [accountAddress, amount.amount, funding, navigation]);
 
   const handleAddCard = useCallback(() => {
     navigation.navigate(Routes.CASH_DEPOSIT_SETUP_SCREEN);
@@ -462,7 +474,7 @@ export const AddCashSheet = memo(function AddCashSheet() {
     setMode('keypad');
   }, [resetKeypadAmount]);
 
-  const view = showPendingView ? 'pending' : mode;
+  const view = showPendingView ? 'pending' : openGate ? 'reauth' : mode;
   const isKeypad = view === 'keypad';
 
   return (
@@ -477,12 +489,14 @@ export const AddCashSheet = memo(function AddCashSheet() {
       <Box background="surfaceSecondary" style={isKeypad ? styles.fullScreenContent : undefined}>
         {view === 'pending' ? (
           <PendingOrderContent onSettings={handleSettings} />
+        ) : openGate ? (
+          <ReauthenticateContent status={openGate} />
         ) : view === 'keypad' ? (
           <KeypadAmountContent
             amount={amount}
             canSubmitAmount={amount.canSubmit}
+            funding={funding}
             isProcessing={isProcessing}
-            linkedCard={linkedCard}
             onAddCard={handleAddCard}
             onAddFrom={handleAddFrom}
             onHoldToAdd={handleHoldToAdd}
@@ -492,8 +506,8 @@ export const AddCashSheet = memo(function AddCashSheet() {
           <PresetAmountContent
             amount={amount}
             canSubmitAmount={amount.canSubmit}
+            funding={funding}
             isProcessing={isProcessing}
-            linkedCard={linkedCard}
             onAddCard={handleAddCard}
             onAddFrom={handleAddFrom}
             onHoldToAdd={handleHoldToAdd}

--- a/src/features/cash/screens/add-cash-sheet/AddFromRow.tsx
+++ b/src/features/cash/screens/add-cash-sheet/AddFromRow.tsx
@@ -1,35 +1,46 @@
 import React from 'react';
 import { StyleSheet } from 'react-native';
 
+import { AnimatedSpinner } from '@/components/animations/AnimatedSpinner';
 import ButtonPressAnimation from '@/components/animations/ButtonPressAnimation';
 import { Box, Inline, Text, useForegroundColor } from '@/design-system';
 import { VisaBadge } from '@/features/cash/components/VisaBadge';
-import type { LinkedCard } from '@/features/cash/stores/cashPaymentMethodStore';
+import type { CashFundingState } from '@/features/cash/stores/cashPaymentMethodStore';
 import * as i18n from '@/languages';
 
-export function AddFromRow({ card, onPress }: { card: LinkedCard; onPress: () => void }) {
+export function AddFromRow({ funding, onPress }: { funding: Exclude<CashFundingState, { kind: 'none' }>; onPress: () => void }) {
   const separatorTertiary = useForegroundColor('separatorTertiary');
+  const labelTertiary = useForegroundColor('labelTertiary');
 
   return (
     <Box paddingTop="12px">
       <Box style={[styles.separator, { backgroundColor: separatorTertiary }]} />
-      <ButtonPressAnimation onPress={onPress} scaleTo={0.96} testID="cash-deposit-add-cash-add-from">
+      <ButtonPressAnimation
+        disabled={funding.kind === 'loading'}
+        onPress={onPress}
+        scaleTo={0.96}
+        testID={funding.kind === 'card' ? 'cash-deposit-add-cash-add-from' : undefined}
+      >
         <Box alignItems="center" flexDirection="row" justifyContent="space-between" paddingHorizontal="28px" paddingTop="20px">
           <Text color="labelQuaternary" size="17pt" weight="bold">
             {i18n.t(i18n.l.cash.add_cash_screen.add_from)}
           </Text>
-          <Inline alignVertical="center" space="8px">
-            <VisaBadge />
-            <Text color="label" size="17pt" weight="bold">
-              {card.brand}
-            </Text>
-            <Text color="labelTertiary" size="17pt" weight="semibold">
-              {`*${card.last4}`}
-            </Text>
-            <Text color="labelSecondary" size="13pt" weight="heavy">
-              {'􀆊'}
-            </Text>
-          </Inline>
+          {funding.kind === 'loading' ? (
+            <AnimatedSpinner color={labelTertiary} containerStyle={styles.spinner} isLoading size={18} />
+          ) : (
+            <Inline alignVertical="center" space="8px">
+              <VisaBadge />
+              <Text color="label" size="17pt" weight="bold">
+                {funding.card.brand}
+              </Text>
+              <Text color="labelTertiary" size="17pt" weight="semibold">
+                {`*${funding.card.last4}`}
+              </Text>
+              <Text color="labelSecondary" size="13pt" weight="heavy">
+                {'􀆊'}
+              </Text>
+            </Inline>
+          )}
         </Box>
       </ButtonPressAnimation>
     </Box>
@@ -41,5 +52,9 @@ const styles = StyleSheet.create({
     borderRadius: 1,
     height: 1,
     marginHorizontal: 28,
+  },
+  // The VisaBadge height, so the row keeps its size when the loaded card replaces the spinner.
+  spinner: {
+    height: 20,
   },
 });

--- a/src/features/cash/screens/add-cash-sheet/ReauthenticateContent.tsx
+++ b/src/features/cash/screens/add-cash-sheet/ReauthenticateContent.tsx
@@ -1,0 +1,75 @@
+import React, { useCallback, useState } from 'react';
+import { StyleSheet } from 'react-native';
+
+import Animated, { FadeIn, FadeOut } from 'react-native-reanimated';
+
+import { Box, Text } from '@/design-system';
+import { CashActionButton } from '@/features/cash/components/CashActionButton';
+import * as i18n from '@/languages';
+
+import { reauthenticateCashGate } from '../../services/cashAuthGateService';
+import type { CashAuthIntent, OpenCashAuthGateStatus } from '../../stores/cashAuthGateStore';
+
+const l = i18n.l.cash.add_cash_screen;
+
+const KEY_ICON = '􀟖';
+
+type GatePrompt = { action: string; description: string; title: string };
+
+const PROMPT_BY_INTENT: Record<CashAuthIntent['kind'], Record<OpenCashAuthGateStatus['step'], GatePrompt>> = {
+  loadCards: {
+    authRequired: { action: l.reauth_continue, description: l.reauth_description, title: l.reauth_title },
+    error: { action: l.reauth_try_again, description: l.reauth_error_description, title: l.reauth_error_title },
+  },
+};
+
+const TEST_ID_BY_STEP: Record<OpenCashAuthGateStatus['step'], string> = {
+  authRequired: 'cash-reauth-continue',
+  error: 'cash-reauth-try-again',
+};
+
+export function ReauthenticateContent({ status }: { status: OpenCashAuthGateStatus }) {
+  const [submitting, setSubmitting] = useState(false);
+
+  const handleContinue = useCallback(async () => {
+    setSubmitting(true);
+    try {
+      await reauthenticateCashGate();
+    } finally {
+      setSubmitting(false);
+    }
+  }, []);
+
+  const prompt = PROMPT_BY_INTENT[status.intent.kind][status.step];
+  return (
+    <Box as={Animated.View} entering={FadeIn.duration(160)} exiting={FadeOut.duration(160)}>
+      <Box gap={48} paddingHorizontal="32px" paddingTop={{ custom: 52 }}>
+        <Text color="blue" size="44pt" style={styles.keyIcon} weight="heavy">
+          {KEY_ICON}
+        </Text>
+        <Box gap={24}>
+          <Text color="label" size="26pt" weight="heavy">
+            {i18n.t(prompt.title)}
+          </Text>
+          <Text color="labelQuaternary" size="17pt" weight="bold">
+            {i18n.t(prompt.description)}
+          </Text>
+        </Box>
+      </Box>
+      <Box paddingBottom="16px" paddingHorizontal="20px" paddingTop="44px">
+        <CashActionButton
+          label={i18n.t(prompt.action)}
+          loading={submitting}
+          onPress={handleContinue}
+          testID={TEST_ID_BY_STEP[status.step]}
+        />
+      </Box>
+    </Box>
+  );
+}
+
+const styles = StyleSheet.create({
+  keyIcon: {
+    lineHeight: 64,
+  },
+});

--- a/src/features/cash/screens/cash-deposit-setup/steps/useAddPasskeyFlow.test.ts
+++ b/src/features/cash/screens/cash-deposit-setup/steps/useAddPasskeyFlow.test.ts
@@ -2,10 +2,8 @@ import { analytics } from '@/analytics';
 import { logger } from '@/logger';
 
 import { createPasskeyCredential } from '../../../services/cashPasskeyService';
-import { listCards } from '../../../services/rampClient';
 import { addPasskey, finishAddPasskey } from '../../../services/userClient';
 import { useCashAccountStore } from '../../../stores/cashAccountStore';
-import { useCashPaymentMethodStore } from '../../../stores/cashPaymentMethodStore';
 import { useCashSetupSessionStore, type RecoveryPhoneChallenge } from '../../../stores/cashSetupSessionStore';
 import { useAddPasskeyFlowStore } from './useAddPasskeyFlow';
 
@@ -30,10 +28,6 @@ jest.mock('../../../services/userClient', () => ({
   finishAddPasskey: jest.fn(),
 }));
 
-jest.mock('../../../services/rampClient', () => ({
-  listCards: jest.fn(),
-}));
-
 jest.mock('../../../services/cashPasskeyService', () => ({
   createPasskeyCredential: jest.fn(),
   getPasskeyName: jest.fn(() => 'iPhone 15 Pro'),
@@ -45,23 +39,15 @@ jest.mock('../../../stores/cashAccountStore', () => {
   return { useCashAccountStore: { getState: jest.fn(() => state) } };
 });
 
-jest.mock('../../../stores/cashPaymentMethodStore', () => {
-  const state = { linkedCard: null, setLinkedCard: jest.fn(), clearLinkedCard: jest.fn() };
-  return { useCashPaymentMethodStore: { getState: jest.fn(() => state) } };
-});
-
 const mockAddPasskey = jest.mocked(addPasskey);
 const mockFinishAddPasskey = jest.mocked(finishAddPasskey);
 const mockCreatePasskeyCredential = jest.mocked(createPasskeyCredential);
-const mockListCards = jest.mocked(listCards);
 const track = jest.mocked(analytics.track);
 const setUserId = jest.mocked(useCashAccountStore.getState().setUserId);
-const setLinkedCard = jest.mocked(useCashPaymentMethodStore.getState().setLinkedCard);
 
 const TOKEN = 'bst_1';
 const OPTIONS_JSON = '{"publicKey":{"challenge":"abc"}}';
 const CREDENTIAL_JSON = '{"id":"cred-1"}';
-const RECOVERED_CARD = { id: 'card-1', brand: 'Visa', last4: '4242' };
 
 const flow = () => useAddPasskeyFlowStore.getState();
 const session = () => useCashSetupSessionStore.getState();
@@ -90,7 +76,6 @@ beforeEach(() => {
   mockAddPasskey.mockResolvedValue({ passkeyId: 'pk-1', publicKeyOptionsJson: OPTIONS_JSON, userId: 'user-1' });
   mockCreatePasskeyCredential.mockResolvedValue(CREDENTIAL_JSON);
   mockFinishAddPasskey.mockResolvedValue(undefined);
-  mockListCards.mockResolvedValue([]);
 });
 
 describe('useAddPasskeyFlowStore.submit', () => {
@@ -163,29 +148,13 @@ describe('useAddPasskeyFlowStore.submit', () => {
     expect(setUserId).toHaveBeenCalledWith('user-1');
   });
 
-  it('restores the recovered account card after passkey enrollment', async () => {
+  it('resolves recovered when enrolling from a recovery session', async () => {
     verifyRecoverySession();
-    mockListCards.mockResolvedValue([RECOVERED_CARD]);
-
-    await expect(flow().submit()).resolves.toBe('recovered');
-
-    expect(mockListCards).toHaveBeenCalledWith({ trigger: 'recovery' });
-    expect(setLinkedCard).toHaveBeenCalledWith(RECOVERED_CARD);
-    expect(setUserId).toHaveBeenCalledWith('user-1');
-    expect(mockFinishAddPasskey).toHaveBeenCalledTimes(1);
-  });
-
-  it('completes recovery when card restoration fails after passkey enrollment', async () => {
-    verifyRecoverySession();
-    mockListCards.mockRejectedValue(new Error('network down'));
 
     await expect(flow().submit()).resolves.toBe('recovered');
 
     expect(setUserId).toHaveBeenCalledWith('user-1');
-    expect(mockAddPasskey).toHaveBeenCalledTimes(1);
     expect(mockFinishAddPasskey).toHaveBeenCalledTimes(1);
-    expect(track).not.toHaveBeenCalledWith('cash.passkey_failed', expect.anything());
-    expect(logger.error).toHaveBeenCalled();
   });
 
   it('skips a second submit while one is in flight', async () => {

--- a/src/features/cash/screens/cash-deposit-setup/steps/useAddPasskeyFlow.ts
+++ b/src/features/cash/screens/cash-deposit-setup/steps/useAddPasskeyFlow.ts
@@ -4,10 +4,8 @@ import { analytics } from '@/analytics';
 import { logger, RainbowError } from '@/logger';
 
 import { createPasskeyCredential, getPasskeyName, isPasskeyCancellation } from '../../../services/cashPasskeyService';
-import { listCards } from '../../../services/rampClient';
 import { addPasskey, finishAddPasskey } from '../../../services/userClient';
 import { useCashAccountStore } from '../../../stores/cashAccountStore';
-import { useCashPaymentMethodStore } from '../../../stores/cashPaymentMethodStore';
 import { useCashSetupSessionStore } from '../../../stores/cashSetupSessionStore';
 import { getTelemetryErrorReason } from '../../../utils/getTelemetryErrorReason';
 
@@ -42,17 +40,6 @@ export const useAddPasskeyFlowStore = createBaseStore<AddPasskeyFlowStore>((set,
 
       useCashAccountStore.getState().setUserId(userId);
       analytics.track(analytics.event.cashPasskeyAdded);
-
-      if (recovering) {
-        try {
-          const [card] = await listCards({ trigger: 'recovery' });
-          if (card) useCashPaymentMethodStore.getState().setLinkedCard(card);
-        } catch (error) {
-          if (!isPasskeyCancellation(error)) {
-            logger.error(new RainbowError('[useAddPasskeyFlow]: Failed to restore recovered account', error));
-          }
-        }
-      }
 
       set({ state: 'entry' });
       return recovering ? 'recovered' : 'completed';

--- a/src/features/cash/screens/cash-sign-in/CashSignInScreen.tsx
+++ b/src/features/cash/screens/cash-sign-in/CashSignInScreen.tsx
@@ -11,8 +11,6 @@ import Routes from '@/navigation/routesNames';
 
 import { isPasskeyCancellation } from '../../services/cashPasskeyService';
 import { signInWithPhone } from '../../services/cashSignInService';
-import { listCards } from '../../services/rampClient';
-import { useCashPaymentMethodStore } from '../../stores/cashPaymentMethodStore';
 import { extractNationalDigits, formatNationalNumber, NATIONAL_NUMBER_LENGTH, US_COUNTRY_CALLING_CODE } from '../../utils/phoneNumber';
 
 const l = i18n.l.cash.sign_in;
@@ -45,15 +43,6 @@ export const CashSignInScreen = memo(function CashSignInScreen() {
       logger.error(new RainbowError('[CashSignInScreen]: Failed to sign in', e));
       setState('error');
       return;
-    }
-
-    // Best effort: signed in either way, and the Add Cash sheet offers card linking when no card is stored.
-    try {
-      // An account can hold only one card today; picking among several lands with multi-card support.
-      const [card] = await listCards({ trigger: 'signInScreen' });
-      if (card) useCashPaymentMethodStore.getState().setLinkedCard(card);
-    } catch (e) {
-      logger.error(new RainbowError('[CashSignInScreen]: Failed to fetch cards', e));
     }
 
     replace(Routes.ADD_CASH_SHEET);

--- a/src/features/cash/services/cardLinkService.ts
+++ b/src/features/cash/services/cardLinkService.ts
@@ -6,6 +6,7 @@ import { delay } from '@/utils/delay';
 import { withTimeout } from '@/utils/promise';
 
 import { MOCK_LINKED_CARD, type LinkedCard } from '../stores/cashPaymentMethodStore';
+import { ensureAccessToken } from './cashSignInService';
 import { completeCardLinkSession, startCardLinkSession, type CardBrand } from './rampClient';
 
 const BIVO_SUBMIT_TIMEOUT = time.seconds(30);
@@ -30,7 +31,7 @@ export async function linkCardWithVault(
   abortController?: AbortController | null
 ): Promise<LinkedCard> {
   if (IS_TESTING === 'true') {
-    await delay(time.seconds(3));
+    await Promise.all([ensureAccessToken('cardLink'), delay(time.seconds(3))]);
     return MOCK_LINKED_CARD;
   }
 

--- a/src/features/cash/services/cardListService.test.ts
+++ b/src/features/cash/services/cardListService.test.ts
@@ -1,0 +1,156 @@
+import { logger } from '@/logger';
+
+import { useCashAccountStore } from '../stores/cashAccountStore';
+import { useCashPaymentMethodStore, type LinkedCard } from '../stores/cashPaymentMethodStore';
+import { loadLinkedCards } from './cardListService';
+import { listCardsWithCachedAuth } from './rampClient';
+
+jest.mock('@/logger', () => ({
+  logger: { debug: jest.fn(), error: jest.fn(), warn: jest.fn() },
+  RainbowError: class RainbowError extends Error {},
+}));
+
+jest.mock('./rampClient', () => ({
+  listCardsWithCachedAuth: jest.fn(),
+}));
+
+const mockListCardsWithCachedAuth = jest.mocked(listCardsWithCachedAuth);
+
+const CARD: LinkedCard = { id: 'card_1', brand: 'Visa Debit', last4: '8990' };
+const OTHER_CARD: LinkedCard = { id: 'card_2', brand: 'Visa', last4: '1115' };
+
+const store = () => useCashPaymentMethodStore.getState();
+const cards = () => store().cards;
+
+function deferListCards() {
+  let settle!: (result: { authRequired?: boolean; cards?: LinkedCard[]; error?: unknown }) => void;
+  const pending = new Promise<{ authRequired?: boolean; cards?: LinkedCard[]; error?: unknown }>(resolve => {
+    settle = resolve;
+  });
+  mockListCardsWithCachedAuth.mockImplementationOnce(async () => {
+    const { authRequired, cards, error } = await pending;
+    if (error) throw error;
+    if (authRequired) return { kind: 'authRequired' };
+    return { kind: 'success', data: cards ?? [] };
+  });
+  return settle;
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  store().clear();
+  useCashAccountStore.getState().setUserId('user-1');
+  mockListCardsWithCachedAuth.mockResolvedValue({ kind: 'success', data: [CARD] });
+});
+
+describe('loadLinkedCards', () => {
+  it('stores the fetched list', async () => {
+    const settle = deferListCards();
+
+    const load = loadLinkedCards();
+    expect(cards()).toBeNull();
+
+    settle({ cards: [CARD] });
+    await expect(load).resolves.toBe('completed');
+
+    expect(cards()).toEqual([CARD]);
+    expect(mockListCardsWithCachedAuth).toHaveBeenCalledWith();
+  });
+
+  it('joins an in-flight request that started from the same list', async () => {
+    const settle = deferListCards();
+
+    const first = loadLinkedCards();
+    const second = loadLinkedCards();
+    expect(mockListCardsWithCachedAuth).toHaveBeenCalledTimes(1);
+
+    settle({ cards: [CARD] });
+    await Promise.all([first, second]);
+    expect(cards()).toEqual([CARD]);
+  });
+
+  it('starts a fresh request, and drops the old one, when the list changed since it started', async () => {
+    const settleStale = deferListCards();
+    const stale = loadLinkedCards();
+
+    store().addLinkedCard(CARD);
+    mockListCardsWithCachedAuth.mockResolvedValue({ kind: 'success', data: [OTHER_CARD] });
+    await loadLinkedCards();
+    expect(mockListCardsWithCachedAuth).toHaveBeenCalledTimes(2);
+    expect(cards()).toEqual([OTHER_CARD]);
+
+    settleStale({ cards: [] });
+    await stale;
+    expect(cards()).toEqual([OTHER_CARD]);
+  });
+
+  it('starts a fresh request and drops the old response when the account changes while the list is null', async () => {
+    const settleOldAccount = deferListCards();
+    const oldAccountLoad = loadLinkedCards();
+
+    useCashAccountStore.getState().setUserId('user-2');
+    expect(cards()).toBeNull();
+    mockListCardsWithCachedAuth.mockResolvedValue({ kind: 'success', data: [OTHER_CARD] });
+
+    await expect(loadLinkedCards()).resolves.toBe('completed');
+    expect(mockListCardsWithCachedAuth).toHaveBeenCalledTimes(2);
+    expect(cards()).toEqual([OTHER_CARD]);
+
+    settleOldAccount({ cards: [CARD] });
+    await expect(oldAccountLoad).resolves.toBe('completed');
+    expect(cards()).toEqual([OTHER_CARD]);
+  });
+
+  it('drops a stale failure when the list was mutated while the request was in flight', async () => {
+    const settle = deferListCards();
+
+    const load = loadLinkedCards();
+    store().addLinkedCard(CARD);
+
+    settle({ error: new Error('network down') });
+    await expect(load).resolves.toBe('completed');
+
+    expect(cards()).toEqual([CARD]);
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+
+  it('keeps the list fetched earlier this session when a refresh fails', async () => {
+    store().setCards([CARD]);
+    mockListCardsWithCachedAuth.mockRejectedValue(new Error('network down'));
+
+    await expect(loadLinkedCards()).resolves.toBe('completed');
+
+    expect(cards()).toEqual([CARD]);
+    expect(logger.error).toHaveBeenCalled();
+  });
+
+  it('rejects when the first load fails', async () => {
+    mockListCardsWithCachedAuth.mockRejectedValue(new Error('network down'));
+
+    await expect(loadLinkedCards()).rejects.toThrow('network down');
+
+    expect(cards()).toBeNull();
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+
+  it('drops an authRequired answer from a request that went stale while in flight', async () => {
+    const settle = deferListCards();
+    const stale = loadLinkedCards();
+
+    store().addLinkedCard(CARD);
+    settle({ authRequired: true });
+
+    await expect(stale).resolves.toBe('completed');
+    expect(cards()).toEqual([CARD]);
+  });
+
+  it('returns authRequired without discarding cards fetched earlier this session', async () => {
+    store().setCards([CARD]);
+    mockListCardsWithCachedAuth.mockResolvedValue({ kind: 'authRequired' });
+
+    await expect(loadLinkedCards()).resolves.toBe('authRequired');
+
+    expect(cards()).toEqual([CARD]);
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/cash/services/cardListService.ts
+++ b/src/features/cash/services/cardListService.ts
@@ -1,0 +1,48 @@
+import { logger, RainbowError } from '@/logger';
+
+import { useCashAccountStore } from '../stores/cashAccountStore';
+import { useCashPaymentMethodStore, type LinkedCard } from '../stores/cashPaymentMethodStore';
+import { listCardsWithCachedAuth } from './rampClient';
+
+export type CardListResult = 'completed' | 'authRequired';
+
+type CardListRequest = {
+  cardsAtRequest: LinkedCard[] | null;
+  promise: Promise<CardListResult>;
+  userIdAtRequest: string | null;
+};
+
+let inFlight: CardListRequest | null = null;
+
+export function loadLinkedCards(): Promise<CardListResult> {
+  const { cards } = useCashPaymentMethodStore.getState();
+  const { userId } = useCashAccountStore.getState();
+  if (inFlight?.cardsAtRequest === cards && inFlight.userIdAtRequest === userId) return inFlight.promise;
+
+  const request: CardListRequest = {
+    cardsAtRequest: cards,
+    promise: fetchCards(userId, cards).finally(() => {
+      if (inFlight === request) inFlight = null;
+    }),
+    userIdAtRequest: userId,
+  };
+  inFlight = request;
+  return request.promise;
+}
+
+async function fetchCards(userIdAtRequest: string | null, cardsAtRequest: LinkedCard[] | null): Promise<CardListResult> {
+  const isStale = () =>
+    useCashAccountStore.getState().userId !== userIdAtRequest || useCashPaymentMethodStore.getState().cards !== cardsAtRequest;
+  try {
+    const result = await listCardsWithCachedAuth();
+    if (isStale()) return 'completed';
+    if (result.kind === 'authRequired') return 'authRequired';
+    useCashPaymentMethodStore.getState().setCards(result.data);
+    return 'completed';
+  } catch (error) {
+    if (isStale()) return 'completed';
+    if (cardsAtRequest === null) throw error;
+    logger.error(new RainbowError('[cardListService]: Failed to refresh cards', error));
+    return 'completed';
+  }
+}

--- a/src/features/cash/services/cashAuthGateService.test.ts
+++ b/src/features/cash/services/cashAuthGateService.test.ts
@@ -1,0 +1,213 @@
+import { logger } from '@/logger';
+
+import { useCashAuthGateStore } from '../stores/cashAuthGateStore';
+import { loadLinkedCards } from './cardListService';
+import { openCashAuthGate, reauthenticateCashGate } from './cashAuthGateService';
+import { isPasskeyCancellation } from './cashPasskeyService';
+import { ensureAccessToken } from './cashSignInService';
+
+jest.mock('@/logger', () => ({
+  logger: { debug: jest.fn(), error: jest.fn(), warn: jest.fn() },
+  RainbowError: class RainbowError extends Error {},
+}));
+
+jest.mock('./cardListService', () => ({
+  loadLinkedCards: jest.fn(),
+}));
+
+jest.mock('./cashPasskeyService', () => ({
+  isPasskeyCancellation: jest.fn(),
+}));
+
+jest.mock('./cashSignInService', () => ({
+  ensureAccessToken: jest.fn(),
+}));
+
+const mockLoadLinkedCards = jest.mocked(loadLinkedCards);
+const mockEnsureAccessToken = jest.mocked(ensureAccessToken);
+const mockIsPasskeyCancellation = jest.mocked(isPasskeyCancellation);
+
+const LOAD_CARDS = { kind: 'loadCards' } as const;
+
+const gate = () => useCashAuthGateStore.getState().status;
+
+function deferLoadCards() {
+  let settle!: (result: { error?: unknown; result?: 'completed' | 'authRequired' }) => void;
+  const pending = new Promise<{ error?: unknown; result?: 'completed' | 'authRequired' }>(resolve => {
+    settle = resolve;
+  });
+  mockLoadLinkedCards.mockImplementationOnce(async () => {
+    const { error, result } = await pending;
+    if (error) throw error;
+    return result ?? 'completed';
+  });
+  return settle;
+}
+
+function deferCeremony() {
+  let settle!: (result: { error?: unknown }) => void;
+  const pending = new Promise<{ error?: unknown }>(resolve => {
+    settle = resolve;
+  });
+  mockEnsureAccessToken.mockImplementation(async () => {
+    const { error } = await pending;
+    if (error) throw error;
+    return 'token';
+  });
+  return settle;
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  useCashAuthGateStore.getState().clear();
+  mockEnsureAccessToken.mockResolvedValue('token');
+  mockLoadLinkedCards.mockResolvedValue('completed');
+  mockIsPasskeyCancellation.mockReturnValue(false);
+});
+
+describe('openCashAuthGate', () => {
+  it('runs the continuation and leaves the gate closed when it succeeds', async () => {
+    useCashAuthGateStore.getState().park(LOAD_CARDS);
+
+    await openCashAuthGate();
+
+    expect(gate()).toEqual({ step: 'closed' });
+    expect(mockLoadLinkedCards).toHaveBeenCalledTimes(1);
+    expect(mockEnsureAccessToken).not.toHaveBeenCalled();
+  });
+
+  it('parks the intent when the continuation needs a fresh sign-in', async () => {
+    mockLoadLinkedCards.mockResolvedValue('authRequired');
+
+    await openCashAuthGate();
+
+    expect(gate()).toEqual({ step: 'authRequired', intent: LOAD_CARDS });
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+
+  it('fails the gate when the continuation fails', async () => {
+    mockLoadLinkedCards.mockRejectedValue(new Error('network down'));
+
+    await openCashAuthGate();
+
+    expect(gate()).toEqual({ step: 'error', intent: LOAD_CARDS });
+    expect(logger.error).toHaveBeenCalled();
+  });
+
+  it('leaves a gate that was cleared mid-run alone, whether the run parks or fails', async () => {
+    const settlePark = deferLoadCards();
+    const parked = openCashAuthGate();
+    useCashAuthGateStore.getState().clear();
+    settlePark({ result: 'authRequired' });
+    await parked;
+    expect(gate()).toEqual({ step: 'closed' });
+
+    const settleFailure = deferLoadCards();
+    const failed = openCashAuthGate();
+    useCashAuthGateStore.getState().clear();
+    settleFailure({ error: new Error('network down') });
+    await failed;
+    expect(gate()).toEqual({ step: 'closed' });
+    expect(logger.error).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('reauthenticateCashGate', () => {
+  beforeEach(() => {
+    useCashAuthGateStore.getState().park(LOAD_CARDS);
+  });
+
+  it('does nothing when the gate is closed', async () => {
+    useCashAuthGateStore.getState().clear();
+
+    await reauthenticateCashGate();
+
+    expect(mockEnsureAccessToken).not.toHaveBeenCalled();
+    expect(mockLoadLinkedCards).not.toHaveBeenCalled();
+  });
+
+  it('runs one ceremony, then the parked intent continues', async () => {
+    await reauthenticateCashGate();
+
+    expect(mockEnsureAccessToken).toHaveBeenCalledWith('addCash');
+    expect(gate()).toEqual({ step: 'closed' });
+    expect(mockLoadLinkedCards).toHaveBeenCalledTimes(1);
+
+    const [ceremonyOrder] = mockEnsureAccessToken.mock.invocationCallOrder;
+    const [continuationOrder] = mockLoadLinkedCards.mock.invocationCallOrder;
+    expect(ceremonyOrder).toBeLessThan(continuationOrder);
+  });
+
+  it('stays parked silently when the ceremony is cancelled', async () => {
+    mockEnsureAccessToken.mockRejectedValue(new Error('user cancelled'));
+    mockIsPasskeyCancellation.mockReturnValue(true);
+
+    await reauthenticateCashGate();
+
+    expect(gate()).toEqual({ step: 'authRequired', intent: LOAD_CARDS });
+    expect(mockLoadLinkedCards).not.toHaveBeenCalled();
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+
+  it('fails the gate when the ceremony fails', async () => {
+    mockEnsureAccessToken.mockRejectedValue(new Error('sign-in exploded'));
+
+    await reauthenticateCashGate();
+
+    expect(gate()).toEqual({ step: 'error', intent: LOAD_CARDS });
+    expect(mockLoadLinkedCards).not.toHaveBeenCalled();
+    expect(logger.error).toHaveBeenCalled();
+  });
+
+  it('re-parks when the continuation still needs a fresh sign-in after the ceremony', async () => {
+    mockLoadLinkedCards.mockResolvedValue('authRequired');
+
+    await reauthenticateCashGate();
+
+    expect(gate()).toEqual({ step: 'authRequired', intent: LOAD_CARDS });
+  });
+
+  it('retries from the error state', async () => {
+    mockEnsureAccessToken.mockRejectedValueOnce(new Error('sign-in exploded'));
+
+    await reauthenticateCashGate();
+    expect(gate()).toEqual({ step: 'error', intent: LOAD_CARDS });
+
+    await reauthenticateCashGate();
+    expect(gate()).toEqual({ step: 'closed' });
+    expect(mockLoadLinkedCards).toHaveBeenCalledTimes(1);
+  });
+
+  it('lets a tap on a reopened sheet finish its own gate while the dismissed sheet stays silent', async () => {
+    const settle = deferCeremony();
+    const dismissed = reauthenticateCashGate();
+    useCashAuthGateStore.getState().clear();
+
+    useCashAuthGateStore.getState().park(LOAD_CARDS);
+    const reopened = reauthenticateCashGate();
+
+    settle({});
+    await Promise.all([dismissed, reopened]);
+    expect(gate()).toEqual({ step: 'closed' });
+    expect(mockLoadLinkedCards).toHaveBeenCalledTimes(1);
+  });
+
+  it('leaves a gate that was cleared during the ceremony alone, whether it succeeds or fails', async () => {
+    const settleSuccess = deferCeremony();
+    const succeeded = reauthenticateCashGate();
+    useCashAuthGateStore.getState().clear();
+    settleSuccess({});
+    await succeeded;
+    expect(gate()).toEqual({ step: 'closed' });
+    expect(mockLoadLinkedCards).not.toHaveBeenCalled();
+
+    useCashAuthGateStore.getState().park(LOAD_CARDS);
+    const settleFailure = deferCeremony();
+    const failed = reauthenticateCashGate();
+    useCashAuthGateStore.getState().clear();
+    settleFailure({ error: new Error('sign-in exploded') });
+    await failed;
+    expect(gate()).toEqual({ step: 'closed' });
+    expect(logger.error).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/features/cash/services/cashAuthGateService.ts
+++ b/src/features/cash/services/cashAuthGateService.ts
@@ -1,0 +1,52 @@
+import { logger, RainbowError } from '@/logger';
+
+import { useCashAuthGateStore, type CashAuthIntent } from '../stores/cashAuthGateStore';
+import { loadLinkedCards } from './cardListService';
+import { isPasskeyCancellation } from './cashPasskeyService';
+import { ensureAccessToken } from './cashSignInService';
+
+type CashAuthGateResumeResult = 'completed' | 'authRequired';
+
+const RESUME_BY_INTENT: Record<CashAuthIntent['kind'], () => Promise<CashAuthGateResumeResult>> = {
+  loadCards: loadLinkedCards,
+};
+
+/** Sheet entry: run what belongs behind the gate; the gate only opens if that needs a fresh sign-in. */
+export function openCashAuthGate(): Promise<void> {
+  return runIntent({ kind: 'loadCards' });
+}
+
+/** The user's Re-authenticate tap: one announced ceremony, then the parked intent continues. */
+export async function reauthenticateCashGate(): Promise<void> {
+  const gate = useCashAuthGateStore.getState();
+  const parked = gate.status;
+  if (parked.step === 'closed') return;
+  // Dismissing the sheet while the ceremony is up clears the gate; a stale outcome must not reopen it.
+  const isCurrent = () => useCashAuthGateStore.getState().status === parked;
+
+  try {
+    await ensureAccessToken('addCash');
+  } catch (error) {
+    // A cancelled sign-in is a deliberate dismissal, not a failure: stay parked, silently.
+    if (isPasskeyCancellation(error)) return;
+    logger.error(new RainbowError('[cashAuthGateService]: Failed to re-authenticate', error));
+    if (isCurrent()) gate.fail(parked.intent);
+    return;
+  }
+  if (isCurrent()) await runIntent(parked.intent);
+}
+
+async function runIntent(intent: CashAuthIntent): Promise<void> {
+  const gate = useCashAuthGateStore.getState();
+  gate.clear();
+  // Dismissing the sheet (or a newer run) clears the gate again; a stale completion must not reopen it.
+  const cleared = useCashAuthGateStore.getState().status;
+  const isCurrent = () => useCashAuthGateStore.getState().status === cleared;
+  try {
+    const result = await RESUME_BY_INTENT[intent.kind]();
+    if (result === 'authRequired' && isCurrent()) gate.park(intent);
+  } catch (error) {
+    logger.error(new RainbowError(`[cashAuthGateService]: ${intent.kind} failed`, error));
+    if (isCurrent()) gate.fail(intent);
+  }
+}

--- a/src/features/cash/services/cashSignInService.ts
+++ b/src/features/cash/services/cashSignInService.ts
@@ -8,13 +8,13 @@ import { US_COUNTRY_CALLING_CODE } from '../utils/phoneNumber';
 import { getPasskeyAssertion, isPasskeyCancellation } from './cashPasskeyService';
 import { finalizeAuth, finishLogin, startLogin, type StartLoginParams } from './userClient';
 
-export type CashSignInTrigger = 'cardLink' | 'addCash' | 'signInScreen' | 'recovery';
+export type CashSignInTrigger = 'cardLink' | 'addCash' | 'signInScreen';
 
 const TOKEN_EXPIRY_MARGIN = time.seconds(30);
 
 let pendingSignIn: Promise<string> | null = null;
 
-function getCachedAccessToken(): string | null {
+export function getCachedAccessToken(): string | null {
   const token = useCashAuthTokenStore.getState().token;
   if (!token) return null;
   const remaining = token.expiresAt - Date.now();

--- a/src/features/cash/services/rampClient.test.ts
+++ b/src/features/cash/services/rampClient.test.ts
@@ -4,7 +4,7 @@ import { logger } from '@/logger';
 
 import { useCashAuthTokenStore } from '../stores/cashAuthTokenStore';
 import { getCashPlatformClient } from './cashPlatformClient';
-import { ensureAccessToken } from './cashSignInService';
+import { ensureAccessToken, getCachedAccessToken } from './cashSignInService';
 import {
   CardBrand,
   completeCardLinkSession,
@@ -12,6 +12,7 @@ import {
   getOrder,
   linkWallet,
   listCards,
+  listCardsWithCachedAuth,
   listWallets,
   OrderFailureReason,
   OrderStatus,
@@ -31,6 +32,7 @@ jest.mock('./cashPlatformClient', () => ({
 
 jest.mock('./cashSignInService', () => ({
   ensureAccessToken: jest.fn(),
+  getCachedAccessToken: jest.fn(),
 }));
 
 jest.mock('@/logger', () => ({
@@ -40,6 +42,7 @@ jest.mock('@/logger', () => ({
 const get = jest.fn();
 const post = jest.fn();
 const mockEnsureAccessToken = ensureAccessToken as jest.Mock;
+const mockGetCachedAccessToken = jest.mocked(getCachedAccessToken);
 
 // `tokenExpiresTime` rides along on the wire but nothing reads it, so the parsed session drops it.
 const SESSION = { linkUrl: 'https://link', token: 'vault-token', tokenExpiresTime: '2026-07-24T00:00:00Z' };
@@ -97,6 +100,7 @@ beforeEach(() => {
   jest.clearAllMocks();
   (getCashPlatformClient as jest.Mock).mockReturnValue({ get, post });
   mockEnsureAccessToken.mockResolvedValue('jwt-1');
+  mockGetCachedAccessToken.mockReturnValue('jwt-1');
   useCashAuthTokenStore.getState().setToken({ accessToken: 'jwt-1', expiresAt: Date.now() + 60_000 });
   post.mockResolvedValue({ data: SESSION });
 });
@@ -138,6 +142,50 @@ describe('startCardLinkSession', () => {
     await expect(startCardLinkSession()).rejects.toThrow('server error');
     expect(post).toHaveBeenCalledTimes(1);
     expect(useCashAuthTokenStore.getState().token).not.toBeNull();
+  });
+});
+
+describe('listCardsWithCachedAuth', () => {
+  it('returns authRequired without sending a request when no token is cached', async () => {
+    mockGetCachedAccessToken.mockReturnValue(null);
+
+    await expect(listCardsWithCachedAuth()).resolves.toEqual({ kind: 'authRequired' });
+
+    expect(get).not.toHaveBeenCalled();
+    expect(mockEnsureAccessToken).not.toHaveBeenCalled();
+  });
+
+  it('returns parsed cards without starting a ceremony when a token is cached', async () => {
+    get.mockResolvedValue({ data: {} });
+
+    await expect(listCardsWithCachedAuth()).resolves.toEqual({ kind: 'success', data: [] });
+
+    expect(get).toHaveBeenCalledWith('/ramp/payment-methods/cards', {
+      abortController: undefined,
+      headers: { Authorization: 'Bearer jwt-1' },
+    });
+    expect(mockEnsureAccessToken).not.toHaveBeenCalled();
+  });
+
+  it('clears a rejected cached token and returns authRequired without retrying', async () => {
+    get.mockRejectedValue(fetchError(401, 'unauthorized'));
+
+    await expect(listCardsWithCachedAuth()).resolves.toEqual({ kind: 'authRequired' });
+
+    expect(get).toHaveBeenCalledTimes(1);
+    expect(useCashAuthTokenStore.getState().token).toBeNull();
+    expect(mockEnsureAccessToken).not.toHaveBeenCalled();
+  });
+
+  it('keeps a token minted by a newer sign-in when a stale request is rejected', async () => {
+    get.mockImplementation(async () => {
+      useCashAuthTokenStore.getState().setToken({ accessToken: 'jwt-2', expiresAt: Date.now() + 60_000 });
+      throw fetchError(401, 'unauthorized');
+    });
+
+    await expect(listCardsWithCachedAuth()).resolves.toEqual({ kind: 'authRequired' });
+
+    expect(useCashAuthTokenStore.getState().token?.accessToken).toBe('jwt-2');
   });
 });
 

--- a/src/features/cash/services/rampClient.ts
+++ b/src/features/cash/services/rampClient.ts
@@ -7,9 +7,9 @@ import { greaterThan } from '@/helpers/utilities';
 import { logger } from '@/logger';
 
 import { useCashAuthTokenStore } from '../stores/cashAuthTokenStore';
-import type { LinkedCard } from '../stores/cashPaymentMethodStore';
+import { selectCashLinkedCards, useCashPaymentMethodStore, type LinkedCard } from '../stores/cashPaymentMethodStore';
 import { buildAuthenticatedHeader, getCashPlatformClient } from './cashPlatformClient';
-import { ensureAccessToken, type CashSignInTrigger } from './cashSignInService';
+import { ensureAccessToken, getCachedAccessToken, type CashSignInTrigger } from './cashSignInService';
 
 // ---- Wire enums (values mirror the platform `/v1/ramp` OpenAPI spec) --------
 
@@ -199,23 +199,49 @@ export function isDefinitiveRejection(error: unknown): boolean {
   return status !== undefined && status >= 400 && status < 500 && status !== 408 && status !== 429;
 }
 
-// The user JWT replaces the shared app key on these calls. On 401 the cached
-// token is assumed stale: drop it, run one fresh sign-in ceremony, retry once.
-// Tokens are acquired outside the try so a 401 from the ceremony's own RPCs
-// propagates instead of triggering a second ceremony.
-async function authorizedRequest<T>(trigger: CashSignInTrigger, send: (headers: { Authorization: string }) => Promise<T>): Promise<T> {
-  const headers = buildAuthenticatedHeader(await ensureAccessToken(trigger));
+export type CashAuthResult<T> = { kind: 'success'; data: T } | { kind: 'authRequired' };
+
+type CashAuthMode = { kind: 'cachedOnly' } | { kind: 'interactive'; trigger: CashSignInTrigger };
+
+async function authorizedRequest<T>(
+  mode: Extract<CashAuthMode, { kind: 'cachedOnly' }>,
+  send: (headers: { Authorization: string }) => Promise<T>
+): Promise<CashAuthResult<T>>;
+async function authorizedRequest<T>(
+  mode: Extract<CashAuthMode, { kind: 'interactive' }>,
+  send: (headers: { Authorization: string }) => Promise<T>
+): Promise<T>;
+async function authorizedRequest<T>(
+  mode: CashAuthMode,
+  send: (headers: { Authorization: string }) => Promise<T>
+): Promise<T | CashAuthResult<T>> {
+  if (mode.kind === 'cachedOnly') {
+    const accessToken = getCachedAccessToken();
+    if (!accessToken) return { kind: 'authRequired' };
+
+    try {
+      return { kind: 'success', data: await send(buildAuthenticatedHeader(accessToken)) };
+    } catch (error) {
+      if (!isUnauthorized(error)) throw error;
+      // A sign-in may have replaced the token while this request was in flight; only the rejected one is dead.
+      const { token, clearToken } = useCashAuthTokenStore.getState();
+      if (token?.accessToken === accessToken) clearToken();
+      return { kind: 'authRequired' };
+    }
+  }
+
+  const headers = buildAuthenticatedHeader(await ensureAccessToken(mode.trigger));
   try {
     return await send(headers);
   } catch (error) {
     if (!isUnauthorized(error)) throw error;
     useCashAuthTokenStore.getState().clearToken();
-    return send(buildAuthenticatedHeader(await ensureAccessToken(trigger)));
+    return send(buildAuthenticatedHeader(await ensureAccessToken(mode.trigger)));
   }
 }
 
 export async function startCardLinkSession(abortController?: AbortController | null): Promise<StartCardLinkSessionResponse> {
-  const { data } = await authorizedRequest('cardLink', headers =>
+  const { data } = await authorizedRequest({ kind: 'interactive', trigger: 'cardLink' }, headers =>
     getCashPlatformClient().post('/ramp/payment-methods/link-card-session', {}, { abortController, headers })
   );
   return parseResponse(startCardLinkSessionResponseSchema, data, 'startCardLinkSession');
@@ -225,7 +251,7 @@ export async function completeCardLinkSession(
   { providerCardId, brand }: CompleteCardLinkSessionRequest,
   abortController?: AbortController | null
 ): Promise<LinkedCard> {
-  const { data } = await authorizedRequest('cardLink', headers =>
+  const { data } = await authorizedRequest({ kind: 'interactive', trigger: 'cardLink' }, headers =>
     getCashPlatformClient().post(
       '/ramp/payment-methods/link-card-session/complete',
       { brand, providerCardId },
@@ -242,16 +268,35 @@ export async function listCards({
   abortController?: AbortController | null;
   trigger: CashSignInTrigger;
 }): Promise<LinkedCard[]> {
-  if (IS_TESTING === 'true') return [];
+  if (IS_TESTING === 'true') return selectCashLinkedCards(useCashPaymentMethodStore.getState());
 
-  const { data } = await authorizedRequest(trigger, headers =>
-    getCashPlatformClient().get('/ramp/payment-methods/cards', { abortController, headers })
-  );
+  const data = await authorizedRequest({ kind: 'interactive', trigger }, async headers => {
+    const response = await getCashPlatformClient().get('/ramp/payment-methods/cards', { abortController, headers });
+    return response.data;
+  });
+  return parseLinkedCards(data);
+}
+
+export async function listCardsWithCachedAuth(abortController?: AbortController | null): Promise<CashAuthResult<LinkedCard[]>> {
+  if (IS_TESTING === 'true') {
+    if (!getCachedAccessToken()) return { kind: 'authRequired' };
+    return { kind: 'success', data: selectCashLinkedCards(useCashPaymentMethodStore.getState()) };
+  }
+
+  const result = await authorizedRequest({ kind: 'cachedOnly' }, async headers => {
+    const response = await getCashPlatformClient().get('/ramp/payment-methods/cards', { abortController, headers });
+    return response.data;
+  });
+  if (result.kind === 'authRequired') return result;
+  return { kind: 'success', data: parseLinkedCards(result.data) };
+}
+
+function parseLinkedCards(data: unknown): LinkedCard[] {
   return parseResponse(listCardsResponseSchema, data, 'listCards').cards.map(toLinkedCard);
 }
 
 export async function deleteCard(cardId: string, abortController?: AbortController | null): Promise<void> {
-  await authorizedRequest('addCash', headers =>
+  await authorizedRequest({ kind: 'interactive', trigger: 'addCash' }, headers =>
     getCashPlatformClient().delete(`/ramp/payment-methods/${encodeURIComponent(cardId)}`, { abortController, headers })
   );
 }
@@ -273,7 +318,7 @@ export type WalletSignature = {
 };
 
 export async function listWallets(abortController?: AbortController | null): Promise<RampWallet[]> {
-  const { data } = await authorizedRequest('addCash', headers =>
+  const { data } = await authorizedRequest({ kind: 'interactive', trigger: 'addCash' }, headers =>
     getCashPlatformClient().get('/ramp/wallets', { abortController, headers })
   );
   return parseResponse(listWalletsResponseSchema, data, 'listWallets').wallets;
@@ -283,7 +328,7 @@ export async function linkWallet(
   { address, signature }: { address: string; signature: WalletSignature },
   abortController?: AbortController | null
 ): Promise<RampWallet> {
-  const { data } = await authorizedRequest('addCash', headers =>
+  const { data } = await authorizedRequest({ kind: 'interactive', trigger: 'addCash' }, headers =>
     getCashPlatformClient().post('/ramp/wallets/link', { address, signature }, { abortController, headers })
   );
   return { ...parseResponse(linkWalletResponseSchema, data, 'linkWallet').wallet, address };
@@ -296,7 +341,9 @@ const getOrderResponseSchema = z.object({ order: buyOrderSchema });
 export async function createBuyOrder(params: CreateBuyOrderParams): Promise<void> {
   if (IS_TESTING === 'true') return e2eCreateBuyOrder(params);
 
-  await authorizedRequest('addCash', headers => getCashPlatformClient().post('/ramp/orders/buy', params, { headers }));
+  await authorizedRequest({ kind: 'interactive', trigger: 'addCash' }, headers =>
+    getCashPlatformClient().post('/ramp/orders/buy', params, { headers })
+  );
 }
 
 export async function getOrder(orderId: string, abortController?: AbortController | null): Promise<BuyOrder> {
@@ -304,7 +351,7 @@ export async function getOrder(orderId: string, abortController?: AbortControlle
     IS_TESTING === 'true'
       ? e2eGetOrderResponse(orderId)
       : (
-          await authorizedRequest('addCash', headers =>
+          await authorizedRequest({ kind: 'interactive', trigger: 'addCash' }, headers =>
             getCashPlatformClient().get(`/ramp/orders/${encodeURIComponent(orderId)}`, { abortController, headers })
           )
         ).data;

--- a/src/features/cash/stores/cardLinkFlowStore.test.ts
+++ b/src/features/cash/stores/cardLinkFlowStore.test.ts
@@ -6,7 +6,7 @@ import { linkCardWithVault } from '../services/cardLinkService';
 import { isPasskeyCancellation } from '../services/cashPasskeyService';
 import type { CardBrand } from '../services/rampClient';
 import { useCardLinkFlowStore } from './cardLinkFlowStore';
-import { useCashPaymentMethodStore, type LinkedCard } from './cashPaymentMethodStore';
+import { selectCashLinkedCard, useCashPaymentMethodStore, type LinkedCard } from './cashPaymentMethodStore';
 
 jest.mock('@/analytics', () => ({
   analytics: {
@@ -40,7 +40,7 @@ const CARD_BRAND = 'CARD_BRAND_VISA' as CardBrand;
 const BIVO_STORE = {} as BivoSecureStore;
 
 const flow = () => useCardLinkFlowStore.getState();
-const linkedCard = () => useCashPaymentMethodStore.getState().linkedCard;
+const linkedCard = () => selectCashLinkedCard(useCashPaymentMethodStore.getState());
 
 function deferLink() {
   let settle!: (result: { card?: LinkedCard; error?: unknown }) => void;
@@ -58,7 +58,7 @@ function deferLink() {
 beforeEach(() => {
   jest.clearAllMocks();
   flow().reset();
-  useCashPaymentMethodStore.getState().clearLinkedCard();
+  useCashPaymentMethodStore.getState().clear();
   mockLinkCardWithVault.mockResolvedValue(CARD);
   mockIsPasskeyCancellation.mockReturnValue(false);
 });

--- a/src/features/cash/stores/cardLinkFlowStore.ts
+++ b/src/features/cash/stores/cardLinkFlowStore.ts
@@ -35,7 +35,7 @@ export const useCardLinkFlowStore = createBaseStore<CardLinkFlowStore>((set, get
     try {
       const card = await linkCardWithVault(bivoStore, cardBrand, controller);
       if (controller.signal.aborted) return 'cancelled';
-      useCashPaymentMethodStore.getState().setLinkedCard(card);
+      useCashPaymentMethodStore.getState().addLinkedCard(card);
       analytics.track(analytics.event.cashCardLinked, { brand: card.brand });
       set({ state: 'success' });
       return 'completed';

--- a/src/features/cash/stores/cardRemovalFlowStore.test.ts
+++ b/src/features/cash/stores/cardRemovalFlowStore.test.ts
@@ -3,7 +3,7 @@ import { RainbowFetchError } from '@/framework/data/http/rainbowFetch';
 import { isPasskeyCancellation } from '../services/cashPasskeyService';
 import { deleteCard, listCards } from '../services/rampClient';
 import { useCardRemovalFlowStore } from './cardRemovalFlowStore';
-import { useCashPaymentMethodStore, type LinkedCard } from './cashPaymentMethodStore';
+import { selectCashLinkedCard, useCashPaymentMethodStore, type LinkedCard } from './cashPaymentMethodStore';
 
 jest.mock('@/logger', () => ({
   logger: { debug: jest.fn(), error: jest.fn(), warn: jest.fn() },
@@ -28,7 +28,7 @@ const CARD: LinkedCard = { id: 'card_1', brand: 'Visa Debit', last4: '8990' };
 const REPLACEMENT_CARD: LinkedCard = { id: 'card_2', brand: 'Visa Debit', last4: '1234' };
 
 const flow = () => useCardRemovalFlowStore.getState();
-const linkedCard = () => useCashPaymentMethodStore.getState().linkedCard;
+const linkedCard = () => selectCashLinkedCard(useCashPaymentMethodStore.getState());
 
 function fetchError(status: number): RainbowFetchError {
   return new RainbowFetchError({ message: 'request failed', response: { status } as Response });
@@ -49,7 +49,8 @@ function deferDelete() {
 beforeEach(() => {
   jest.clearAllMocks();
   useCardRemovalFlowStore.setState({ state: 'idle' });
-  useCashPaymentMethodStore.getState().setLinkedCard(CARD);
+  useCashPaymentMethodStore.getState().clear();
+  useCashPaymentMethodStore.getState().addLinkedCard(CARD);
   mockDeleteCard.mockResolvedValue(undefined);
   mockListCards.mockResolvedValue([CARD]);
   mockIsPasskeyCancellation.mockReturnValue(false);
@@ -140,7 +141,7 @@ describe('cardRemovalFlowStore', () => {
     const settle = deferDelete();
 
     const removal = flow().remove(CARD);
-    useCashPaymentMethodStore.getState().setLinkedCard(REPLACEMENT_CARD);
+    useCashPaymentMethodStore.getState().addLinkedCard(REPLACEMENT_CARD);
     settle();
     await removal;
 

--- a/src/features/cash/stores/cardRemovalFlowStore.ts
+++ b/src/features/cash/stores/cardRemovalFlowStore.ts
@@ -4,7 +4,7 @@ import { logger, RainbowError } from '@/logger';
 
 import { removeLinkedCard } from '../services/cardRemovalService';
 import { isPasskeyCancellation } from '../services/cashPasskeyService';
-import { useCashPaymentMethodStore, type LinkedCard } from './cashPaymentMethodStore';
+import { selectCashLinkedCards, useCashPaymentMethodStore, type LinkedCard } from './cashPaymentMethodStore';
 
 type CardRemovalResult = 'removed' | 'cancelled' | 'failed' | 'skipped';
 
@@ -18,15 +18,12 @@ export const useCardRemovalFlowStore = createBaseStore<CardRemovalFlowStore>((se
 
   remove: async card => {
     if (get().state === 'removing') return 'skipped';
-    if (useCashPaymentMethodStore.getState().linkedCard?.id !== card.id) return 'skipped';
+    if (!selectCashLinkedCards(useCashPaymentMethodStore.getState()).some(linked => linked.id === card.id)) return 'skipped';
 
     set({ state: 'removing' });
     try {
       await removeLinkedCard(card.id);
-      // The card can be replaced while the delete is in flight, so only drop the one that was removed.
-      if (useCashPaymentMethodStore.getState().linkedCard?.id === card.id) {
-        useCashPaymentMethodStore.getState().clearLinkedCard();
-      }
+      useCashPaymentMethodStore.getState().removeCard(card.id);
       return 'removed';
     } catch (error) {
       // A cancelled sign-in is a deliberate dismissal, not a failure.

--- a/src/features/cash/stores/cashAccountStore.ts
+++ b/src/features/cash/stores/cashAccountStore.ts
@@ -16,7 +16,7 @@ type CashAccountStore = {
 function clearAccountScopedState(): void {
   useCashAuthTokenStore.getState().clearToken();
   useCashWalletStore.getState().clear();
-  useCashPaymentMethodStore.getState().clearLinkedCard();
+  useCashPaymentMethodStore.getState().clear();
 }
 
 export const useCashAccountStore = createBaseStore<CashAccountStore>(

--- a/src/features/cash/stores/cashAuthGateStore.ts
+++ b/src/features/cash/stores/cashAuthGateStore.ts
@@ -1,0 +1,26 @@
+import { createBaseStore } from '@storesjs/stores';
+
+export type CashAuthIntent = { kind: 'loadCards' };
+
+export type CashAuthGateStatus =
+  | { step: 'closed' }
+  | { step: 'authRequired'; intent: CashAuthIntent }
+  | { step: 'error'; intent: CashAuthIntent };
+
+export type OpenCashAuthGateStatus = Exclude<CashAuthGateStatus, { step: 'closed' }>;
+
+type CashAuthGateStore = {
+  status: CashAuthGateStatus;
+  park: (intent: CashAuthIntent) => void;
+  fail: (intent: CashAuthIntent) => void;
+  clear: () => void;
+};
+
+// Deliberately memory-only: the gate is recomputed from persisted inputs on every sheet open,
+// so persisting it would only add rehydration edge cases.
+export const useCashAuthGateStore = createBaseStore<CashAuthGateStore>(set => ({
+  status: { step: 'closed' },
+  park: intent => set({ status: { step: 'authRequired', intent } }),
+  fail: intent => set({ status: { step: 'error', intent } }),
+  clear: () => set({ status: { step: 'closed' } }),
+}));

--- a/src/features/cash/stores/cashDepositSetupStore.test.ts
+++ b/src/features/cash/stores/cashDepositSetupStore.test.ts
@@ -7,7 +7,7 @@ const A_CARD: LinkedCard = { id: 'card-1', brand: 'Visa', last4: '4242' };
 describe('useCashDepositSetupStatusStore', () => {
   beforeEach(() => {
     useCashAccountStore.getState().clearUserId();
-    useCashPaymentMethodStore.setState({ linkedCard: null });
+    useCashPaymentMethodStore.getState().clear();
   });
 
   it('is needsCard with an account but no card', () => {
@@ -17,7 +17,7 @@ describe('useCashDepositSetupStatusStore', () => {
 
   it('regresses from ready to needsIdentity when the account record clears', () => {
     useCashAccountStore.getState().setUserId('user-1');
-    useCashPaymentMethodStore.setState({ linkedCard: A_CARD });
+    useCashPaymentMethodStore.getState().addLinkedCard(A_CARD);
     expect(useCashDepositSetupStatusStore.getState()).toBe('ready');
 
     useCashAccountStore.getState().clearUserId();

--- a/src/features/cash/stores/cashDepositSetupStore.ts
+++ b/src/features/cash/stores/cashDepositSetupStore.ts
@@ -1,13 +1,13 @@
 import { createDerivedStore } from '@storesjs/stores';
 
 import { useCashAccountStore } from './cashAccountStore';
-import { useCashPaymentMethodStore } from './cashPaymentMethodStore';
+import { selectCashLinkedCard, useCashPaymentMethodStore } from './cashPaymentMethodStore';
 import { deriveCashDepositSetupStatus, type CashDepositSetupStatus } from './deriveCashDepositSetupStatus';
 
 export const useCashDepositSetupStatusStore = createDerivedStore<CashDepositSetupStatus>(
   $ => {
     const hasAccount = $(useCashAccountStore, state => state.userId != null);
-    const linkedCard = $(useCashPaymentMethodStore, state => state.linkedCard);
+    const linkedCard = $(useCashPaymentMethodStore, selectCashLinkedCard);
     return deriveCashDepositSetupStatus({ hasAccount, hasLinkedCard: linkedCard != null });
   },
   { lockDependencies: true }

--- a/src/features/cash/stores/cashPaymentMethodStore.ts
+++ b/src/features/cash/stores/cashPaymentMethodStore.ts
@@ -1,4 +1,4 @@
-import { createBaseStore } from '@storesjs/stores';
+import { createBaseStore, shallowEqual } from '@storesjs/stores';
 
 export type LinkedCard = {
   /** Rainbow internal card token id, sent as `cardId` on a buy order. */
@@ -10,22 +10,72 @@ export type LinkedCard = {
 };
 
 type CashPaymentMethodStore = {
-  linkedCard: LinkedCard | null;
-  setLinkedCard: (linkedCard: LinkedCard) => void;
-  clearLinkedCard: () => void;
+  /** Only the id survives restarts — card objects always come fresh from the backend. */
+  lastUsedCardId: string | null;
+  /** null until the list has been fetched (or a card linked) this session. */
+  cards: LinkedCard[] | null;
+  setCards: (cards: LinkedCard[]) => void;
+  addLinkedCard: (card: LinkedCard) => void;
+  removeCard: (cardId: string) => void;
+  clear: () => void;
 };
 
 export const useCashPaymentMethodStore = createBaseStore<CashPaymentMethodStore>(
-  set => ({
-    linkedCard: null,
-    setLinkedCard: linkedCard => set({ linkedCard }),
-    clearLinkedCard: () => set({ linkedCard: null }),
+  (set, get) => ({
+    lastUsedCardId: null,
+    cards: null,
+    setCards: cards => set({ cards }),
+    addLinkedCard: card => {
+      const others = (get().cards ?? []).filter(existing => existing.id !== card.id);
+      set({ lastUsedCardId: card.id, cards: [...others, card] });
+    },
+    removeCard: cardId => {
+      const { cards, lastUsedCardId } = get();
+      if (!cards) return;
+      set({
+        lastUsedCardId: lastUsedCardId === cardId ? null : lastUsedCardId,
+        cards: cards.filter(card => card.id !== cardId),
+      });
+    },
+    clear: () => set({ lastUsedCardId: null, cards: null }),
   }),
-  { storageKey: 'cashPaymentMethod' }
+  {
+    storageKey: 'cashPaymentMethod',
+    version: 1,
+    partialize: state => ({ lastUsedCardId: state.lastUsedCardId }),
+    // v0 persisted the whole linked card; carry over only its id.
+    migrate: persistedState => {
+      const legacy = persistedState as { linkedCard?: { id?: string } | null } | undefined;
+      return { lastUsedCardId: legacy?.linkedCard?.id ?? null };
+    },
+  }
 );
 
+type CardSelectorState = Pick<CashPaymentMethodStore, 'cards' | 'lastUsedCardId'>;
+
+export function selectCashLinkedCards(state: Pick<CashPaymentMethodStore, 'cards'>): LinkedCard[] {
+  return state.cards ?? [];
+}
+
+export function selectCashLinkedCard(state: CardSelectorState): LinkedCard | null {
+  const cards = selectCashLinkedCards(state);
+  return cards.find(card => card.id === state.lastUsedCardId) ?? cards[0] ?? null;
+}
+
 export function useCashLinkedCard(): LinkedCard | null {
-  return useCashPaymentMethodStore(state => state.linkedCard);
+  return useCashPaymentMethodStore(selectCashLinkedCard);
+}
+
+export type CashFundingState = { kind: 'loading' } | { kind: 'none' } | { kind: 'card'; card: LinkedCard };
+
+export function selectCashFundingState(state: CardSelectorState): CashFundingState {
+  if (state.cards === null) return { kind: 'loading' };
+  const card = selectCashLinkedCard(state);
+  return card ? { kind: 'card', card } : { kind: 'none' };
+}
+
+export function useCashFundingState(): CashFundingState {
+  return useCashPaymentMethodStore(selectCashFundingState, shallowEqual);
 }
 
 export const MOCK_LINKED_CARD: LinkedCard = { id: 'mock-card-1', brand: 'Visa Debit', last4: '8990' };

--- a/src/features/debug/screens/DevSection.tsx
+++ b/src/features/debug/screens/DevSection.tsx
@@ -11,7 +11,6 @@ import Restart from 'react-native-restart';
 import { ImgixImage } from '@/components/images';
 import { IS_STORE_INSTALL } from '@/env';
 import { useCashAccountStore } from '@/features/cash/stores/cashAccountStore';
-import { useCashPaymentMethodStore } from '@/features/cash/stores/cashPaymentMethodStore';
 import { defaultConfig, defaultConfigValues, type ExperimentalConfigKey } from '@/features/config/constants/experimental';
 import { useExperimentalConfigStore } from '@/features/config/stores/experimentalConfigStore';
 import { RevokeReason } from '@/features/delegation/types/revokeReason';
@@ -487,11 +486,6 @@ export const DevSection = () => {
               onPress={() => useCashAccountStore.getState().clearUserId()}
               size={52}
               titleComponent={<MenuItem.Title text={i18n.t(i18n.l.developer_settings.cash_clear_account)} />}
-            />
-            <MenuItem
-              onPress={() => useCashPaymentMethodStore.getState().clearLinkedCard()}
-              size={52}
-              titleComponent={<MenuItem.Title text={i18n.t(i18n.l.developer_settings.cash_clear_linked_card)} />}
             />
           </Menu>
           <Menu header={i18n.t(i18n.l.developer_settings.headers.feature_flags)}>

--- a/src/languages/en_US.json
+++ b/src/languages/en_US.json
@@ -492,7 +492,6 @@
       "reset_experimental_config": "Reset Experimental Config",
       "cash_set_user_id_from_clipboard": "Set cash user id from clipboard",
       "cash_clear_account": "Clear cash account",
-      "cash_clear_linked_card": "Clear linked card",
       "status": "Status",
       "sync_codepush": "Sync CodePush",
       "simulate_device_transfer": "Simulate Device Transfer",
@@ -1561,7 +1560,13 @@
         "buy_error_generic": "Something went wrong. Try again",
         "payment_rejected": "Your card declined this payment",
         "wallet_check_error_title": "Couldn’t Continue",
-        "wallet_check_error_generic": "We couldn’t check your wallet. Try again"
+        "wallet_check_error_generic": "We couldn’t check your wallet. Try again",
+        "reauth_title": "Sign in to continue",
+        "reauth_description": "Sign in with your passkey so you can finish adding cash to your balance.",
+        "reauth_continue": "Continue",
+        "reauth_error_title": "Something went wrong",
+        "reauth_error_description": "We couldn’t load your cards. Please try again.",
+        "reauth_try_again": "Try Again"
       },
       "payment_methods": {
         "title": "Add From",


### PR DESCRIPTION
Fixes APP-4092

## Why?

The Add Cash sheet rendered its card state from a locally cached card object that was only refreshed during sign-in and passkey recovery. Any change to the user's cards outside those two moments was invisible until they re-logged in or reinstalled: the backend would list a linked Visa while the sheet still asked to add a card.

Fetching on every open was not an option as-is, because the card list needs an access token and minting one fires Face ID. Doing that unprompted on every entry to Add Cash is not acceptable.

This PR makes Add Cash an authenticated area, the same model as a banking app. On open, the sheet loads the card list from the backend with the cached token. If there is no live token, the sheet shows a "Sign in to continue" prompt instead of the amount screen, and the passkey ceremony only starts when the user taps Continue. After a successful sign-in the list loads and the amount screen appears with fresh state. A failed sign-in or card fetch shows an error prompt with Try Again; a cancelled passkey leaves the prompt in place silently. Because the access token lives in memory only, the first Add Cash open after every app launch shows this prompt.

The sheet is now the single place the card list is loaded. The special-case fetches during phone sign-in and passkey recovery are removed. Card objects are no longer persisted; only the last-used card id survives restarts, with a migration from the previously persisted card. While the list is loading, the Add From row shows a spinner and hold-to-add stays disabled.

## Approach

Authenticated Ramp requests now have two modes. The cached-only mode never prompts: with no valid token, or on a 401, it drops the token and reports that auth is required. The interactive mode keeps the existing prompt-and-retry behavior. The sheet's open path uses cached-only.

When that path reports auth is required, the intent is parked in a memory-only gate store which the sheet renders as the re-auth prompt. The Re-authenticate tap runs one sign-in ceremony and then replays the parked intent. Each tap snapshots the gate it was tapped on, so a ceremony started from a sheet that was since dismissed cannot act on a reopened one. Dismissing the sheet clears the gate.

## Visuals

https://github.com/user-attachments/assets/61cd5757-330a-46d5-b25c-dbfd0716ad94


## Testing

- Kill and relaunch the app, then open Add Cash. Expect the "Sign in to continue" prompt and no Face ID until Continue is tapped.
- Tap Continue and complete the passkey prompt. Expect the amount screen with the cards the backend returns, including a card linked from another device or directly on the backend.
- Tap Continue and cancel the passkey prompt. Expect the prompt to stay, with no error.
- Go offline, tap Continue. Expect the "Something went wrong" prompt. Go online and tap Try Again. Expect the amount screen.
- With a live session: open Add Cash. Expect a short spinner in the Add From row with hold-to-add disabled, then the card, with no Face ID.
- Remove the card from Add From settings, then link a new one. Expect the sheet to show the add-card hint and then the new card.
- Upgrade from a build with a linked card. Expect Add Cash to ask for sign-in once, then show the card.
