### PR TITLE
fix(CASH): update Add Cash intro availability copy for NY and CA

### DIFF
--- a/src/features/cash/screens/cash-deposit-intro-panel/CashDepositIntroPanel.tsx
+++ b/src/features/cash/screens/cash-deposit-intro-panel/CashDepositIntroPanel.tsx
@@ -114,8 +114,8 @@ export const CashDepositIntroPanel = memo(function CashDepositIntroPanel() {
           </Stack>
         </Box>
 
-        <Box gap={24} paddingBottom="32px" paddingTop="44px">
-          <Box gap={16} paddingHorizontal="20px">
+        <Box gap={24} paddingBottom="32px" paddingHorizontal="20px" paddingTop="44px">
+          <Box gap={16}>
             <ButtonPressAnimation onPress={handleSetUpAccount} scaleTo={0.96} testID="cash-deposit-intro-set-up-account">
               <Box
                 alignItems="center"
@@ -133,14 +133,14 @@ export const CashDepositIntroPanel = memo(function CashDepositIntroPanel() {
               {i18n.t(i18n.l.cash.deposit_intro.availability_disclaimer)}
             </Text>
           </Box>
-          <Separator color="separator" thickness={1} />
-          <Box paddingHorizontal="20px">
-            <ButtonPressAnimation onPress={handleOtherDepositMethods} scaleTo={0.96} testID="cash-deposit-intro-other-deposit-methods">
-              <Text align="center" color="blue" size="17pt" weight="heavy">
-                {i18n.t(i18n.l.cash.deposit_intro.other_deposit_methods)}
-              </Text>
-            </ButtonPressAnimation>
+          <Box marginHorizontal="-20px">
+            <Separator color="separator" thickness={1} />
           </Box>
+          <ButtonPressAnimation onPress={handleOtherDepositMethods} scaleTo={0.96} testID="cash-deposit-intro-other-deposit-methods">
+            <Text align="center" color="blue" size="17pt" weight="heavy">
+              {i18n.t(i18n.l.cash.deposit_intro.other_deposit_methods)}
+            </Text>
+          </ButtonPressAnimation>
         </Box>
       </Box>
     </PanelSheet>

--- a/src/features/cash/screens/cash-deposit-intro-panel/CashDepositIntroPanel.tsx
+++ b/src/features/cash/screens/cash-deposit-intro-panel/CashDepositIntroPanel.tsx
@@ -7,7 +7,7 @@ import { LinearGradient } from 'expo-linear-gradient';
 import { analytics } from '@/analytics';
 import { ButtonPressAnimation } from '@/components/animations/ButtonPressAnimation';
 import { PanelSheet } from '@/components/PanelSheet/PanelSheet';
-import { Box, Stack, Text, TextShadow, useColorMode, useForegroundColor } from '@/design-system';
+import { Box, Separator, Stack, Text, TextShadow, useColorMode, useForegroundColor } from '@/design-system';
 import { opacity } from '@/design-system/utils/opacity';
 import * as i18n from '@/languages';
 import { replace, useNavigation } from '@/navigation/Navigation';
@@ -17,16 +17,6 @@ import { fontWithWidth } from '@/styles/buildTextStyles';
 import { CashDepositIntroFeatureRow } from '../../components/CashDepositIntroFeatureRow';
 
 const HERO_DOLLAR_COLOR = '#0086FF';
-
-function VisaBadge({ color }: { color: string }) {
-  return (
-    <Box alignItems="center" justifyContent="center" paddingLeft="2px" style={[styles.visaBadge, { borderColor: color }]}>
-      <Text color="blue" size="11pt" weight="heavy">
-        {'VISA'}
-      </Text>
-    </Box>
-  );
-}
 
 export const CashDepositIntroPanel = memo(function CashDepositIntroPanel() {
   const { navigate } = useNavigation();
@@ -113,29 +103,44 @@ export const CashDepositIntroPanel = memo(function CashDepositIntroPanel() {
               }
               text={i18n.t(i18n.l.cash.deposit_intro.encrypted_feature)}
             />
-            <CashDepositIntroFeatureRow icon={<VisaBadge color={blue} />} text={i18n.t(i18n.l.cash.deposit_intro.visa_feature)} />
+            <CashDepositIntroFeatureRow
+              icon={
+                <Text align="center" color="blue" size="30pt" weight="medium">
+                  {'􀋦'}
+                </Text>
+              }
+              text={i18n.t(i18n.l.cash.deposit_intro.instant_feature)}
+            />
           </Stack>
         </Box>
 
-        <Box gap={32} paddingBottom="32px" paddingHorizontal="20px" paddingTop="44px">
-          <ButtonPressAnimation onPress={handleSetUpAccount} scaleTo={0.96} testID="cash-deposit-intro-set-up-account">
-            <Box
-              alignItems="center"
-              borderRadius={52}
-              height={{ custom: 48 }}
-              justifyContent="center"
-              style={[styles.cta, { backgroundColor: blue, shadowColor: blue }]}
-            >
-              <Text align="center" color="white" size="22pt" weight="heavy">
-                {i18n.t(i18n.l.cash.deposit_intro.set_up_account)}
-              </Text>
-            </Box>
-          </ButtonPressAnimation>
-          <ButtonPressAnimation onPress={handleOtherDepositMethods} scaleTo={0.96} testID="cash-deposit-intro-other-deposit-methods">
-            <Text align="center" color="blue" size="17pt" weight="heavy">
-              {i18n.t(i18n.l.cash.deposit_intro.other_deposit_methods)}
+        <Box gap={24} paddingBottom="32px" paddingTop="44px">
+          <Box gap={16} paddingHorizontal="20px">
+            <ButtonPressAnimation onPress={handleSetUpAccount} scaleTo={0.96} testID="cash-deposit-intro-set-up-account">
+              <Box
+                alignItems="center"
+                borderRadius={52}
+                height={{ custom: 48 }}
+                justifyContent="center"
+                style={[styles.cta, { backgroundColor: blue, shadowColor: blue }]}
+              >
+                <Text align="center" color="white" size="22pt" weight="heavy">
+                  {i18n.t(i18n.l.cash.deposit_intro.set_up_account)}
+                </Text>
+              </Box>
+            </ButtonPressAnimation>
+            <Text align="center" color="labelTertiary" size="15pt" weight="semibold">
+              {i18n.t(i18n.l.cash.deposit_intro.availability_disclaimer)}
             </Text>
-          </ButtonPressAnimation>
+          </Box>
+          <Separator color="separator" thickness={1} />
+          <Box paddingHorizontal="20px">
+            <ButtonPressAnimation onPress={handleOtherDepositMethods} scaleTo={0.96} testID="cash-deposit-intro-other-deposit-methods">
+              <Text align="center" color="blue" size="17pt" weight="heavy">
+                {i18n.t(i18n.l.cash.deposit_intro.other_deposit_methods)}
+              </Text>
+            </ButtonPressAnimation>
+          </Box>
         </Box>
       </Box>
     </PanelSheet>
@@ -184,11 +189,5 @@ const styles = StyleSheet.create({
   title: {
     fontSize: 41,
     lineHeight: 45,
-  },
-  visaBadge: {
-    borderRadius: 8,
-    borderWidth: 2,
-    height: 25,
-    width: 40,
   },
 });

--- a/src/languages/en_US.json
+++ b/src/languages/en_US.json
@@ -1539,7 +1539,7 @@
         "introducing": "Introducing",
         "title": "Cash Deposits",
         "encrypted_feature": "Your information is encrypted and protected.",
-        "visa_feature": "Available for US-based customers using a Visa card.",
+        "visa_feature": "Available for US-based customers except New York, Utah, Hawaii, using a Visa card.",
         "set_up_account": "Set Up Account",
         "other_deposit_methods": "Other Deposit Methods",
         "sign_in": "Sign In"

--- a/src/languages/en_US.json
+++ b/src/languages/en_US.json
@@ -1539,7 +1539,8 @@
         "introducing": "Introducing",
         "title": "Cash Deposits",
         "encrypted_feature": "Your information is encrypted and protected.",
-        "visa_feature": "Available for US-based customers except New York, Utah, Hawaii, using a Visa card.",
+        "instant_feature": "Cash transactions are instant and seamless.",
+        "availability_disclaimer": "Available for US-based customers except New York and California, using a Visa card.",
         "set_up_account": "Set Up Account",
         "other_deposit_methods": "Other Deposit Methods",
         "sign_in": "Sign In"


### PR DESCRIPTION
Fixes APP-4104
Update Cash Deposits intro sheet availability line + "Cash transactions are instant and seamless" row
Added further comments: https://linear.app/rainbow/issue/APP-4104/update-add-cash-intro-screen-with-availability-copy-re-ny-and-ca#comment-8357f2ae

Fixes APP-4104

## Screen recordings / screenshots
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-09-11 at 11 34 26" src="https://github.com/user-attachments/assets/93756400-b4e5-4b22-8fea-e6749df523af" />


