### PR TITLE
feat(CASH): implement state coming soon sheet for NY

### DIFF
--- a/src/analytics/event.ts
+++ b/src/analytics/event.ts
@@ -585,7 +585,7 @@ export type EventProperties = {
     source: 'submit' | 'resume';
   };
   [event.cashKycFailed]: {
-    reason: TelemetryErrorReason | 'rejected';
+    reason: TelemetryErrorReason | 'rejected' | 'state_not_supported';
   };
   [event.cashPasskeySubmitted]: undefined;
   [event.cashPasskeyAdded]: undefined;

--- a/src/features/cash/components/CashStatusHalfSheet.tsx
+++ b/src/features/cash/components/CashStatusHalfSheet.tsx
@@ -7,7 +7,6 @@ import { AbsolutePortal } from '@/components/AbsolutePortal';
 import { ButtonPressAnimation } from '@/components/animations/ButtonPressAnimation';
 import { PanelSheet } from '@/components/PanelSheet/PanelSheet';
 import { Box, Separator, Text } from '@/design-system';
-import { type TextColor } from '@/design-system/color/palettes';
 
 import { useCashHalfSheetVisibilityStore } from '../stores/cashHalfSheetVisibilityStore';
 import { CashActionButton } from './CashActionButton';
@@ -31,8 +30,8 @@ type CommonProps = {
 type CashStatusPanelContent = CommonProps &
   (
     | { status: 'inProgress' }
-    // icon/iconColor override the default reviewing appearance, e.g. for an info-style sheet.
-    | { status: 'reviewing'; action: HalfSheetAction; icon?: string; iconColor?: TextColor }
+    | { status: 'reviewing'; action: HalfSheetAction }
+    | { status: 'info'; action: HalfSheetAction; icon: string }
     | { status: 'success'; action: HalfSheetAction; successIcon: string }
     | { status: 'error'; primaryAction: HalfSheetAction; secondaryAction?: HalfSheetAction }
     | { status: 'warning'; primaryAction: HalfSheetAction; secondaryAction: HalfSheetAction }
@@ -48,6 +47,7 @@ const STATUS_ICONS = {
 const STATUS_ICON_COLORS = {
   error: 'red',
   inProgress: 'blue',
+  info: 'labelQuaternary',
   reviewing: 'blue',
   success: 'green',
   warning: 'red',
@@ -58,13 +58,8 @@ const PANEL_EXITING_ANIMATION = SlideOutDown.springify().damping(70).mass(0.8).s
 const PANEL_RESIZE_ANIMATION = LinearTransition.duration(200).easing(Easing.inOut(Easing.ease));
 
 export function CashStatusPanel({ content: props }: { content: CashStatusPanelContent }) {
-  const icon =
-    props.status === 'success'
-      ? props.successIcon
-      : props.status === 'reviewing'
-        ? (props.icon ?? STATUS_ICONS.reviewing)
-        : STATUS_ICONS[props.status];
-  const iconColor = props.status === 'reviewing' ? (props.iconColor ?? STATUS_ICON_COLORS.reviewing) : STATUS_ICON_COLORS[props.status];
+  const icon = props.status === 'success' ? props.successIcon : props.status === 'info' ? props.icon : STATUS_ICONS[props.status];
+  const iconColor = STATUS_ICON_COLORS[props.status];
   const isAlert = props.status === 'error' || props.status === 'warning';
 
   return (
@@ -92,7 +87,7 @@ export function CashStatusPanel({ content: props }: { content: CashStatusPanelCo
             </Box>
           )}
 
-          {props.status === 'reviewing' && (
+          {(props.status === 'reviewing' || props.status === 'info') && (
             <Box paddingTop="32px">
               <CashActionButton {...props.action} variant="tinted" />
             </Box>

--- a/src/features/cash/components/CashStatusHalfSheet.tsx
+++ b/src/features/cash/components/CashStatusHalfSheet.tsx
@@ -4,9 +4,8 @@ import { Keyboard, StyleSheet, View } from 'react-native';
 import Animated, { Easing, FadeIn, FadeOut, LinearTransition, SlideInDown, SlideOutDown } from 'react-native-reanimated';
 
 import { AbsolutePortal } from '@/components/AbsolutePortal';
-import { ButtonPressAnimation } from '@/components/animations/ButtonPressAnimation';
 import { PanelSheet } from '@/components/PanelSheet/PanelSheet';
-import { Box, Separator, Text } from '@/design-system';
+import { Box, Text } from '@/design-system';
 
 import { useCashHalfSheetVisibilityStore } from '../stores/cashHalfSheetVisibilityStore';
 import { CashActionButton } from './CashActionButton';
@@ -23,8 +22,6 @@ type CommonProps = {
   description: string;
   testID: string;
   title: string;
-  // A footer link below a divider, e.g. an alternative when the main action doesn't apply.
-  footerAction?: HalfSheetAction;
 };
 
 type CashStatusPanelContent = CommonProps &
@@ -103,17 +100,6 @@ export function CashStatusPanel({ content: props }: { content: CashStatusPanelCo
             </Box>
           )}
         </Box>
-
-        {props.footerAction && (
-          <Box gap={24} paddingBottom="24px">
-            <Separator color="separatorTertiary" />
-            <ButtonPressAnimation onPress={props.footerAction.onPress} scaleTo={0.96} testID={props.footerAction.testID}>
-              <Text align="center" color="label" size="17pt" weight="heavy">
-                {props.footerAction.label}
-              </Text>
-            </ButtonPressAnimation>
-          </Box>
-        )}
       </Animated.View>
     </PanelSheet>
   );

--- a/src/features/cash/components/CashStatusHalfSheet.tsx
+++ b/src/features/cash/components/CashStatusHalfSheet.tsx
@@ -7,6 +7,7 @@ import { AbsolutePortal } from '@/components/AbsolutePortal';
 import { ButtonPressAnimation } from '@/components/animations/ButtonPressAnimation';
 import { PanelSheet } from '@/components/PanelSheet/PanelSheet';
 import { Box, Separator, Text } from '@/design-system';
+import { type TextColor } from '@/design-system/color/palettes';
 
 import { useCashHalfSheetVisibilityStore } from '../stores/cashHalfSheetVisibilityStore';
 import { CashActionButton } from './CashActionButton';
@@ -30,8 +31,8 @@ type CommonProps = {
 type CashStatusPanelContent = CommonProps &
   (
     | { status: 'inProgress' }
-    | { status: 'reviewing'; action: HalfSheetAction }
-    | { status: 'info'; action: HalfSheetAction; icon: string }
+    // icon/iconColor override the default reviewing appearance, e.g. for an info-style sheet.
+    | { status: 'reviewing'; action: HalfSheetAction; icon?: string; iconColor?: TextColor }
     | { status: 'success'; action: HalfSheetAction; successIcon: string }
     | { status: 'error'; primaryAction: HalfSheetAction; secondaryAction?: HalfSheetAction }
     | { status: 'warning'; primaryAction: HalfSheetAction; secondaryAction: HalfSheetAction }
@@ -47,7 +48,6 @@ const STATUS_ICONS = {
 const STATUS_ICON_COLORS = {
   error: 'red',
   inProgress: 'blue',
-  info: 'labelQuaternary',
   reviewing: 'blue',
   success: 'green',
   warning: 'red',
@@ -58,8 +58,13 @@ const PANEL_EXITING_ANIMATION = SlideOutDown.springify().damping(70).mass(0.8).s
 const PANEL_RESIZE_ANIMATION = LinearTransition.duration(200).easing(Easing.inOut(Easing.ease));
 
 export function CashStatusPanel({ content: props }: { content: CashStatusPanelContent }) {
-  const icon = props.status === 'success' ? props.successIcon : props.status === 'info' ? props.icon : STATUS_ICONS[props.status];
-  const iconColor = STATUS_ICON_COLORS[props.status];
+  const icon =
+    props.status === 'success'
+      ? props.successIcon
+      : props.status === 'reviewing'
+        ? (props.icon ?? STATUS_ICONS.reviewing)
+        : STATUS_ICONS[props.status];
+  const iconColor = props.status === 'reviewing' ? (props.iconColor ?? STATUS_ICON_COLORS.reviewing) : STATUS_ICON_COLORS[props.status];
   const isAlert = props.status === 'error' || props.status === 'warning';
 
   return (
@@ -87,7 +92,7 @@ export function CashStatusPanel({ content: props }: { content: CashStatusPanelCo
             </Box>
           )}
 
-          {(props.status === 'reviewing' || props.status === 'info') && (
+          {props.status === 'reviewing' && (
             <Box paddingTop="32px">
               <CashActionButton {...props.action} variant="tinted" />
             </Box>

--- a/src/features/cash/components/CashStatusHalfSheet.tsx
+++ b/src/features/cash/components/CashStatusHalfSheet.tsx
@@ -4,8 +4,9 @@ import { Keyboard, StyleSheet, View } from 'react-native';
 import Animated, { Easing, FadeIn, FadeOut, LinearTransition, SlideInDown, SlideOutDown } from 'react-native-reanimated';
 
 import { AbsolutePortal } from '@/components/AbsolutePortal';
+import { ButtonPressAnimation } from '@/components/animations/ButtonPressAnimation';
 import { PanelSheet } from '@/components/PanelSheet/PanelSheet';
-import { Box, Text } from '@/design-system';
+import { Box, Separator, Text } from '@/design-system';
 
 import { useCashHalfSheetVisibilityStore } from '../stores/cashHalfSheetVisibilityStore';
 import { CashActionButton } from './CashActionButton';
@@ -22,12 +23,15 @@ type CommonProps = {
   description: string;
   testID: string;
   title: string;
+  // A footer link below a divider, e.g. an alternative when the main action doesn't apply.
+  footerAction?: HalfSheetAction;
 };
 
 type CashStatusPanelContent = CommonProps &
   (
     | { status: 'inProgress' }
     | { status: 'reviewing'; action: HalfSheetAction }
+    | { status: 'info'; action: HalfSheetAction; icon: string }
     | { status: 'success'; action: HalfSheetAction; successIcon: string }
     | { status: 'error'; primaryAction: HalfSheetAction; secondaryAction?: HalfSheetAction }
     | { status: 'warning'; primaryAction: HalfSheetAction; secondaryAction: HalfSheetAction }
@@ -43,6 +47,7 @@ const STATUS_ICONS = {
 const STATUS_ICON_COLORS = {
   error: 'red',
   inProgress: 'blue',
+  info: 'labelQuaternary',
   reviewing: 'blue',
   success: 'green',
   warning: 'red',
@@ -53,7 +58,7 @@ const PANEL_EXITING_ANIMATION = SlideOutDown.springify().damping(70).mass(0.8).s
 const PANEL_RESIZE_ANIMATION = LinearTransition.duration(200).easing(Easing.inOut(Easing.ease));
 
 export function CashStatusPanel({ content: props }: { content: CashStatusPanelContent }) {
-  const icon = props.status === 'success' ? props.successIcon : STATUS_ICONS[props.status];
+  const icon = props.status === 'success' ? props.successIcon : props.status === 'info' ? props.icon : STATUS_ICONS[props.status];
   const iconColor = STATUS_ICON_COLORS[props.status];
   const isAlert = props.status === 'error' || props.status === 'warning';
 
@@ -82,7 +87,7 @@ export function CashStatusPanel({ content: props }: { content: CashStatusPanelCo
             </Box>
           )}
 
-          {props.status === 'reviewing' && (
+          {(props.status === 'reviewing' || props.status === 'info') && (
             <Box paddingTop="32px">
               <CashActionButton {...props.action} variant="tinted" />
             </Box>
@@ -97,6 +102,17 @@ export function CashStatusPanel({ content: props }: { content: CashStatusPanelCo
             </Box>
           )}
         </Box>
+
+        {props.footerAction && (
+          <Box gap={24} paddingBottom="24px">
+            <Separator color="separatorTertiary" />
+            <ButtonPressAnimation onPress={props.footerAction.onPress} scaleTo={0.96} testID={props.footerAction.testID}>
+              <Text align="center" color="label" size="17pt" weight="heavy">
+                {props.footerAction.label}
+              </Text>
+            </ButtonPressAnimation>
+          </Box>
+        )}
       </Animated.View>
     </PanelSheet>
   );

--- a/src/features/cash/components/CashStatusHalfSheet.tsx
+++ b/src/features/cash/components/CashStatusHalfSheet.tsx
@@ -31,7 +31,7 @@ type CashStatusPanelContent = CommonProps &
   (
     | { status: 'inProgress' }
     | { status: 'reviewing'; action: HalfSheetAction }
-    | { status: 'info'; action: HalfSheetAction; icon: string }
+    | { status: 'info'; action: HalfSheetAction }
     | { status: 'success'; action: HalfSheetAction; successIcon: string }
     | { status: 'error'; primaryAction: HalfSheetAction; secondaryAction?: HalfSheetAction }
     | { status: 'warning'; primaryAction: HalfSheetAction; secondaryAction: HalfSheetAction }
@@ -40,6 +40,7 @@ type CashStatusPanelContent = CommonProps &
 const STATUS_ICONS = {
   error: '􀁠',
   inProgress: '􀖇',
+  info: '􀆪',
   reviewing: '􀐫',
   warning: '􀇾',
 } as const;
@@ -58,7 +59,7 @@ const PANEL_EXITING_ANIMATION = SlideOutDown.springify().damping(70).mass(0.8).s
 const PANEL_RESIZE_ANIMATION = LinearTransition.duration(200).easing(Easing.inOut(Easing.ease));
 
 export function CashStatusPanel({ content: props }: { content: CashStatusPanelContent }) {
-  const icon = props.status === 'success' ? props.successIcon : props.status === 'info' ? props.icon : STATUS_ICONS[props.status];
+  const icon = props.status === 'success' ? props.successIcon : STATUS_ICONS[props.status];
   const iconColor = STATUS_ICON_COLORS[props.status];
   const isAlert = props.status === 'error' || props.status === 'warning';
 

--- a/src/features/cash/screens/cash-deposit-setup/components/KycOutcomeSheet.tsx
+++ b/src/features/cash/screens/cash-deposit-setup/components/KycOutcomeSheet.tsx
@@ -60,13 +60,12 @@ export const KycOutcomeSheet = memo(function KycOutcomeSheet({ onContinue, outco
     case 'unsupportedState':
       return (
         <CashStatusHalfSheet
-          action={{ label: i18n.t(i18n.l.button.dismiss), onPress: goBack, testID: 'cash-setup-kyc-state-not-supported-dismiss' }}
-          description={i18n.t(l.state_not_supported_description)}
-          footerAction={{
+          action={{
             label: i18n.t(i18n.l.cash.deposit_intro.other_deposit_methods),
             onPress: otherDepositMethods,
             testID: 'cash-setup-kyc-state-not-supported-other-methods',
           }}
+          description={i18n.t(l.state_not_supported_description)}
           status="info"
           testID="cash-setup-kyc-state-not-supported"
           title={i18n.t(l.state_not_supported_title)}

--- a/src/features/cash/screens/cash-deposit-setup/components/KycOutcomeSheet.tsx
+++ b/src/features/cash/screens/cash-deposit-setup/components/KycOutcomeSheet.tsx
@@ -69,8 +69,7 @@ export const KycOutcomeSheet = memo(function KycOutcomeSheet({ onContinue, outco
             testID: 'cash-setup-kyc-state-not-supported-other-methods',
           }}
           icon={STATE_NOT_SUPPORTED_ICON}
-          iconColor="labelQuaternary"
-          status="reviewing"
+          status="info"
           testID="cash-setup-kyc-state-not-supported"
           title={i18n.t(l.state_not_supported_title)}
         />

--- a/src/features/cash/screens/cash-deposit-setup/components/KycOutcomeSheet.tsx
+++ b/src/features/cash/screens/cash-deposit-setup/components/KycOutcomeSheet.tsx
@@ -11,7 +11,6 @@ import { type KycOutcome } from '../../../services/userClient';
 
 const l = i18n.l.cash.deposit_setup.kyc;
 const IDENTITY_VERIFIED_ICON = '􀯧';
-const STATE_NOT_SUPPORTED_ICON = '􀆪';
 
 function contactSupport() {
   openInBrowser(RAINBOW_SUPPORT_URL);
@@ -68,7 +67,6 @@ export const KycOutcomeSheet = memo(function KycOutcomeSheet({ onContinue, outco
             onPress: otherDepositMethods,
             testID: 'cash-setup-kyc-state-not-supported-other-methods',
           }}
-          icon={STATE_NOT_SUPPORTED_ICON}
           status="info"
           testID="cash-setup-kyc-state-not-supported"
           title={i18n.t(l.state_not_supported_title)}

--- a/src/features/cash/screens/cash-deposit-setup/components/KycOutcomeSheet.tsx
+++ b/src/features/cash/screens/cash-deposit-setup/components/KycOutcomeSheet.tsx
@@ -2,7 +2,8 @@ import React, { memo } from 'react';
 
 import { CashStatusHalfSheet } from '@/features/cash/components/CashStatusHalfSheet';
 import * as i18n from '@/languages';
-import { goBack } from '@/navigation/Navigation';
+import { goBack, navigate } from '@/navigation/Navigation';
+import Routes from '@/navigation/routesNames';
 import { RAINBOW_SUPPORT_URL } from '@/references/constants';
 import { openInBrowser } from '@/utils/openInBrowser';
 
@@ -10,10 +11,15 @@ import { type KycOutcome } from '../../../services/userClient';
 
 const l = i18n.l.cash.deposit_setup.kyc;
 const IDENTITY_VERIFIED_ICON = '􀯧';
+const STATE_NOT_SUPPORTED_ICON = '􀆪';
 
 function contactSupport() {
   openInBrowser(RAINBOW_SUPPORT_URL);
   goBack();
+}
+
+function otherDepositMethods() {
+  navigate(Routes.FIAT_ON_RAMP_SHEET);
 }
 
 export const KycOutcomeSheet = memo(function KycOutcomeSheet({ onContinue, outcome }: { onContinue: () => void; outcome: KycOutcome }) {
@@ -50,6 +56,22 @@ export const KycOutcomeSheet = memo(function KycOutcomeSheet({ onContinue, outco
           status="error"
           testID="cash-setup-kyc-rejected"
           title={i18n.t(l.rejected_title)}
+        />
+      );
+    case 'unsupportedState':
+      return (
+        <CashStatusHalfSheet
+          action={{ label: i18n.t(l.dismiss), onPress: goBack, testID: 'cash-setup-kyc-state-not-supported-dismiss' }}
+          description={i18n.t(l.state_not_supported_description)}
+          footerAction={{
+            label: i18n.t(i18n.l.cash.deposit_intro.other_deposit_methods),
+            onPress: otherDepositMethods,
+            testID: 'cash-setup-kyc-state-not-supported-other-methods',
+          }}
+          icon={STATE_NOT_SUPPORTED_ICON}
+          status="info"
+          testID="cash-setup-kyc-state-not-supported"
+          title={i18n.t(l.state_not_supported_title)}
         />
       );
   }

--- a/src/features/cash/screens/cash-deposit-setup/components/KycOutcomeSheet.tsx
+++ b/src/features/cash/screens/cash-deposit-setup/components/KycOutcomeSheet.tsx
@@ -61,7 +61,7 @@ export const KycOutcomeSheet = memo(function KycOutcomeSheet({ onContinue, outco
     case 'unsupportedState':
       return (
         <CashStatusHalfSheet
-          action={{ label: i18n.t(l.dismiss), onPress: goBack, testID: 'cash-setup-kyc-state-not-supported-dismiss' }}
+          action={{ label: i18n.t(i18n.l.button.dismiss), onPress: goBack, testID: 'cash-setup-kyc-state-not-supported-dismiss' }}
           description={i18n.t(l.state_not_supported_description)}
           footerAction={{
             label: i18n.t(i18n.l.cash.deposit_intro.other_deposit_methods),
@@ -69,7 +69,8 @@ export const KycOutcomeSheet = memo(function KycOutcomeSheet({ onContinue, outco
             testID: 'cash-setup-kyc-state-not-supported-other-methods',
           }}
           icon={STATE_NOT_SUPPORTED_ICON}
-          status="info"
+          iconColor="labelQuaternary"
+          status="reviewing"
           testID="cash-setup-kyc-state-not-supported"
           title={i18n.t(l.state_not_supported_title)}
         />

--- a/src/features/cash/screens/cash-deposit-setup/steps/useSubmitReviewFlow.test.ts
+++ b/src/features/cash/screens/cash-deposit-setup/steps/useSubmitReviewFlow.test.ts
@@ -4,7 +4,7 @@ import { logger } from '@/logger';
 import { delay } from '@/utils/delay';
 
 import { createUsSsnLast4GovernmentId, isValidUsSsnLast4 } from '../../../services/cashSetupIdentityService';
-import { getUserStatus, KycStatus, submitOnboarding } from '../../../services/userClient';
+import { getUserStatus, KycRejectionReason, KycStatus, submitOnboarding } from '../../../services/userClient';
 import { useCashSetupSessionStore } from '../../../stores/cashSetupSessionStore';
 import { KYC_POLL_INTERVAL_MS, useSubmitReviewFlowStore, type SubmitReviewState } from './useSubmitReviewFlow';
 
@@ -41,6 +41,10 @@ jest.mock('../../../services/userClient', () => ({
     Approved: 'KYC_STATUS_APPROVED',
     Rejected: 'KYC_STATUS_REJECTED',
     Review: 'KYC_STATUS_REVIEW',
+  },
+  KycRejectionReason: {
+    Unspecified: 'KYC_REJECTION_REASON_UNSPECIFIED',
+    StateNotSupported: 'KYC_REJECTION_REASON_STATE_NOT_SUPPORTED',
   },
   getUserStatus: jest.fn(),
   submitOnboarding: jest.fn(),
@@ -81,8 +85,8 @@ beforeEach(() => {
   session().setLastName(IDENTITY.lastName);
   session().setDateOfBirth(IDENTITY.dateOfBirth);
   session().setSsnLast4(GOVERNMENT_ID.value);
-  mockSubmitOnboarding.mockResolvedValue({ kycStatus: KycStatus.Approved });
-  mockGetUserStatus.mockResolvedValue({ kycStatus: KycStatus.Approved });
+  mockSubmitOnboarding.mockResolvedValue({ kycStatus: KycStatus.Approved, kycRejectionReason: KycRejectionReason.Unspecified });
+  mockGetUserStatus.mockResolvedValue({ kycStatus: KycStatus.Approved, kycRejectionReason: KycRejectionReason.Unspecified });
 });
 
 afterEach(() => {
@@ -112,8 +116,10 @@ describe('useSubmitReviewFlowStore.submit onboarding', () => {
   });
 
   it('polls while pending, then approves', async () => {
-    mockSubmitOnboarding.mockResolvedValue({ kycStatus: KycStatus.Pending });
-    mockGetUserStatus.mockResolvedValueOnce({ kycStatus: KycStatus.Pending }).mockResolvedValueOnce({ kycStatus: KycStatus.Approved });
+    mockSubmitOnboarding.mockResolvedValue({ kycStatus: KycStatus.Pending, kycRejectionReason: KycRejectionReason.Unspecified });
+    mockGetUserStatus
+      .mockResolvedValueOnce({ kycStatus: KycStatus.Pending, kycRejectionReason: KycRejectionReason.Unspecified })
+      .mockResolvedValueOnce({ kycStatus: KycStatus.Approved, kycRejectionReason: KycRejectionReason.Unspecified });
 
     await expect(flow().submit()).resolves.toBe('approved');
 
@@ -124,17 +130,17 @@ describe('useSubmitReviewFlowStore.submit onboarding', () => {
 
   it('switches to reviewing once the delay elapses, and keeps polling until the verdict lands', async () => {
     const clock = fakeClock();
-    mockSubmitOnboarding.mockResolvedValue({ kycStatus: KycStatus.Pending });
+    mockSubmitOnboarding.mockResolvedValue({ kycStatus: KycStatus.Pending, kycRejectionReason: KycRejectionReason.Unspecified });
     const statesWhilePolling: SubmitReviewState[] = [];
     mockGetUserStatus
       .mockImplementationOnce(() => {
         statesWhilePolling.push(flow().state);
         clock.advance(REVIEW_DELAY_MS);
-        return Promise.resolve({ kycStatus: KycStatus.Pending });
+        return Promise.resolve({ kycStatus: KycStatus.Pending, kycRejectionReason: KycRejectionReason.Unspecified });
       })
       .mockImplementationOnce(() => {
         statesWhilePolling.push(flow().state);
-        return Promise.resolve({ kycStatus: KycStatus.Approved });
+        return Promise.resolve({ kycStatus: KycStatus.Approved, kycRejectionReason: KycRejectionReason.Unspecified });
       });
 
     await expect(flow().submit()).resolves.toBe('approved');
@@ -147,15 +153,15 @@ describe('useSubmitReviewFlowStore.submit onboarding', () => {
 
   it('tracks the awaiting-decision event only once however long the wait runs', async () => {
     const clock = fakeClock();
-    mockSubmitOnboarding.mockResolvedValue({ kycStatus: KycStatus.Pending });
+    mockSubmitOnboarding.mockResolvedValue({ kycStatus: KycStatus.Pending, kycRejectionReason: KycRejectionReason.Unspecified });
     mockDelay.mockImplementationOnce(() => {
       clock.advance(REVIEW_DELAY_MS);
       return Promise.resolve();
     });
     mockGetUserStatus
-      .mockResolvedValueOnce({ kycStatus: KycStatus.Pending })
-      .mockResolvedValueOnce({ kycStatus: KycStatus.Pending })
-      .mockResolvedValueOnce({ kycStatus: KycStatus.Approved });
+      .mockResolvedValueOnce({ kycStatus: KycStatus.Pending, kycRejectionReason: KycRejectionReason.Unspecified })
+      .mockResolvedValueOnce({ kycStatus: KycStatus.Pending, kycRejectionReason: KycRejectionReason.Unspecified })
+      .mockResolvedValueOnce({ kycStatus: KycStatus.Approved, kycRejectionReason: KycRejectionReason.Unspecified });
 
     await flow().submit();
 
@@ -163,7 +169,7 @@ describe('useSubmitReviewFlowStore.submit onboarding', () => {
   });
 
   it('reports a rejection without offering a retry', async () => {
-    mockSubmitOnboarding.mockResolvedValue({ kycStatus: KycStatus.Rejected });
+    mockSubmitOnboarding.mockResolvedValue({ kycStatus: KycStatus.Rejected, kycRejectionReason: KycRejectionReason.Unspecified });
 
     await expect(flow().submit()).resolves.toBe('rejected');
 
@@ -172,9 +178,19 @@ describe('useSubmitReviewFlowStore.submit onboarding', () => {
     expect(flow().state).toBe('rejected');
   });
 
+  it('reports unsupportedState when rejected for an unsupported state', async () => {
+    mockSubmitOnboarding.mockResolvedValue({ kycStatus: KycStatus.Rejected, kycRejectionReason: KycRejectionReason.StateNotSupported });
+
+    await expect(flow().submit()).resolves.toBe('unsupportedState');
+
+    expect(mockGetUserStatus).not.toHaveBeenCalled();
+    expect(track).toHaveBeenCalledWith('cash.kyc_failed', { reason: 'state_not_supported' });
+    expect(flow().state).toBe('unsupportedState');
+  });
+
   it.each([KycStatus.Unspecified, KycStatus.Review])('keeps polling on %s instead of failing', async kycStatus => {
-    mockSubmitOnboarding.mockResolvedValue({ kycStatus });
-    mockGetUserStatus.mockResolvedValue({ kycStatus: KycStatus.Approved });
+    mockSubmitOnboarding.mockResolvedValue({ kycStatus, kycRejectionReason: KycRejectionReason.Unspecified });
+    mockGetUserStatus.mockResolvedValue({ kycStatus: KycStatus.Approved, kycRejectionReason: KycRejectionReason.Unspecified });
 
     await expect(flow().submit()).resolves.toBe('approved');
 
@@ -183,7 +199,7 @@ describe('useSubmitReviewFlowStore.submit onboarding', () => {
   });
 
   it('falls back to reviewing when a status poll fails, never to the retryable error', async () => {
-    mockSubmitOnboarding.mockResolvedValue({ kycStatus: KycStatus.Pending });
+    mockSubmitOnboarding.mockResolvedValue({ kycStatus: KycStatus.Pending, kycRejectionReason: KycRejectionReason.Unspecified });
     mockGetUserStatus.mockRejectedValue(new Error('token expired'));
 
     await expect(flow().submit()).resolves.toBe('awaitingDecision');
@@ -195,9 +211,9 @@ describe('useSubmitReviewFlowStore.submit onboarding', () => {
   });
 
   it('ignores an active status poll after the flow is reset', async () => {
-    const poll = Promise.withResolvers<{ kycStatus: KycStatus }>();
+    const poll = Promise.withResolvers<{ kycStatus: KycStatus; kycRejectionReason: KycRejectionReason }>();
     const pollStarted = Promise.withResolvers<void>();
-    mockSubmitOnboarding.mockResolvedValue({ kycStatus: KycStatus.Pending });
+    mockSubmitOnboarding.mockResolvedValue({ kycStatus: KycStatus.Pending, kycRejectionReason: KycRejectionReason.Unspecified });
     mockGetUserStatus.mockImplementationOnce(() => {
       pollStarted.resolve();
       return poll.promise;
@@ -206,7 +222,7 @@ describe('useSubmitReviewFlowStore.submit onboarding', () => {
     const submission = flow().submit();
     await pollStarted.promise;
     flow().reset();
-    poll.resolve({ kycStatus: KycStatus.Approved });
+    poll.resolve({ kycStatus: KycStatus.Approved, kycRejectionReason: KycRejectionReason.Unspecified });
 
     await expect(submission).resolves.toBe('cancelled');
 
@@ -226,14 +242,14 @@ describe('useSubmitReviewFlowStore.submit onboarding', () => {
   });
 
   it('skips a second submit while one is in flight', async () => {
-    const submit = Promise.withResolvers<{ kycStatus: KycStatus }>();
+    const submit = Promise.withResolvers<{ kycStatus: KycStatus; kycRejectionReason: KycRejectionReason }>();
     mockSubmitOnboarding.mockReturnValue(submit.promise);
 
     const first = flow().submit();
     await expect(flow().submit()).resolves.toBe('skipped');
 
     expect(mockSubmitOnboarding).toHaveBeenCalledTimes(1);
-    submit.resolve({ kycStatus: KycStatus.Approved });
+    submit.resolve({ kycStatus: KycStatus.Approved, kycRejectionReason: KycRejectionReason.Unspecified });
     await expect(first).resolves.toBe('approved');
   });
 

--- a/src/features/cash/screens/cash-deposit-setup/steps/useSubmitReviewFlow.test.ts
+++ b/src/features/cash/screens/cash-deposit-setup/steps/useSubmitReviewFlow.test.ts
@@ -4,7 +4,7 @@ import { logger } from '@/logger';
 import { delay } from '@/utils/delay';
 
 import { createUsSsnLast4GovernmentId, isValidUsSsnLast4 } from '../../../services/cashSetupIdentityService';
-import { getUserStatus, KycRejectionReason, KycStatus, submitOnboarding } from '../../../services/userClient';
+import { getUserStatus, KycRejectionReason, KycStatus, submitOnboarding, type KycStatusResult } from '../../../services/userClient';
 import { useCashSetupSessionStore } from '../../../stores/cashSetupSessionStore';
 import { KYC_POLL_INTERVAL_MS, useSubmitReviewFlowStore, type SubmitReviewState } from './useSubmitReviewFlow';
 
@@ -85,8 +85,8 @@ beforeEach(() => {
   session().setLastName(IDENTITY.lastName);
   session().setDateOfBirth(IDENTITY.dateOfBirth);
   session().setSsnLast4(GOVERNMENT_ID.value);
-  mockSubmitOnboarding.mockResolvedValue({ kycStatus: KycStatus.Approved, kycRejectionReason: KycRejectionReason.Unspecified });
-  mockGetUserStatus.mockResolvedValue({ kycStatus: KycStatus.Approved, kycRejectionReason: KycRejectionReason.Unspecified });
+  mockSubmitOnboarding.mockResolvedValue({ kycStatus: KycStatus.Approved });
+  mockGetUserStatus.mockResolvedValue({ kycStatus: KycStatus.Approved });
 });
 
 afterEach(() => {
@@ -116,10 +116,8 @@ describe('useSubmitReviewFlowStore.submit onboarding', () => {
   });
 
   it('polls while pending, then approves', async () => {
-    mockSubmitOnboarding.mockResolvedValue({ kycStatus: KycStatus.Pending, kycRejectionReason: KycRejectionReason.Unspecified });
-    mockGetUserStatus
-      .mockResolvedValueOnce({ kycStatus: KycStatus.Pending, kycRejectionReason: KycRejectionReason.Unspecified })
-      .mockResolvedValueOnce({ kycStatus: KycStatus.Approved, kycRejectionReason: KycRejectionReason.Unspecified });
+    mockSubmitOnboarding.mockResolvedValue({ kycStatus: KycStatus.Pending });
+    mockGetUserStatus.mockResolvedValueOnce({ kycStatus: KycStatus.Pending }).mockResolvedValueOnce({ kycStatus: KycStatus.Approved });
 
     await expect(flow().submit()).resolves.toBe('approved');
 
@@ -130,17 +128,17 @@ describe('useSubmitReviewFlowStore.submit onboarding', () => {
 
   it('switches to reviewing once the delay elapses, and keeps polling until the verdict lands', async () => {
     const clock = fakeClock();
-    mockSubmitOnboarding.mockResolvedValue({ kycStatus: KycStatus.Pending, kycRejectionReason: KycRejectionReason.Unspecified });
+    mockSubmitOnboarding.mockResolvedValue({ kycStatus: KycStatus.Pending });
     const statesWhilePolling: SubmitReviewState[] = [];
     mockGetUserStatus
       .mockImplementationOnce(() => {
         statesWhilePolling.push(flow().state);
         clock.advance(REVIEW_DELAY_MS);
-        return Promise.resolve({ kycStatus: KycStatus.Pending, kycRejectionReason: KycRejectionReason.Unspecified });
+        return Promise.resolve({ kycStatus: KycStatus.Pending });
       })
       .mockImplementationOnce(() => {
         statesWhilePolling.push(flow().state);
-        return Promise.resolve({ kycStatus: KycStatus.Approved, kycRejectionReason: KycRejectionReason.Unspecified });
+        return Promise.resolve({ kycStatus: KycStatus.Approved });
       });
 
     await expect(flow().submit()).resolves.toBe('approved');
@@ -153,15 +151,15 @@ describe('useSubmitReviewFlowStore.submit onboarding', () => {
 
   it('tracks the awaiting-decision event only once however long the wait runs', async () => {
     const clock = fakeClock();
-    mockSubmitOnboarding.mockResolvedValue({ kycStatus: KycStatus.Pending, kycRejectionReason: KycRejectionReason.Unspecified });
+    mockSubmitOnboarding.mockResolvedValue({ kycStatus: KycStatus.Pending });
     mockDelay.mockImplementationOnce(() => {
       clock.advance(REVIEW_DELAY_MS);
       return Promise.resolve();
     });
     mockGetUserStatus
-      .mockResolvedValueOnce({ kycStatus: KycStatus.Pending, kycRejectionReason: KycRejectionReason.Unspecified })
-      .mockResolvedValueOnce({ kycStatus: KycStatus.Pending, kycRejectionReason: KycRejectionReason.Unspecified })
-      .mockResolvedValueOnce({ kycStatus: KycStatus.Approved, kycRejectionReason: KycRejectionReason.Unspecified });
+      .mockResolvedValueOnce({ kycStatus: KycStatus.Pending })
+      .mockResolvedValueOnce({ kycStatus: KycStatus.Pending })
+      .mockResolvedValueOnce({ kycStatus: KycStatus.Approved });
 
     await flow().submit();
 
@@ -169,7 +167,7 @@ describe('useSubmitReviewFlowStore.submit onboarding', () => {
   });
 
   it('reports a rejection without offering a retry', async () => {
-    mockSubmitOnboarding.mockResolvedValue({ kycStatus: KycStatus.Rejected, kycRejectionReason: KycRejectionReason.Unspecified });
+    mockSubmitOnboarding.mockResolvedValue({ kycStatus: KycStatus.Rejected });
 
     await expect(flow().submit()).resolves.toBe('rejected');
 
@@ -189,8 +187,8 @@ describe('useSubmitReviewFlowStore.submit onboarding', () => {
   });
 
   it.each([KycStatus.Unspecified, KycStatus.Review])('keeps polling on %s instead of failing', async kycStatus => {
-    mockSubmitOnboarding.mockResolvedValue({ kycStatus, kycRejectionReason: KycRejectionReason.Unspecified });
-    mockGetUserStatus.mockResolvedValue({ kycStatus: KycStatus.Approved, kycRejectionReason: KycRejectionReason.Unspecified });
+    mockSubmitOnboarding.mockResolvedValue({ kycStatus });
+    mockGetUserStatus.mockResolvedValue({ kycStatus: KycStatus.Approved });
 
     await expect(flow().submit()).resolves.toBe('approved');
 
@@ -199,7 +197,7 @@ describe('useSubmitReviewFlowStore.submit onboarding', () => {
   });
 
   it('falls back to reviewing when a status poll fails, never to the retryable error', async () => {
-    mockSubmitOnboarding.mockResolvedValue({ kycStatus: KycStatus.Pending, kycRejectionReason: KycRejectionReason.Unspecified });
+    mockSubmitOnboarding.mockResolvedValue({ kycStatus: KycStatus.Pending });
     mockGetUserStatus.mockRejectedValue(new Error('token expired'));
 
     await expect(flow().submit()).resolves.toBe('awaitingDecision');
@@ -211,9 +209,9 @@ describe('useSubmitReviewFlowStore.submit onboarding', () => {
   });
 
   it('ignores an active status poll after the flow is reset', async () => {
-    const poll = Promise.withResolvers<{ kycStatus: KycStatus; kycRejectionReason: KycRejectionReason }>();
+    const poll = Promise.withResolvers<KycStatusResult>();
     const pollStarted = Promise.withResolvers<void>();
-    mockSubmitOnboarding.mockResolvedValue({ kycStatus: KycStatus.Pending, kycRejectionReason: KycRejectionReason.Unspecified });
+    mockSubmitOnboarding.mockResolvedValue({ kycStatus: KycStatus.Pending });
     mockGetUserStatus.mockImplementationOnce(() => {
       pollStarted.resolve();
       return poll.promise;
@@ -222,7 +220,7 @@ describe('useSubmitReviewFlowStore.submit onboarding', () => {
     const submission = flow().submit();
     await pollStarted.promise;
     flow().reset();
-    poll.resolve({ kycStatus: KycStatus.Approved, kycRejectionReason: KycRejectionReason.Unspecified });
+    poll.resolve({ kycStatus: KycStatus.Approved });
 
     await expect(submission).resolves.toBe('cancelled');
 
@@ -242,14 +240,14 @@ describe('useSubmitReviewFlowStore.submit onboarding', () => {
   });
 
   it('skips a second submit while one is in flight', async () => {
-    const submit = Promise.withResolvers<{ kycStatus: KycStatus; kycRejectionReason: KycRejectionReason }>();
+    const submit = Promise.withResolvers<KycStatusResult>();
     mockSubmitOnboarding.mockReturnValue(submit.promise);
 
     const first = flow().submit();
     await expect(flow().submit()).resolves.toBe('skipped');
 
     expect(mockSubmitOnboarding).toHaveBeenCalledTimes(1);
-    submit.resolve({ kycStatus: KycStatus.Approved, kycRejectionReason: KycRejectionReason.Unspecified });
+    submit.resolve({ kycStatus: KycStatus.Approved });
     await expect(first).resolves.toBe('approved');
   });
 

--- a/src/features/cash/screens/cash-deposit-setup/steps/useSubmitReviewFlow.ts
+++ b/src/features/cash/screens/cash-deposit-setup/steps/useSubmitReviewFlow.ts
@@ -149,7 +149,7 @@ export const useSubmitReviewFlowStore = createBaseStore<SubmitReviewFlowStore>((
     };
 
     let kycStatus: KycStatus;
-    let kycRejectionReason: KycRejectionReason;
+    let kycRejectionReason: KycRejectionReason | undefined;
     try {
       ({ kycStatus, kycRejectionReason } = await submitOnboarding({
         bootstrapToken,

--- a/src/features/cash/screens/cash-deposit-setup/steps/useSubmitReviewFlow.ts
+++ b/src/features/cash/screens/cash-deposit-setup/steps/useSubmitReviewFlow.ts
@@ -10,6 +10,7 @@ import { US_COUNTRY_CODE } from '../../../services/cashSetupIdentityService';
 import {
   finishRecovery,
   getUserStatus,
+  KycRejectionReason,
   KycStatus,
   startRecovery,
   startSignupResume,
@@ -27,6 +28,7 @@ export type SubmitReviewState = 'entry' | 'submitting' | 'identityMismatch' | 'e
 type SubmitReviewResult =
   | 'approved'
   | 'rejected'
+  | 'unsupportedState'
   | 'awaitingDecision'
   | 'recovered'
   | 'phoneCodeRequired'
@@ -147,8 +149,14 @@ export const useSubmitReviewFlowStore = createBaseStore<SubmitReviewFlowStore>((
     };
 
     let kycStatus: KycStatus;
+    let kycRejectionReason: KycRejectionReason;
     try {
-      ({ kycStatus } = await submitOnboarding({ bootstrapToken, countryCode: US_COUNTRY_CODE, identity, governmentId }));
+      ({ kycStatus, kycRejectionReason } = await submitOnboarding({
+        bootstrapToken,
+        countryCode: US_COUNTRY_CODE,
+        identity,
+        governmentId,
+      }));
     } catch (error) {
       if (isStale()) return 'cancelled';
       logger.error(new RainbowError('[useSubmitReviewFlow]: Failed to submit KYC', error));
@@ -165,7 +173,7 @@ export const useSubmitReviewFlowStore = createBaseStore<SubmitReviewFlowStore>((
       await delay(KYC_POLL_INTERVAL_MS);
       if (isStale()) return 'cancelled';
       try {
-        ({ kycStatus } = await getUserStatus({ bootstrapToken }));
+        ({ kycStatus, kycRejectionReason } = await getUserStatus({ bootstrapToken }));
       } catch (error) {
         if (isStale()) return 'cancelled';
         // The identity data is already with the provider, so a status we cannot
@@ -181,6 +189,15 @@ export const useSubmitReviewFlowStore = createBaseStore<SubmitReviewFlowStore>((
       analytics.track(analytics.event.cashKycApproved);
       set({ state: 'approved' });
       return 'approved';
+    }
+
+    // Today the provider only tells us the state wasn't supported (NY); it never
+    // rejects for any other reason, so unspecified/other reasons still map to
+    // the generic rejected outcome.
+    if (kycRejectionReason === KycRejectionReason.StateNotSupported) {
+      analytics.track(analytics.event.cashKycFailed, { reason: 'state_not_supported' });
+      set({ state: 'unsupportedState' });
+      return 'unsupportedState';
     }
 
     analytics.track(analytics.event.cashKycFailed, { reason: 'rejected' });

--- a/src/features/cash/screens/cash-deposit-setup/steps/useSubmitReviewFlow.ts
+++ b/src/features/cash/screens/cash-deposit-setup/steps/useSubmitReviewFlow.ts
@@ -191,9 +191,6 @@ export const useSubmitReviewFlowStore = createBaseStore<SubmitReviewFlowStore>((
       return 'approved';
     }
 
-    // Today the provider only tells us the state wasn't supported (NY); it never
-    // rejects for any other reason, so unspecified/other reasons still map to
-    // the generic rejected outcome.
     if (kycRejectionReason === KycRejectionReason.StateNotSupported) {
       analytics.track(analytics.event.cashKycFailed, { reason: 'state_not_supported' });
       set({ state: 'unsupportedState' });

--- a/src/features/cash/services/userClient.test.ts
+++ b/src/features/cash/services/userClient.test.ts
@@ -1,18 +1,31 @@
 import { RainbowFetchError } from '@/framework/data/http/rainbowFetch';
 
 import { createUsSsnLast4GovernmentId, isValidUsSsnLast4 } from './cashSetupIdentityService';
-import { createUserWithPhone, finishRecovery, finishSignupResume, startRecovery, startSignupResume, verifyPhone } from './userClient';
+import {
+  createUserWithPhone,
+  finishRecovery,
+  finishSignupResume,
+  getUserStatus,
+  KycRejectionReason,
+  KycStatus,
+  startRecovery,
+  startSignupResume,
+  submitOnboarding,
+  verifyPhone,
+} from './userClient';
 
 jest.mock('react-native-dotenv', () => ({ IS_TESTING: 'false' }));
 
 const mockPost = jest.fn();
+const mockGet = jest.fn();
 
 jest.mock('./cashPlatformClient', () => ({
-  getCashPlatformClient: () => ({ post: mockPost }),
+  getCashPlatformClient: () => ({ post: mockPost, get: mockGet }),
   buildAuthenticatedHeader: (token: string) => ({ Authorization: `Bearer ${token}` }),
 }));
 
 const post = mockPost;
+const get = mockGet;
 
 const PARAMS = { userId: 'user-1', code: '123456' };
 const IDENTITY = { firstName: 'Ada', lastName: 'Lovelace', dateOfBirth: { year: 1815, month: 12, day: 10 } };
@@ -25,6 +38,7 @@ function governmentId() {
 
 beforeEach(() => {
   post.mockReset();
+  get.mockReset();
 });
 
 afterEach(() => {
@@ -199,4 +213,60 @@ describe('account recovery', () => {
 
     await expect(finishRecovery(finishParams)).rejects.toBe(error);
   });
+});
+
+describe('submitOnboarding', () => {
+  const submit = () =>
+    submitOnboarding({ bootstrapToken: 'bst_test', countryCode: 'US', identity: IDENTITY, governmentId: governmentId() });
+
+  it('omits the rejection reason when the provider approves', async () => {
+    post.mockResolvedValue({ data: { kycStatus: KycStatus.Approved } });
+
+    await expect(submit()).resolves.toEqual({ kycStatus: KycStatus.Approved, kycRejectionReason: undefined });
+  });
+
+  it('surfaces a state-not-supported rejection', async () => {
+    post.mockResolvedValue({ data: { kycStatus: KycStatus.Rejected, kycRejectionReason: 'KYC_REJECTION_REASON_STATE_NOT_SUPPORTED' } });
+
+    await expect(submit()).resolves.toEqual({ kycStatus: KycStatus.Rejected, kycRejectionReason: KycRejectionReason.StateNotSupported });
+  });
+
+  it.each([undefined, 'KYC_REJECTION_REASON_UNSPECIFIED', 'some-future-reason'])(
+    'normalizes a plain rejection whose reason is %p to undefined',
+    async kycRejectionReason => {
+      post.mockResolvedValue({ data: { kycStatus: KycStatus.Rejected, kycRejectionReason } });
+
+      await expect(submit()).resolves.toEqual({ kycStatus: KycStatus.Rejected, kycRejectionReason: undefined });
+    }
+  );
+});
+
+describe('getUserStatus', () => {
+  const params = { bootstrapToken: 'bst_test' };
+
+  it('omits the rejection reason when the provider approves', async () => {
+    get.mockResolvedValue({ data: { status: { kyc: { status: KycStatus.Approved } } } });
+
+    await expect(getUserStatus(params)).resolves.toEqual({ kycStatus: KycStatus.Approved, kycRejectionReason: undefined });
+  });
+
+  it('surfaces a state-not-supported rejection', async () => {
+    get.mockResolvedValue({
+      data: { status: { kyc: { status: KycStatus.Rejected, reason: 'KYC_REJECTION_REASON_STATE_NOT_SUPPORTED' } } },
+    });
+
+    await expect(getUserStatus(params)).resolves.toEqual({
+      kycStatus: KycStatus.Rejected,
+      kycRejectionReason: KycRejectionReason.StateNotSupported,
+    });
+  });
+
+  it.each([undefined, 'KYC_REJECTION_REASON_UNSPECIFIED', 'some-future-reason'])(
+    'normalizes a plain rejection whose reason is %p to undefined',
+    async reason => {
+      get.mockResolvedValue({ data: { status: { kyc: { status: KycStatus.Rejected, reason } } } });
+
+      await expect(getUserStatus(params)).resolves.toEqual({ kycStatus: KycStatus.Rejected, kycRejectionReason: undefined });
+    }
+  );
 });

--- a/src/features/cash/services/userClient.ts
+++ b/src/features/cash/services/userClient.ts
@@ -83,8 +83,15 @@ export enum KycStatus {
   Review = 'KYC_STATUS_REVIEW',
 }
 
+// Set only when kycStatus is Rejected. The provider gives no reason for a
+// plain reject, so today this only ever flags an unsupported state.
+export enum KycRejectionReason {
+  Unspecified = 'KYC_REJECTION_REASON_UNSPECIFIED',
+  StateNotSupported = 'KYC_REJECTION_REASON_STATE_NOT_SUPPORTED',
+}
+
 // Pending and Review are one state to the app: the provider has not decided yet.
-export type KycOutcome = 'reviewing' | 'approved' | 'rejected';
+export type KycOutcome = 'reviewing' | 'approved' | 'rejected' | 'unsupportedState';
 
 export type CreateUserWithPhoneResult =
   | { outcome: 'created'; userId: string; resendAfter: number }
@@ -116,6 +123,7 @@ type SubmitOnboardingRequest = {
 
 type SubmitOnboardingResponse = {
   kycStatus: KycStatus;
+  kycRejectionReason: KycRejectionReason;
 };
 
 type GetUserStatusParams = {
@@ -171,6 +179,7 @@ type GetUserStatusResponse = {
   status: {
     kyc: {
       status: KycStatus;
+      reason: KycRejectionReason;
     };
   };
 };
@@ -238,7 +247,7 @@ export async function submitOnboarding({
 }: SubmitOnboardingParams): Promise<SubmitOnboardingResponse> {
   if (IS_TESTING === 'true') {
     await delay(time.seconds(1));
-    return { kycStatus: KycStatus.Approved };
+    return { kycStatus: KycStatus.Approved, kycRejectionReason: KycRejectionReason.Unspecified };
   }
 
   const request: SubmitOnboardingRequest = {
@@ -328,16 +337,21 @@ export async function finalizeAuth({
   return parseAccessCredential(data);
 }
 
-export async function getUserStatus({ bootstrapToken }: GetUserStatusParams): Promise<{ kycStatus: KycStatus }> {
+export async function getUserStatus({
+  bootstrapToken,
+}: GetUserStatusParams): Promise<{ kycStatus: KycStatus; kycRejectionReason: KycRejectionReason }> {
   if (IS_TESTING === 'true') {
     await delay(time.seconds(1));
-    return { kycStatus: bootstrapToken === MOCK_KYC_PENDING_BOOTSTRAP_TOKEN ? KycStatus.Pending : KycStatus.Approved };
+    return {
+      kycStatus: bootstrapToken === MOCK_KYC_PENDING_BOOTSTRAP_TOKEN ? KycStatus.Pending : KycStatus.Approved,
+      kycRejectionReason: KycRejectionReason.Unspecified,
+    };
   }
 
   const { data } = await getCashPlatformClient().get<GetUserStatusResponse>('/status/GetUserStatus', {
     headers: buildAuthenticatedHeader(bootstrapToken),
   });
-  return { kycStatus: data.status.kyc.status };
+  return { kycStatus: data.status.kyc.status, kycRejectionReason: data.status.kyc.reason };
 }
 
 export async function startSignupResume({

--- a/src/features/cash/services/userClient.ts
+++ b/src/features/cash/services/userClient.ts
@@ -90,6 +90,17 @@ export enum KycRejectionReason {
   StateNotSupported = 'KYC_REJECTION_REASON_STATE_NOT_SUPPORTED',
 }
 
+export type KycStatusResult = {
+  kycStatus: KycStatus;
+  kycRejectionReason?: KycRejectionReason;
+};
+
+// The wire field is only ever sent when kycStatus is Rejected; anything else
+// (absent, or a reason we don't recognize) has no bearing on today's outcomes.
+function parseKycRejectionReason(reason: unknown): KycRejectionReason | undefined {
+  return reason === KycRejectionReason.StateNotSupported ? KycRejectionReason.StateNotSupported : undefined;
+}
+
 // Pending and Review are one state to the app: the provider has not decided yet.
 export type KycOutcome = 'reviewing' | 'approved' | 'rejected' | 'unsupportedState';
 
@@ -123,7 +134,7 @@ type SubmitOnboardingRequest = {
 
 type SubmitOnboardingResponse = {
   kycStatus: KycStatus;
-  kycRejectionReason: KycRejectionReason;
+  kycRejectionReason: unknown;
 };
 
 type GetUserStatusParams = {
@@ -179,7 +190,7 @@ type GetUserStatusResponse = {
   status: {
     kyc: {
       status: KycStatus;
-      reason: KycRejectionReason;
+      reason: unknown;
     };
   };
 };
@@ -244,10 +255,10 @@ export async function submitOnboarding({
   countryCode,
   identity,
   governmentId,
-}: SubmitOnboardingParams): Promise<SubmitOnboardingResponse> {
+}: SubmitOnboardingParams): Promise<KycStatusResult> {
   if (IS_TESTING === 'true') {
     await delay(time.seconds(1));
-    return { kycStatus: KycStatus.Approved, kycRejectionReason: KycRejectionReason.Unspecified };
+    return { kycStatus: KycStatus.Approved };
   }
 
   const request: SubmitOnboardingRequest = {
@@ -259,7 +270,7 @@ export async function submitOnboarding({
   const { data } = await getCashPlatformClient().post<SubmitOnboardingResponse>('/onboarding/SubmitOnboarding', request, {
     headers: buildAuthenticatedHeader(bootstrapToken),
   });
-  return data;
+  return { kycStatus: data.kycStatus, kycRejectionReason: parseKycRejectionReason(data.kycRejectionReason) };
 }
 
 export async function addPasskey({ bootstrapToken }: { bootstrapToken: string }): Promise<AddPasskeyResponse> {
@@ -337,21 +348,16 @@ export async function finalizeAuth({
   return parseAccessCredential(data);
 }
 
-export async function getUserStatus({
-  bootstrapToken,
-}: GetUserStatusParams): Promise<{ kycStatus: KycStatus; kycRejectionReason: KycRejectionReason }> {
+export async function getUserStatus({ bootstrapToken }: GetUserStatusParams): Promise<KycStatusResult> {
   if (IS_TESTING === 'true') {
     await delay(time.seconds(1));
-    return {
-      kycStatus: bootstrapToken === MOCK_KYC_PENDING_BOOTSTRAP_TOKEN ? KycStatus.Pending : KycStatus.Approved,
-      kycRejectionReason: KycRejectionReason.Unspecified,
-    };
+    return { kycStatus: bootstrapToken === MOCK_KYC_PENDING_BOOTSTRAP_TOKEN ? KycStatus.Pending : KycStatus.Approved };
   }
 
   const { data } = await getCashPlatformClient().get<GetUserStatusResponse>('/status/GetUserStatus', {
     headers: buildAuthenticatedHeader(bootstrapToken),
   });
-  return { kycStatus: data.status.kyc.status, kycRejectionReason: data.status.kyc.reason };
+  return { kycStatus: data.status.kyc.status, kycRejectionReason: parseKycRejectionReason(data.status.kyc.reason) };
 }
 
 export async function startSignupResume({

--- a/src/features/cash/stores/verifyPhoneFlowStore.test.ts
+++ b/src/features/cash/stores/verifyPhoneFlowStore.test.ts
@@ -92,7 +92,7 @@ beforeEach(() => {
   useVerifyPhoneFlowStore.getState().reset();
   mockVerifyPhone.mockResolvedValue(TOKEN);
   mockFinishSignupResume.mockResolvedValue({ outcome: 'verified', ...TOKEN });
-  mockGetUserStatus.mockResolvedValue({ kycStatus: KycStatus.Unspecified, kycRejectionReason: KycRejectionReason.Unspecified });
+  mockGetUserStatus.mockResolvedValue({ kycStatus: KycStatus.Unspecified });
   mockResendPhoneCode.mockResolvedValue({ resendAfter: RESEND_AFTER });
   mockStartRecovery.mockResolvedValue({ recoveryId: 'recovery-2', resendAfter: RESEND_AFTER });
   mockStartSignupResume.mockResolvedValue({ resumeId: 'rcv_2', resendAfter: RESEND_AFTER });
@@ -131,10 +131,10 @@ describe('useVerifyPhoneFlowStore.submit', () => {
   });
 
   it.each([
-    { kycStatus: KycStatus.Approved, kycRejectionReason: KycRejectionReason.Unspecified, expected: 'approved' },
-    { kycStatus: KycStatus.Pending, kycRejectionReason: KycRejectionReason.Unspecified, expected: 'reviewing' },
-    { kycStatus: KycStatus.Review, kycRejectionReason: KycRejectionReason.Unspecified, expected: 'reviewing' },
-    { kycStatus: KycStatus.Rejected, kycRejectionReason: KycRejectionReason.Unspecified, expected: 'rejected' },
+    { kycStatus: KycStatus.Approved, kycRejectionReason: undefined, expected: 'approved' },
+    { kycStatus: KycStatus.Pending, kycRejectionReason: undefined, expected: 'reviewing' },
+    { kycStatus: KycStatus.Review, kycRejectionReason: undefined, expected: 'reviewing' },
+    { kycStatus: KycStatus.Rejected, kycRejectionReason: undefined, expected: 'rejected' },
     { kycStatus: KycStatus.Rejected, kycRejectionReason: KycRejectionReason.StateNotSupported, expected: 'unsupportedState' },
   ])('surfaces $expected for a resumed account whose KYC is $kycStatus', async ({ kycStatus, kycRejectionReason, expected }) => {
     submitPhone({ kind: 'resume', resumeId: 'rcv_1' });
@@ -151,16 +151,16 @@ describe('useVerifyPhoneFlowStore.submit', () => {
   });
 
   it.each([
-    { kycStatus: KycStatus.Approved, kycRejectionReason: KycRejectionReason.Unspecified, event: 'cash.kyc_approved', payload: undefined },
+    { kycStatus: KycStatus.Approved, kycRejectionReason: undefined, event: 'cash.kyc_approved', payload: undefined },
     {
       kycStatus: KycStatus.Pending,
-      kycRejectionReason: KycRejectionReason.Unspecified,
+      kycRejectionReason: undefined,
       event: 'cash.kyc_awaiting_decision',
       payload: { source: 'resume' },
     },
     {
       kycStatus: KycStatus.Rejected,
-      kycRejectionReason: KycRejectionReason.Unspecified,
+      kycRejectionReason: undefined,
       event: 'cash.kyc_failed',
       payload: { reason: 'rejected' },
     },
@@ -182,7 +182,7 @@ describe('useVerifyPhoneFlowStore.submit', () => {
 
   it('sends a resumed account that never submitted KYC through the KYC steps', async () => {
     submitPhone({ kind: 'resume', resumeId: 'rcv_1' });
-    mockGetUserStatus.mockResolvedValue({ kycStatus: KycStatus.Unspecified, kycRejectionReason: KycRejectionReason.Unspecified });
+    mockGetUserStatus.mockResolvedValue({ kycStatus: KycStatus.Unspecified });
     flow().setCode(CODE);
 
     await expect(flow().submit()).resolves.toBe('verified');
@@ -192,9 +192,7 @@ describe('useVerifyPhoneFlowStore.submit', () => {
 
   it('retries a failed resume status check once after a delay', async () => {
     submitPhone({ kind: 'resume', resumeId: 'rcv_1' });
-    mockGetUserStatus
-      .mockRejectedValueOnce(new Error('network down'))
-      .mockResolvedValueOnce({ kycStatus: KycStatus.Approved, kycRejectionReason: KycRejectionReason.Unspecified });
+    mockGetUserStatus.mockRejectedValueOnce(new Error('network down')).mockResolvedValueOnce({ kycStatus: KycStatus.Approved });
     flow().setCode(CODE);
 
     await expect(flow().submit()).resolves.toBe('verifiedKycOutcome');
@@ -220,7 +218,7 @@ describe('useVerifyPhoneFlowStore.submit', () => {
   });
 
   it('does not check KYC status for a fresh signup', async () => {
-    mockGetUserStatus.mockResolvedValue({ kycStatus: KycStatus.Approved, kycRejectionReason: KycRejectionReason.Unspecified });
+    mockGetUserStatus.mockResolvedValue({ kycStatus: KycStatus.Approved });
     flow().setCode(CODE);
 
     await expect(flow().submit()).resolves.toBe('verified');

--- a/src/features/cash/stores/verifyPhoneFlowStore.test.ts
+++ b/src/features/cash/stores/verifyPhoneFlowStore.test.ts
@@ -5,6 +5,7 @@ import { delay } from '@/utils/delay';
 import {
   finishSignupResume,
   getUserStatus,
+  KycRejectionReason,
   KycStatus,
   resendPhoneCode,
   startRecovery,
@@ -45,6 +46,10 @@ jest.mock('../services/userClient', () => ({
     Approved: 'KYC_STATUS_APPROVED',
     Rejected: 'KYC_STATUS_REJECTED',
     Review: 'KYC_STATUS_REVIEW',
+  },
+  KycRejectionReason: {
+    Unspecified: 'KYC_REJECTION_REASON_UNSPECIFIED',
+    StateNotSupported: 'KYC_REJECTION_REASON_STATE_NOT_SUPPORTED',
   },
   finishSignupResume: jest.fn(),
   getUserStatus: jest.fn(),
@@ -87,7 +92,7 @@ beforeEach(() => {
   useVerifyPhoneFlowStore.getState().reset();
   mockVerifyPhone.mockResolvedValue(TOKEN);
   mockFinishSignupResume.mockResolvedValue({ outcome: 'verified', ...TOKEN });
-  mockGetUserStatus.mockResolvedValue({ kycStatus: KycStatus.Unspecified });
+  mockGetUserStatus.mockResolvedValue({ kycStatus: KycStatus.Unspecified, kycRejectionReason: KycRejectionReason.Unspecified });
   mockResendPhoneCode.mockResolvedValue({ resendAfter: RESEND_AFTER });
   mockStartRecovery.mockResolvedValue({ recoveryId: 'recovery-2', resendAfter: RESEND_AFTER });
   mockStartSignupResume.mockResolvedValue({ resumeId: 'rcv_2', resendAfter: RESEND_AFTER });
@@ -126,13 +131,14 @@ describe('useVerifyPhoneFlowStore.submit', () => {
   });
 
   it.each([
-    { kycStatus: KycStatus.Approved, expected: 'approved' },
-    { kycStatus: KycStatus.Pending, expected: 'reviewing' },
-    { kycStatus: KycStatus.Review, expected: 'reviewing' },
-    { kycStatus: KycStatus.Rejected, expected: 'rejected' },
-  ])('surfaces $expected for a resumed account whose KYC is $kycStatus', async ({ kycStatus, expected }) => {
+    { kycStatus: KycStatus.Approved, kycRejectionReason: KycRejectionReason.Unspecified, expected: 'approved' },
+    { kycStatus: KycStatus.Pending, kycRejectionReason: KycRejectionReason.Unspecified, expected: 'reviewing' },
+    { kycStatus: KycStatus.Review, kycRejectionReason: KycRejectionReason.Unspecified, expected: 'reviewing' },
+    { kycStatus: KycStatus.Rejected, kycRejectionReason: KycRejectionReason.Unspecified, expected: 'rejected' },
+    { kycStatus: KycStatus.Rejected, kycRejectionReason: KycRejectionReason.StateNotSupported, expected: 'unsupportedState' },
+  ])('surfaces $expected for a resumed account whose KYC is $kycStatus', async ({ kycStatus, kycRejectionReason, expected }) => {
     submitPhone({ kind: 'resume', resumeId: 'rcv_1' });
-    mockGetUserStatus.mockResolvedValue({ kycStatus });
+    mockGetUserStatus.mockResolvedValue({ kycStatus, kycRejectionReason });
     flow().setCode(CODE);
 
     await expect(flow().submit()).resolves.toBe('verifiedKycOutcome');
@@ -145,12 +151,28 @@ describe('useVerifyPhoneFlowStore.submit', () => {
   });
 
   it.each([
-    { kycStatus: KycStatus.Approved, event: 'cash.kyc_approved', payload: undefined },
-    { kycStatus: KycStatus.Pending, event: 'cash.kyc_awaiting_decision', payload: { source: 'resume' } },
-    { kycStatus: KycStatus.Rejected, event: 'cash.kyc_failed', payload: { reason: 'rejected' } },
-  ])('tracks $event when a resumed account reports $kycStatus', async ({ event, kycStatus, payload }) => {
+    { kycStatus: KycStatus.Approved, kycRejectionReason: KycRejectionReason.Unspecified, event: 'cash.kyc_approved', payload: undefined },
+    {
+      kycStatus: KycStatus.Pending,
+      kycRejectionReason: KycRejectionReason.Unspecified,
+      event: 'cash.kyc_awaiting_decision',
+      payload: { source: 'resume' },
+    },
+    {
+      kycStatus: KycStatus.Rejected,
+      kycRejectionReason: KycRejectionReason.Unspecified,
+      event: 'cash.kyc_failed',
+      payload: { reason: 'rejected' },
+    },
+    {
+      kycStatus: KycStatus.Rejected,
+      kycRejectionReason: KycRejectionReason.StateNotSupported,
+      event: 'cash.kyc_failed',
+      payload: { reason: 'state_not_supported' },
+    },
+  ])('tracks $event when a resumed account reports $kycStatus', async ({ event, kycStatus, kycRejectionReason, payload }) => {
     submitPhone({ kind: 'resume', resumeId: 'rcv_1' });
-    mockGetUserStatus.mockResolvedValue({ kycStatus });
+    mockGetUserStatus.mockResolvedValue({ kycStatus, kycRejectionReason });
     flow().setCode(CODE);
 
     await flow().submit();
@@ -160,7 +182,7 @@ describe('useVerifyPhoneFlowStore.submit', () => {
 
   it('sends a resumed account that never submitted KYC through the KYC steps', async () => {
     submitPhone({ kind: 'resume', resumeId: 'rcv_1' });
-    mockGetUserStatus.mockResolvedValue({ kycStatus: KycStatus.Unspecified });
+    mockGetUserStatus.mockResolvedValue({ kycStatus: KycStatus.Unspecified, kycRejectionReason: KycRejectionReason.Unspecified });
     flow().setCode(CODE);
 
     await expect(flow().submit()).resolves.toBe('verified');
@@ -170,7 +192,9 @@ describe('useVerifyPhoneFlowStore.submit', () => {
 
   it('retries a failed resume status check once after a delay', async () => {
     submitPhone({ kind: 'resume', resumeId: 'rcv_1' });
-    mockGetUserStatus.mockRejectedValueOnce(new Error('network down')).mockResolvedValueOnce({ kycStatus: KycStatus.Approved });
+    mockGetUserStatus
+      .mockRejectedValueOnce(new Error('network down'))
+      .mockResolvedValueOnce({ kycStatus: KycStatus.Approved, kycRejectionReason: KycRejectionReason.Unspecified });
     flow().setCode(CODE);
 
     await expect(flow().submit()).resolves.toBe('verifiedKycOutcome');
@@ -196,7 +220,7 @@ describe('useVerifyPhoneFlowStore.submit', () => {
   });
 
   it('does not check KYC status for a fresh signup', async () => {
-    mockGetUserStatus.mockResolvedValue({ kycStatus: KycStatus.Approved });
+    mockGetUserStatus.mockResolvedValue({ kycStatus: KycStatus.Approved, kycRejectionReason: KycRejectionReason.Unspecified });
     flow().setCode(CODE);
 
     await expect(flow().submit()).resolves.toBe('verified');

--- a/src/features/cash/stores/verifyPhoneFlowStore.ts
+++ b/src/features/cash/stores/verifyPhoneFlowStore.ts
@@ -8,6 +8,7 @@ import { delay } from '@/utils/delay';
 import {
   finishSignupResume,
   getUserStatus,
+  KycRejectionReason,
   KycStatus,
   resendPhoneCode,
   startRecovery,
@@ -27,12 +28,12 @@ export type VerifyPhoneResult = 'verified' | 'verifiedKycOutcome' | 'failed' | '
 // Null means the wizard proceeds to the KYC steps: either nothing was ever
 // submitted, or the status could not be read and a redundant pass is the safe
 // guess — showing "we're reviewing" to someone who never submitted strands them.
-function toKycOutcome(status: KycStatus): KycOutcome | null {
+function toKycOutcome(status: KycStatus, reason: KycRejectionReason): KycOutcome | null {
   switch (status) {
     case KycStatus.Approved:
       return 'approved';
     case KycStatus.Rejected:
-      return 'rejected';
+      return reason === KycRejectionReason.StateNotSupported ? 'unsupportedState' : 'rejected';
     case KycStatus.Pending:
     case KycStatus.Review:
       return 'reviewing';
@@ -44,7 +45,10 @@ function toKycOutcome(status: KycStatus): KycOutcome | null {
 // Best-effort: failing only costs the user a redundant pass through KYC entry,
 // so a transient status failure gets one delayed retry.
 async function getResumeKycOutcome(bootstrapToken: string): Promise<KycOutcome | null> {
-  const check = async () => toKycOutcome((await getUserStatus({ bootstrapToken })).kycStatus);
+  const check = async () => {
+    const { kycStatus, kycRejectionReason } = await getUserStatus({ bootstrapToken });
+    return toKycOutcome(kycStatus, kycRejectionReason);
+  };
   return check()
     .catch(() => delay(time.seconds(2)).then(check))
     .catch(() => null);
@@ -122,6 +126,7 @@ export const useVerifyPhoneFlowStore = createBaseStore<VerifyPhoneFlowStore>((se
       if (kycOutcome === 'approved') analytics.track(analytics.event.cashKycApproved);
       else if (kycOutcome === 'reviewing') analytics.track(analytics.event.cashKycAwaitingDecision, { source: 'resume' });
       else if (kycOutcome === 'rejected') analytics.track(analytics.event.cashKycFailed, { reason: 'rejected' });
+      else if (kycOutcome === 'unsupportedState') analytics.track(analytics.event.cashKycFailed, { reason: 'state_not_supported' });
       // Keep the retained OTP input disabled without leaving setup controls loading.
       set({ kycOutcome, state: 'submitted' });
       return kycOutcome ? 'verifiedKycOutcome' : 'verified';

--- a/src/features/cash/stores/verifyPhoneFlowStore.ts
+++ b/src/features/cash/stores/verifyPhoneFlowStore.ts
@@ -28,7 +28,7 @@ export type VerifyPhoneResult = 'verified' | 'verifiedKycOutcome' | 'failed' | '
 // Null means the wizard proceeds to the KYC steps: either nothing was ever
 // submitted, or the status could not be read and a redundant pass is the safe
 // guess — showing "we're reviewing" to someone who never submitted strands them.
-function toKycOutcome(status: KycStatus, reason: KycRejectionReason): KycOutcome | null {
+function toKycOutcome(status: KycStatus, reason: KycRejectionReason | undefined): KycOutcome | null {
   switch (status) {
     case KycStatus.Approved:
       return 'approved';

--- a/src/languages/en_US.json
+++ b/src/languages/en_US.json
@@ -1655,7 +1655,7 @@
           "contact_support": "Contact Support",
           "close": "Close",
           "state_not_supported_title": "New York support coming soon",
-          "state_not_supported_description": "Sorry, instant cash deposits are not available in NY yet.\n\nWe are adding NY soon. You will receive a push notification when instant deposits are available in NY."
+          "state_not_supported_description": "Sorry, instant cash deposits are not available in NY yet.\n\nWe’ll let you know as soon as your state is supported."
         },
         "passkey": {
           "title": "Add a Passkey",

--- a/src/languages/en_US.json
+++ b/src/languages/en_US.json
@@ -1653,7 +1653,10 @@
           "rejected_title": "There was an issue verifying your details",
           "rejected_description": "We weren’t able to verify your identity. Contact support if you think this is a mistake.",
           "contact_support": "Contact Support",
-          "close": "Close"
+          "close": "Close",
+          "state_not_supported_title": "New York support coming soon",
+          "state_not_supported_description": "Sorry, instant cash deposits are not available in NY yet.\n\nWe are adding NY soon. You will receive a push notification when instant deposits are available in NY.",
+          "dismiss": "Dismiss"
         },
         "passkey": {
           "title": "Add a Passkey",

--- a/src/languages/en_US.json
+++ b/src/languages/en_US.json
@@ -1655,8 +1655,7 @@
           "contact_support": "Contact Support",
           "close": "Close",
           "state_not_supported_title": "New York support coming soon",
-          "state_not_supported_description": "Sorry, instant cash deposits are not available in NY yet.\n\nWe are adding NY soon. You will receive a push notification when instant deposits are available in NY.",
-          "dismiss": "Dismiss"
+          "state_not_supported_description": "Sorry, instant cash deposits are not available in NY yet.\n\nWe are adding NY soon. You will receive a push notification when instant deposits are available in NY."
         },
         "passkey": {
           "title": "Add a Passkey",


### PR DESCRIPTION
Fixes APP-4015

The KYC rejection reason is optionally returned from the backend from the submit step as well as the get user status endpoint.

Surfaces the KYC rejection reason on KycOutcomeSheet, and the phone-verify resume flow, so a soft-rejected KYC waitlisted for an unsupported state shows a dedicated "New York support coming soon" sheet instead of the generic rejection sheet.

Hardcoded for NY for now, awaiting response about other states.

## Screen recordings / screenshots
Check linear ticket
